### PR TITLE
Adaptive theme: derive a whole theme from two queried colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `Theme::adaptive(background, foreground, palette16)` derives a full theme
+  from externally chosen colors (e.g. queried from the terminal). A light
+  background yields a light theme, and every derived theme passes the same
+  contrast floors the presets are held to.
+- `color::luminance` and `color::contrast` (WCAG 2.1), `color::away_from` and
+  `color::nearest_to` (which end of the ramp a color shifts toward).
+- `color::ROW_FOCUS_SHIFT`, previously duplicated privately in `List` and
+  `Select`.
 - `color::blendable`, picking the first of two colors that has channels to
   blend — how disabled fills derive on a theme whose background is the
   terminal's own.
@@ -115,6 +123,11 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Breaking:** the direction-named shift constant pairs collapse into
+  `color::FOCUS_SHIFT`, `HOVER_SHIFT`, `FIELD_FOCUS_SHIFT`, and
+  `FIELD_HOVER_SHIFT` — the direction now comes from the theme.
+- **Breaking:** `from_theme` and `themed` on `ListStyle`, `SelectStyle`,
+  `TabsStyle`, and `ButtonStyle` are no longer `const fn`.
 - **Breaking:** `runtime::RenderCtx` is `runtime::DeclareCtx`. `render` now
   names one thing — `Ratcn::render`, the whole frame — while `declare` names
   tree building and `paint` names cell writing. Every signature, bound, and
@@ -233,6 +246,8 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   draws moves to `Component::paint`.
 - **Breaking:** `Dialog` and `Tooltip` hold their bodies, footer, and actions in
   private types. Their builders are unchanged.
+- Fills shift by the background's polarity instead of a hardcoded direction.
+  The seven presets render identically; light backgrounds get the mirror image.
 - Every theme preset is retuned. Wells, dialogs, and text are re-derived from
   each palette's official tones into one consistent model — `background` <
   `surface` < `field`, with the focus, hover, and cursor fills stepping up from

--- a/crates/ratcn/src/color.rs
+++ b/crates/ratcn/src/color.rs
@@ -1,14 +1,16 @@
 //! Small color helpers for deriving state colors from a theme's base palette.
 //!
 //! A theme stores only base colors. Where a state color is a uniform function
-//! of a base color — a bright fill darkening on focus, a dark fill lightening,
-//! a control dimming when disabled — components derive it with these helpers
-//! rather than the theme storing every variant. All operate on channels
+//! of a base color — a well separating from the background on focus, a fill
+//! deepening, a control dimming when disabled — components derive it with these
+//! helpers rather than the theme storing every variant. All operate on channels
 //! resolved by [`resolve_rgb`]: `Color::Rgb` directly, the 16 named colors via
 //! a fixed VGA approximation (so state changes stay visible on named-color
 //! themes, at the cost of the derived color leaving the terminal palette), and
 //! `Indexed`/`Reset` pass through unchanged (those carry no channels to
 //! resolve).
+
+use std::sync::LazyLock;
 
 use ratatui::style::Color;
 
@@ -16,34 +18,43 @@ use ratatui::style::Color;
 // with the helpers below. Centralised so the visual design language reads in one
 // place; each names the kind of element it governs.
 
-/// A bright fill (a default or destructive button) darkens this much on focus.
+/// A filled control (a button, a selected tab) shifts this far on focus.
 ///
-/// The shift is capped by the label that stays put on top of it. A fill moving
-/// away from the background is also moving toward its own label: past about
-/// this much, palettes with a mid-luminance accent (Solarized's blue, Nord's
-/// frost) drop their hovered button labels under 4.5:1, which the preset
-/// contrast test pins.
-pub const FOCUS_DARKEN: u16 = 6;
-
-/// A dark fill (a secondary or ghost button) lightens this much on focus — the
-/// mirror of [`FOCUS_DARKEN`], toward white instead of black.
-pub const FOCUS_LIGHTEN: u16 = 6;
+/// The amount carries no direction of its own: which end a fill moves toward
+/// comes from [`nearest_to`] and [`away_from`], so the same number deepens a
+/// light theme's control and brightens a dark theme's.
+///
+/// It is capped by the label that stays put on top of it. A fill moving toward
+/// the screen's own end is also moving toward its own label: past about this
+/// much, palettes with a mid-luminance accent (Solarized's blue, Nord's frost)
+/// drop their hovered button labels under 4.5:1, which the preset contrast test
+/// pins.
+pub const FOCUS_SHIFT: u16 = 6;
 
 /// Hover is stronger than focus so moving the pointer over an already-focused
 /// control still produces a visible state change.
-pub const HOVER_DARKEN: u16 = 12;
+pub const HOVER_SHIFT: u16 = 12;
 
-/// The light-fill counterpart to [`HOVER_DARKEN`].
-pub const HOVER_LIGHTEN: u16 = 12;
+/// An inset well (input, list) shifts this far from the background on focus —
+/// gentler than a button, so a focused field separates subtly rather than
+/// jumping.
+pub const FIELD_FOCUS_SHIFT: u16 = 4;
 
-/// An inset well (input, list) lightens this much on focus — gentler than a
-/// button, so a focused field brightens subtly rather than jumping.
-pub const FIELD_FOCUS_LIGHTEN: u16 = 4;
-
-/// The field counterpart to [`HOVER_LIGHTEN`]: double the focus shift, for the
-/// same reason — the pointer over an already-focused field still produces a
+/// The well counterpart to [`HOVER_SHIFT`]: double the focus shift, for the
+/// same reason — the pointer over an already-focused well still produces a
 /// visible state change.
-pub const FIELD_HOVER_LIGHTEN: u16 = 8;
+pub const FIELD_HOVER_SHIFT: u16 = 8;
+
+/// The cursor row inside a well shifts this far past the focused well it sits
+/// on — the top rung of the ladder, and the only one a row rather than the
+/// whole control gets.
+///
+/// It is the largest of the state shifts because it marks one row out of many
+/// — [`DISABLED_DIM`] is larger still, but that is a blend toward another
+/// layer rather than a step along the ladder. It is also the rung where a
+/// theme's text budget runs out first, which is why a list draws it in the
+/// ordinary foreground rather than the muted one.
+pub const ROW_FOCUS_SHIFT: u16 = 15;
 
 /// A disabled control blends this far toward the layer behind it — low enough
 /// that the variant's hue still reads.
@@ -82,6 +93,94 @@ pub const fn resolve_rgb(color: Color) -> Option<(u8, u8, u8)> {
         Color::LightCyan => Some((0, 255, 255)),
         Color::White => Some((255, 255, 255)),
         Color::Indexed(_) | Color::Reset => None,
+    }
+}
+
+/// Relative luminance of the channels [`resolve_rgb`] reads, per WCAG 2.1 —
+/// `None` for a color that carries none.
+///
+/// This is the crate's one definition of how light a color is. The derivation
+/// and the tests that hold it to contrast floors share it, so a theme cannot
+/// pass a floor that is measured differently than it was solved.
+#[must_use]
+pub fn luminance(color: Color) -> Option<f64> {
+    let (r, g, b) = resolve_rgb(color)?;
+    let channel = &*LINEAR_CHANNEL;
+    Some(0.2126 * channel[r as usize] + 0.7152 * channel[g as usize] + 0.0722 * channel[b as usize])
+}
+
+/// The sRGB transfer function, one entry per channel value.
+///
+/// A channel is a `u8`, so this is the whole domain — the table is exact, not
+/// an approximation. It exists because luminance is the crate's innermost loop:
+/// solving one adaptive theme measures thousands of candidate colors, and
+/// `powf` per channel per measurement made that the dominant cost.
+static LINEAR_CHANNEL: LazyLock<[f64; 256]> = LazyLock::new(|| {
+    std::array::from_fn(|value| {
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "the index is 0..=255, which f64 represents exactly"
+        )]
+        let value = value as f64 / 255.0;
+        if value <= 0.039_28 {
+            value / 12.92
+        } else {
+            ((value + 0.055) / 1.055).powf(2.4)
+        }
+    })
+});
+
+/// The WCAG 2.1 contrast ratio between two colors, from 1.0 to 21.0 — `None`
+/// if either carries no channels to measure.
+#[must_use]
+pub fn contrast(a: Color, b: Color) -> Option<f64> {
+    match (luminance(a), luminance(b)) {
+        (Some(a), Some(b)) => Some((a.max(b) + 0.05) / (a.min(b) + 0.05)),
+        _ => None,
+    }
+}
+
+/// Whether a color is light enough that things drawn against it have to get
+/// darker to be seen. Unreadable colors are taken as dark, which is the
+/// assumption the crate's own default makes.
+#[must_use]
+fn is_light(anchor: Color) -> bool {
+    luminance(anchor).is_some_and(|luminance| luminance > 0.5)
+}
+
+/// The end of the gray ramp `anchor` sits furthest from: white for a dark
+/// anchor, black for a light one.
+///
+/// This is the direction "more" points in. A well is lifted out of the
+/// background by shifting it this way, and each rung above it goes further the
+/// same way, so one call decides a whole ladder's polarity — on a dark terminal
+/// the wells lighten, on a light one they darken, and nothing else in the
+/// derivation has to know which.
+///
+/// A color with no channels to read is taken as dark, so a theme that leaves
+/// its background to the terminal keeps the lighter-is-more direction the
+/// crate's own default has.
+#[must_use]
+pub fn away_from(anchor: Color) -> Color {
+    if is_light(anchor) {
+        Color::Black
+    } else {
+        Color::White
+    }
+}
+
+/// The end of the gray ramp `anchor` sits nearest to — the mirror of
+/// [`away_from`], and the direction "quieter" points in.
+///
+/// A filled control deepens toward the screen's own end as it gains focus,
+/// rather than climbing away from it like a well: the fill is already the loud
+/// thing on the screen, and the state change is meant to read as pressed.
+#[must_use]
+pub fn nearest_to(anchor: Color) -> Color {
+    if is_light(anchor) {
+        Color::White
+    } else {
+        Color::Black
     }
 }
 
@@ -207,6 +306,57 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The table is a cache, so it has to hold exactly what it caches.
+    ///
+    /// Every contrast floor in the crate is measured through it — a theme is
+    /// solved against these numbers and tested against these numbers, so a
+    /// table that drifted from the formula would move both sides at once and
+    /// nothing else would notice. The comparison is exact rather than
+    /// approximate because the table is built by this formula and nothing
+    /// stands between them: an epsilon here would license a drift.
+    #[test]
+    fn the_channel_table_is_the_wcag_transfer_function() {
+        for value in 0..=255_usize {
+            #[allow(
+                clippy::cast_precision_loss,
+                reason = "the index is 0..=255, which f64 represents exactly"
+            )]
+            let scaled = value as f64 / 255.0;
+            let expected = if scaled <= 0.039_28 {
+                scaled / 12.92
+            } else {
+                ((scaled + 0.055) / 1.055).powf(2.4)
+            };
+            assert_eq!(
+                LINEAR_CHANNEL[value].to_bits(),
+                expected.to_bits(),
+                "the cached transfer of channel {value} is {}, not the {expected} the formula \
+                 gives",
+                LINEAR_CHANNEL[value]
+            );
+        }
+    }
+
+    /// A color the crate cannot read is taken as dark, so a theme that leaves
+    /// its background to the terminal keeps the lighter-is-more direction the
+    /// crate's own default has. The pair is documented on both functions and
+    /// every derived state on the terminal preset depends on it.
+    #[test]
+    fn an_unreadable_anchor_points_the_way_a_dark_one_does() {
+        assert_eq!(
+            away_from(Color::Reset),
+            Color::White,
+            "Color::Reset stopped pointing away toward white, so a terminal-background theme \
+             lifts its wells the wrong way"
+        );
+        assert_eq!(
+            nearest_to(Color::Reset),
+            Color::Black,
+            "Color::Reset stopped pointing nearest toward black, so a terminal-background \
+             theme presses its fills the wrong way"
+        );
     }
 
     #[test]

--- a/crates/ratcn/src/components/button.rs
+++ b/crates/ratcn/src/components/button.rs
@@ -10,9 +10,7 @@ use ratatui::{
 
 use crate::Theme;
 use crate::button_shape::{BOTTOM_CAP, TOP_CAP, cap_row, filled_middle, shape_width};
-use crate::color::{
-    DISABLED_DIM, FOCUS_DARKEN, FOCUS_LIGHTEN, HOVER_DARKEN, HOVER_LIGHTEN, darken, dim, lighten,
-};
+use crate::color::{DISABLED_DIM, FOCUS_SHIFT, HOVER_SHIFT, away_from, dim, nearest_to};
 use crate::runtime::{
     Component, DeclareCtx, Event, EventCtx, EventResult, KeyCode, MeasuredComponent, MouseButton,
     MouseKind, PaintCtx, fixed_height,
@@ -159,30 +157,35 @@ impl ButtonStyle {
     /// This is what [`Button`] and [`ButtonWidget`] call for you. Call it
     /// directly when you want a variant's colors as a starting point to tweak.
     #[must_use]
-    pub const fn from_theme(theme: &Theme, variant: ButtonVariant) -> Self {
-        // Focus shifts a fill by a fixed amount, in the direction that makes it
-        // stand out: a bright fill (primary, destructive) darkens; a dark fill
-        // (secondary, ghost) lightens.
+    pub fn from_theme(theme: &Theme, variant: ButtonVariant) -> Self {
+        // Focus shifts a fill by a fixed amount, in the direction the theme's
+        // own polarity gives it. A loud fill (primary, destructive) deepens
+        // toward the end the screen sits at, so it reads as pressed; a quiet
+        // one (secondary, ghost) climbs away from the screen, so it reads as
+        // raised. On a light terminal both are the other way round in absolute
+        // terms, which is why the direction comes from the background.
+        let pressed = nearest_to(theme.background);
+        let raised = away_from(theme.background);
         match variant {
             ButtonVariant::Default => Self::filled(
                 theme.primary,
                 theme.primary_foreground,
-                darken(theme.primary, FOCUS_DARKEN),
-                darken(theme.primary, HOVER_DARKEN),
+                dim(theme.primary, pressed, FOCUS_SHIFT),
+                dim(theme.primary, pressed, HOVER_SHIFT),
                 theme,
             ),
             ButtonVariant::Secondary => Self::filled(
                 theme.secondary,
                 theme.secondary_foreground,
-                lighten(theme.secondary, FOCUS_LIGHTEN),
-                lighten(theme.secondary, HOVER_LIGHTEN),
+                dim(theme.secondary, raised, FOCUS_SHIFT),
+                dim(theme.secondary, raised, HOVER_SHIFT),
                 theme,
             ),
             ButtonVariant::Destructive => Self::filled(
                 theme.destructive,
                 theme.destructive_foreground,
-                darken(theme.destructive, FOCUS_DARKEN),
-                darken(theme.destructive, HOVER_DARKEN),
+                dim(theme.destructive, pressed, FOCUS_SHIFT),
+                dim(theme.destructive, pressed, HOVER_SHIFT),
                 theme,
             ),
             ButtonVariant::Outline => Self {
@@ -195,7 +198,7 @@ impl ButtonStyle {
                 focused_border: theme.primary,
                 hovered_foreground: theme.foreground,
                 hovered_background: theme.background,
-                hovered_border: darken(theme.primary, HOVER_DARKEN),
+                hovered_border: dim(theme.primary, pressed, HOVER_SHIFT),
                 disabled_foreground: theme.muted_foreground,
                 disabled_background: theme.background,
                 disabled_border: theme.border,
@@ -205,12 +208,12 @@ impl ButtonStyle {
                 foreground: theme.foreground,
                 background: theme.background,
                 focused_foreground: theme.foreground,
-                focused_background: lighten(theme.secondary, FOCUS_LIGHTEN),
+                focused_background: dim(theme.secondary, raised, FOCUS_SHIFT),
                 border: theme.background,
-                focused_border: lighten(theme.secondary, FOCUS_LIGHTEN),
+                focused_border: dim(theme.secondary, raised, FOCUS_SHIFT),
                 hovered_foreground: theme.foreground,
-                hovered_background: lighten(theme.secondary, HOVER_LIGHTEN),
-                hovered_border: lighten(theme.secondary, HOVER_LIGHTEN),
+                hovered_background: dim(theme.secondary, raised, HOVER_SHIFT),
+                hovered_border: dim(theme.secondary, raised, HOVER_SHIFT),
                 disabled_foreground: theme.muted_foreground,
                 disabled_background: theme.background,
                 disabled_border: theme.background,
@@ -1279,7 +1282,8 @@ mod tests {
         let theme = Theme::default_dark();
 
         // The focused fill is derived by shifting the base rather than stored
-        // on the theme; for a bright fill the shift darkens.
+        // on the theme. This theme's background is dark, so a loud fill deepens
+        // toward it.
         let default = ButtonStyle::from_theme(&theme, ButtonVariant::Default);
         let (Color::Rgb(br, bg, bb), Color::Rgb(fr, fg, fb)) =
             (default.background, default.focused_background)
@@ -1289,7 +1293,7 @@ mod tests {
         assert_ne!(default.focused_background, default.background);
         assert!(
             fr <= br && fg <= bg && fb <= bb,
-            "focus should darken a bright fill"
+            "focus should deepen a loud fill toward a dark theme's background"
         );
 
         // Disabled dims toward the surface but keeps the variant's hue, so a

--- a/crates/ratcn/src/components/list.rs
+++ b/crates/ratcn/src/components/list.rs
@@ -10,7 +10,7 @@ use ratatui::{
 
 use crate::Theme;
 use crate::color::{
-    DISABLED_DIM, FIELD_FOCUS_LIGHTEN, FIELD_HOVER_LIGHTEN, blendable, dim, lighten,
+    DISABLED_DIM, FIELD_FOCUS_SHIFT, FIELD_HOVER_SHIFT, ROW_FOCUS_SHIFT, away_from, blendable, dim,
 };
 use crate::linear_nav::{self, NavOutcome, ScrollStep};
 use crate::list_core::{
@@ -23,8 +23,6 @@ use crate::runtime::{
 use crate::selection_indicator;
 use crate::text_width::display_width;
 use crate::theme::resolve_style;
-
-const ROW_FOCUS_LIGHTEN: u16 = 15;
 
 /// Every color a list can paint.
 ///
@@ -107,14 +105,16 @@ impl ListStyle {
 
     /// Derive every list color from `theme`.
     ///
-    /// The focus and cursor-row fills are lightened from the theme's field
-    /// color rather than being separate theme entries, so a custom theme only
+    /// The focus and cursor-row fills are shifted from the theme's field color
+    /// rather than being separate theme entries, so a custom theme only
     /// supplies the base colors and the list stays consistent with the rest of
-    /// the UI.
+    /// the UI. Which way they shift comes from the theme's background: away
+    /// from it, so a light theme's well deepens where a dark theme's
+    /// brightens.
     ///
     /// The cursor row takes the theme's ordinary `foreground`, not its muted
-    /// one: it is the lightest fill in the list, so muted text is where the
-    /// list's contrast is thinnest, and the row the cursor is on is the row
+    /// one: it is the fill furthest from the background, so muted text is where
+    /// the list's contrast is thinnest, and the row the cursor is on is the row
     /// least in need of de-emphasis. `Select` derives its focused option the
     /// same way.
     ///
@@ -126,11 +126,12 @@ impl ListStyle {
     /// dims toward its surface instead: [`Color::Reset`] carries no channels to
     /// blend, and blending toward it would leave the well where it was.
     #[must_use]
-    pub const fn from_theme(theme: &Theme) -> Self {
+    pub fn from_theme(theme: &Theme) -> Self {
         let backdrop = blendable(theme.background, theme.surface);
-        let focused_background = lighten(theme.field, FIELD_FOCUS_LIGHTEN);
-        let hovered_background = lighten(theme.field, FIELD_HOVER_LIGHTEN);
-        let focused_row_background = lighten(focused_background, ROW_FOCUS_LIGHTEN);
+        let away = away_from(theme.background);
+        let focused_background = dim(theme.field, away, FIELD_FOCUS_SHIFT);
+        let hovered_background = dim(theme.field, away, FIELD_HOVER_SHIFT);
+        let focused_row_background = dim(focused_background, away, ROW_FOCUS_SHIFT);
         Self {
             foreground: theme.muted_foreground,
             background: theme.field,
@@ -272,7 +273,7 @@ impl<'a> ListWidget<'a> {
 
     /// Take colors from `theme`.
     #[must_use]
-    pub const fn themed(mut self, theme: &Theme) -> Self {
+    pub fn themed(mut self, theme: &Theme) -> Self {
         self.style = ListStyle::from_theme(theme);
         self
     }

--- a/crates/ratcn/src/components/select.rs
+++ b/crates/ratcn/src/components/select.rs
@@ -24,7 +24,7 @@ use ratatui::{
 
 use crate::Theme;
 use crate::color::{
-    DISABLED_DIM, FIELD_FOCUS_LIGHTEN, FIELD_HOVER_LIGHTEN, blendable, dim, lighten,
+    DISABLED_DIM, FIELD_FOCUS_SHIFT, FIELD_HOVER_SHIFT, ROW_FOCUS_SHIFT, away_from, blendable, dim,
 };
 use crate::linear_nav::{self, NavOutcome, ScrollStep};
 use crate::list_core::{
@@ -37,7 +37,6 @@ use crate::runtime::{
 use crate::selection_indicator;
 use crate::theme::resolve_style;
 
-const ROW_FOCUS_LIGHTEN: u16 = 15;
 const INDICATOR_CLOSED: &str = "∨";
 const INDICATOR_OPEN: &str = "∧";
 
@@ -138,27 +137,28 @@ impl SelectStyle {
 
     /// Derive every select color from `theme`.
     #[must_use]
-    pub const fn from_theme(theme: &Theme) -> Self {
+    pub fn from_theme(theme: &Theme) -> Self {
         // Disabled dims toward the background, or the surface when the theme
         // leaves its background to the terminal — the same answer `ListStyle`
         // gives, so a select and a list cannot disagree about disabled.
         let backdrop = blendable(theme.background, theme.surface);
-        let panel_background = lighten(theme.field, FIELD_FOCUS_LIGHTEN);
+        let away = away_from(theme.background);
+        let panel_background = dim(theme.field, away, FIELD_FOCUS_SHIFT);
         Self {
             value_foreground: theme.foreground,
             placeholder_foreground: theme.muted_foreground,
             trigger_background: theme.field,
             focused_trigger_background: panel_background,
-            hovered_trigger_background: lighten(theme.field, FIELD_HOVER_LIGHTEN),
+            hovered_trigger_background: dim(theme.field, away, FIELD_HOVER_SHIFT),
             indicator: theme.muted_foreground,
             border: theme.border,
             panel_background,
             option_foreground: theme.muted_foreground,
             focused_option_foreground: theme.foreground,
-            focused_option_background: lighten(panel_background, ROW_FOCUS_LIGHTEN),
+            focused_option_background: dim(panel_background, away, ROW_FOCUS_SHIFT),
             selected_foreground: theme.foreground,
             selected_focused_foreground: theme.foreground,
-            selected_focused_background: lighten(panel_background, ROW_FOCUS_LIGHTEN),
+            selected_focused_background: dim(panel_background, away, ROW_FOCUS_SHIFT),
             selected_marker: theme.primary,
             unselected_marker: theme.muted_foreground,
             disabled_foreground: dim(theme.muted_foreground, backdrop, DISABLED_DIM),
@@ -263,7 +263,7 @@ impl<'a> SelectWidget<'a> {
 
     /// Take colors from `theme`.
     #[must_use]
-    pub const fn themed(mut self, theme: &Theme) -> Self {
+    pub fn themed(mut self, theme: &Theme) -> Self {
         self.style = SelectStyle::from_theme(theme);
         self
     }
@@ -1309,10 +1309,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::{
-        ListStyle,
-        runtime::{FocusState, Modifiers, Ratcn, ScopeOptions},
-    };
+    use crate::runtime::{FocusState, Modifiers, Ratcn, ScopeOptions};
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum Fruit {
@@ -1349,89 +1346,6 @@ mod tests {
         .into_iter()
         .map(|(value, label)| ListItem::new(value, label))
         .collect()
-    }
-
-    #[test]
-    fn list_and_select_share_themed_control_surfaces() {
-        for theme in Theme::presets() {
-            let list = ListStyle::from_theme(theme);
-            let select = SelectStyle::from_theme(theme);
-            assert_eq!(
-                select.trigger_background, list.background,
-                "{} base",
-                theme.name
-            );
-            assert_eq!(
-                select.focused_trigger_background, list.focused_background,
-                "{} focus",
-                theme.name
-            );
-            assert_eq!(
-                select.hovered_trigger_background, list.hovered_background,
-                "{} hover",
-                theme.name
-            );
-            assert_eq!(
-                select.panel_background, list.focused_background,
-                "{} panel",
-                theme.name
-            );
-            assert_eq!(
-                select.focused_option_background, list.focused_row_background,
-                "{} row",
-                theme.name
-            );
-            assert_eq!(
-                select.selected_focused_foreground, list.selected_focused_foreground,
-                "{} selected focused foreground",
-                theme.name
-            );
-            assert_eq!(
-                select.selected_focused_background, list.selected_focused_background,
-                "{} selected focused background",
-                theme.name
-            );
-            assert_eq!(
-                select.disabled_background, list.disabled_background,
-                "{} disabled",
-                theme.name
-            );
-            assert_eq!(
-                select.selected_disabled_foreground, list.disabled_foreground,
-                "{} selected disabled foreground",
-                theme.name
-            );
-            assert_eq!(
-                select.selected_disabled_background, list.disabled_background,
-                "{} selected disabled background",
-                theme.name
-            );
-            assert_ne!(
-                list.background, list.focused_background,
-                "{} focus",
-                theme.name
-            );
-            assert_ne!(
-                list.focused_background, list.hovered_background,
-                "{} hover",
-                theme.name
-            );
-            assert_ne!(
-                list.focused_background, list.focused_row_background,
-                "{} focused row",
-                theme.name
-            );
-            assert_ne!(
-                list.foreground, list.selected_foreground,
-                "{} selected text",
-                theme.name
-            );
-            assert_ne!(
-                list.unselected_marker, list.selected_marker,
-                "{} selected marker",
-                theme.name
-            );
-        }
     }
 
     #[test]

--- a/crates/ratcn/src/components/tabs.rs
+++ b/crates/ratcn/src/components/tabs.rs
@@ -10,9 +10,7 @@ use ratatui::{
 
 use crate::Theme;
 use crate::button_shape::{BOTTOM_CAP, TOP_CAP, cap_row, filled_middle, shape_width};
-use crate::color::{
-    DISABLED_DIM, FOCUS_DARKEN, FOCUS_LIGHTEN, HOVER_DARKEN, HOVER_LIGHTEN, darken, dim, lighten,
-};
+use crate::color::{DISABLED_DIM, FOCUS_SHIFT, HOVER_SHIFT, away_from, dim, nearest_to};
 use crate::linear_nav;
 use crate::list_core;
 use crate::runtime::{
@@ -97,7 +95,8 @@ pub struct TabsStyle {
     /// keyboard focus.
     pub focused_foreground: Color,
     /// An unselected tab's fill while it is the cursor tab and the row has
-    /// keyboard focus (the secondary button's focus lighten).
+    /// keyboard focus (the secondary button's focus shift, away from the
+    /// background).
     pub focused_background: Color,
     /// An unselected tab's label while the pointer is over the row and this is
     /// the cursor tab.
@@ -111,7 +110,7 @@ pub struct TabsStyle {
     /// The selected tab's label while focused.
     pub selected_focused_foreground: Color,
     /// The selected tab's fill while focused (the default button's focus
-    /// darken).
+    /// shift, toward the background's own end).
     pub selected_focused_background: Color,
     /// The selected tab's label while hovered.
     pub selected_hovered_foreground: Color,
@@ -155,27 +154,30 @@ impl TabsStyle {
 
     /// Derived from the theme exactly as the button variants are: the selected
     /// tab is a `Default` (primary) button, an unselected tab a `Secondary`
-    /// button — including the same focus and hover shifts (a bright fill
-    /// darkens, a dark fill lightens) and the disabled dim toward the surface.
+    /// button — including the same focus and hover shifts (a selected tab
+    /// deepens toward the screen's own end, an unselected one climbs away from
+    /// it) and the disabled dim toward the surface.
     ///
     /// Label colors do not change with focus or hover here, since the fill
     /// already carries that. A style that flattens the fills should set the
     /// `*_foreground` slots instead.
     #[must_use]
-    pub const fn from_theme(theme: &Theme) -> Self {
+    pub fn from_theme(theme: &Theme) -> Self {
+        let pressed = nearest_to(theme.background);
+        let raised = away_from(theme.background);
         Self {
             foreground: theme.secondary_foreground,
             background: theme.secondary,
             focused_foreground: theme.secondary_foreground,
-            focused_background: lighten(theme.secondary, FOCUS_LIGHTEN),
+            focused_background: dim(theme.secondary, raised, FOCUS_SHIFT),
             hovered_foreground: theme.secondary_foreground,
-            hovered_background: lighten(theme.secondary, HOVER_LIGHTEN),
+            hovered_background: dim(theme.secondary, raised, HOVER_SHIFT),
             selected_foreground: theme.primary_foreground,
             selected_background: theme.primary,
             selected_focused_foreground: theme.primary_foreground,
-            selected_focused_background: darken(theme.primary, FOCUS_DARKEN),
+            selected_focused_background: dim(theme.primary, pressed, FOCUS_SHIFT),
             selected_hovered_foreground: theme.primary_foreground,
-            selected_hovered_background: darken(theme.primary, HOVER_DARKEN),
+            selected_hovered_background: dim(theme.primary, pressed, HOVER_SHIFT),
             disabled_foreground: theme.muted_foreground,
             disabled_background: dim(theme.secondary, theme.surface, DISABLED_DIM),
             selected_disabled_foreground: theme.muted_foreground,
@@ -303,7 +305,7 @@ impl<'a> TabsWidget<'a> {
 
     /// Take colors from `theme`.
     #[must_use]
-    pub const fn themed(mut self, theme: &Theme) -> Self {
+    pub fn themed(mut self, theme: &Theme) -> Self {
         self.style = TabsStyle::from_theme(theme);
         self
     }

--- a/crates/ratcn/src/theme.rs
+++ b/crates/ratcn/src/theme.rs
@@ -9,7 +9,10 @@
 
 use ratatui::style::Color;
 
-use crate::color::dim;
+use crate::color::{
+    DISABLED_DIM, FIELD_FOCUS_SHIFT, FIELD_HOVER_SHIFT, FOCUS_SHIFT, HOVER_SHIFT, ROW_FOCUS_SHIFT,
+    away_from, blendable, contrast, dim, luminance, nearest_to, resolve_rgb,
+};
 use ratatui::symbols::border;
 
 /// The style a component paints with: the override it was declared with, or the
@@ -89,21 +92,25 @@ const RING_DIM: u16 = 10;
 ///
 /// Focus and disabled variants are derived by the components that need them,
 /// not stored here (see [`crate::color`]): a focused fill shifts a fixed amount
-/// in the direction that makes it stand out — a bright fill darkens, a dark fill
-/// (secondary, the inset `field`) lightens — and a disabled control dims toward
-/// the layer behind it: a button toward the `surface`, a well toward the
-/// `background` it already sits close to.
+/// in a direction read off `background` rather than written into the component
+/// — a well climbs away from the screen, a filled control deepens toward it,
+/// and on a light theme both of those are the other way round in absolute terms
+/// — and a disabled control dims toward the layer behind it: a button toward
+/// the `surface`, a well toward the `background` it already sits close to.
 ///
 /// # The well ladder
 ///
 /// `field` is the bottom rung of a four-level ladder every well is painted
-/// from, and it sits *close* to `background` — one tone above it, not a slab
-/// that competes with the screen. A component lifts from there: focused is
-/// lighter than at rest, focused-and-hovered lighter still, and the cursor row
-/// inside a list is the lightest. The lift amounts live in [`crate::color`]
-/// ([`FIELD_FOCUS_LIGHTEN`](crate::color::FIELD_FOCUS_LIGHTEN),
-/// [`FIELD_HOVER_LIGHTEN`](crate::color::FIELD_HOVER_LIGHTEN)), so a palette
-/// that gets `background` and `field` right gets the whole ladder right.
+/// from, and it sits *close* to `background` — one tone off it, not a slab
+/// that competes with the screen. A component lifts from there: focused is one
+/// step further from the background than at rest, focused-and-hovered further
+/// still, and the cursor row inside a list is the furthest. The lift amounts
+/// live in [`crate::color`]
+/// ([`crate::color::FIELD_FOCUS_SHIFT`],
+/// [`crate::color::FIELD_HOVER_SHIFT`]), and the direction
+/// comes from [`crate::color::away_from`], so a palette that gets
+/// `background` and `field` right gets the whole ladder right on either
+/// polarity.
 ///
 /// Text has to stay readable on every rung, which is what caps how far `field`
 /// may sit from `background`: each rung spends contrast the palette can only
@@ -238,7 +245,7 @@ impl Theme {
     /// need real surface colors to lighten from. Named colors (`Gray`,
     /// `Yellow`, …) keep the terminal palette at rest; their derived
     /// focus/hover/disabled states resolve through
-    /// [`resolve_rgb`](crate::color::resolve_rgb)'s fixed VGA approximation.
+    /// [`resolve_rgb`]'s fixed VGA approximation.
     ///
     /// That approximation is why `primary` is neutral here rather than a hue.
     /// A named accent only survives as long as nothing derives from it: the
@@ -506,43 +513,673 @@ impl Theme {
         }
     }
 
+    /// A theme solved around a background and a foreground someone else chose —
+    /// the terminal's own, a browser's computed style, a user setting.
+    ///
+    /// The presets answer "what does Gruvbox look like". This answers a
+    /// different question: given only *these two colors*, what palette keeps
+    /// every relationship the crate's contrast floors demand? Everything is
+    /// solved rather than picked — the well against the 1.10..=1.35 window, the
+    /// surface into the gap below it, text and lines against their floors — in
+    /// the same integer blend arithmetic the components paint with, so a color
+    /// that solves to a floor here measures to the same floor there.
+    ///
+    /// Polarity is not a parameter. A light background derives a light theme:
+    /// wells sit *darker* than the screen and deepen from there, filled
+    /// controls brighten as they take focus, and text darkens. Nothing in the
+    /// call changes; [`crate::color::away_from`] reads it off the
+    /// background.
+    ///
+    /// `palette16` is the terminal's own ANSI colors, if the caller has them,
+    /// used for the three roles a neutral cannot fill — error, warning, and the
+    /// signature accent. They are repaired toward the readable end until they
+    /// clear their floors, because a palette's red is chosen to be *seen as
+    /// text on the background*, not to be a fill with a label on it. Without
+    /// them the same three roles come from fixed seeds and take the same
+    /// repair.
+    ///
+    /// # Total
+    ///
+    /// A derived theme is named `"Adaptive"`, which is not one of the names the
+    /// tests grant a contrast exception, so the solvers have to actually land —
+    /// and no input has been found that stops them. That is a swept property,
+    /// not a proof: the crate's own sweep derives a theme from every preset's
+    /// pair, the four polarity corners, the low-contrast pairs real terminals
+    /// report, the pairs that once broke an invariant, an RGB lattice, and a
+    /// seeded walk between its points — each with and without a terminal
+    /// palette to take hues from — and holds every one of them to every floor
+    /// the presets are held to.
+    ///
+    /// Totality is not free, and where it cannot be had by solving a color it
+    /// is had by refusing the background: a screen too close to the middle of
+    /// the ramp is deepened toward its own end until the rest becomes solvable
+    /// (see below). Colors with no channels to read ([`Color::Reset`],
+    /// `Indexed`) are replaced by [`default_dark`](Self::default_dark)'s pair
+    /// before anything is solved, which is the only sense in which the function
+    /// can refuse an input outright.
+    ///
+    /// # A low-contrast pair is not honored verbatim
+    ///
+    /// A terminal may report a pair that cannot carry a UI: Solarized Light's
+    /// real background and foreground are 4.13:1, and a well's top rung eats
+    /// that to 2.26:1. The foreground is therefore pushed away from the
+    /// background until it holds 4.5:1 on every fill it will be painted on, on
+    /// whichever side can get there. Body text ends up further from what the
+    /// terminal reported than anything else in the theme; the alternative is a
+    /// list whose rows cannot be read.
+    ///
+    /// ```
+    /// use ratatui::style::Color;
+    /// use ratcn::Theme;
+    ///
+    /// fn luminance(color: Color) -> f64 {
+    ///     ratcn::color::luminance(color).expect("a derived theme is rgb")
+    /// }
+    ///
+    /// // A light terminal: the well is darker than the screen behind it.
+    /// let theme = Theme::adaptive(Color::Rgb(253, 246, 227), Color::Rgb(101, 123, 131), None);
+    /// assert!(luminance(theme.field) < luminance(theme.background));
+    ///
+    /// // A dark one: the same call, the other way round.
+    /// let theme = Theme::adaptive(Color::Rgb(10, 10, 10), Color::Rgb(250, 250, 250), None);
+    /// assert!(luminance(theme.field) > luminance(theme.background));
+    /// ```
+    #[must_use]
+    pub fn adaptive(background: Color, foreground: Color, palette16: Option<&[Color; 16]>) -> Self {
+        let fallback = Self::default_dark();
+        let queried_background = blendable(background, fallback.background);
+        let queried_text = blendable(foreground, fallback.foreground);
+        let away = away_from(queried_background);
+        let near = nearest_to(queried_background);
+
+        // A background near the middle of the ramp cannot carry a UI: the well
+        // ladder spends contrast climbing away from it, and text has to clear
+        // both the background and the rung furthest from it. On `#0040ff` those
+        // two demands point opposite ways and neither end can serve both — the
+        // ladder leaves 3.31:1 above it and only 3.17:1 below. So the
+        // background is deepened toward its own end until the pair becomes
+        // solvable, keeping the hue and the polarity the terminal reported
+        // while buying back the room the ladder needs. A background that was
+        // already workable is not moved at all.
+        let (layers, hues) = (0..=100)
+            .map(|deepen| dim(queried_background, near, deepen))
+            .find_map(|background| {
+                let layers = Layers::solve(background, queried_text, away)?;
+                // The hued roles are solved inside the walk, not after it: a
+                // mid-gray screen leaves a delete button no shade of red that
+                // holds the boundary floor in all three of its states, and the
+                // answer to that is a deeper screen, not a worse red.
+                let hues = Hues::solve(palette16, &layers, away, near)?;
+                Some((layers, hues))
+            })
+            // Unreachable in practice — the walk ends at an extreme, and an
+            // extreme always solves — but written as a value rather than an
+            // unwrap so the function has no panic to document.
+            .unwrap_or((
+                Layers {
+                    background: fallback.background,
+                    surface: fallback.surface,
+                    field: fallback.field,
+                    secondary: fallback.secondary,
+                    primary: fallback.primary,
+                    ring: fallback.ring,
+                    foreground: fallback.foreground,
+                    muted_foreground: fallback.muted_foreground,
+                },
+                Hues {
+                    accent: fallback.accent,
+                    destructive: fallback.destructive,
+                    warning: fallback.warning,
+                },
+            ));
+
+        let labels = [layers.background, layers.foreground];
+
+        let mut theme = fallback;
+        theme.name = "Adaptive";
+        theme.foreground = layers.foreground;
+        theme.muted_foreground = layers.muted_foreground;
+        theme.background = layers.background;
+        theme.surface = layers.surface;
+        theme.field = layers.field;
+        theme.primary = layers.primary;
+        theme.primary_foreground = best_label(layers.primary, near, &labels);
+        theme.secondary = layers.secondary;
+        theme.secondary_foreground = best_label(layers.secondary, away, &labels);
+        theme.accent = hues.accent;
+        theme.destructive = hues.destructive;
+        theme.destructive_foreground = best_label(hues.destructive, near, &labels);
+        theme.warning = hues.warning;
+        theme.border = first_blend(layers.background, away, |line| {
+            contrast_or_zero(line, layers.background) >= LINE_FLOOR
+        });
+        theme.ring = layers.ring;
+        theme.cursor = layers.foreground;
+        theme
+    }
+
     /// Every built-in theme, in a stable order — for a theme picker or a
     /// cycle-themes hotkey.
     ///
     /// The slice is returned rather than a fixed-size array so that adding a
     /// preset does not break callers: index it, iterate it, or take its
     /// `len()`, but do not depend on the count.
+    ///
+    /// [`adaptive`](Self::adaptive) is deliberately absent: it is solved per
+    /// terminal rather than authored, so there is no one theme to list.
     #[must_use]
     pub const fn presets() -> &'static [Self] {
         &PRESETS
     }
 }
 
+// The floors a solved theme is built to. They are the same numbers the tests
+// hold every theme to; naming them here is what lets the derivation aim at a
+// floor instead of at a color someone liked.
+
+/// How close a well may sit to the background before it disappears into it,
+/// and how far before it becomes a slab the text budget cannot afford. Every
+/// theme in the crate is held to this window, and a solved one aims at
+/// [`WELL_TARGET`] inside it.
+const WELL_MIN: f64 = 1.10;
+/// The far side of the well window.
+const WELL_MAX: f64 = 1.35;
+
+/// Where a solved well sits inside the window: in the middle, so the surface
+/// has room to split off below it and the rungs have room to climb above it.
+/// At the bottom the split stops fitting; at the top the text budget runs out.
+const WELL_TARGET: f64 = 1.20;
+
+/// What a dialog needs against the screen: only enough to be a different
+/// color, because a dialog also has a ring around it, pinned at [`LINE_FLOOR`].
+const SURFACE_MIN: f64 = 1.03;
+
+/// The smallest change that is a change. Below this a focus or hover state is
+/// in the numbers but not on the screen.
+const VISIBLE_STEP: f64 = 1.05;
+
+/// How far muted text has to sit from body text to be a second register rather
+/// than a rounding error.
+///
+/// Higher than [`VISIBLE_STEP`], because two fills a step apart are read as one
+/// surface changing state while two *texts* a step apart are read as the same
+/// text. It is set just under the tightest a preset gets — Nord has the least
+/// room between its two Snow Storm tones, at 1.17:1.
+const MUTED_STEP: f64 = 1.15;
+
+/// WCAG 2.1 non-text contrast (1.4.11), what a border or a ring has to clear
+/// against what it is drawn on.
+const LINE_FLOOR: f64 = 3.0;
+
+/// WCAG 2.1 normal text (1.4.3), what every label has to clear against every
+/// fill it can land on.
+const TEXT_FLOOR: f64 = 4.5;
+
+/// What a disabled row keeps. WCAG exempts inactive controls, so this is not a
+/// text floor — it is the line between receding and gone.
+const DISABLED_LEGIBILITY: f64 = 2.0;
+
+/// How far a neutral fill sits from the background. Near enough to the far end
+/// that a label of the background's own tone reads on it, which is what makes
+/// `primary` a neutral rather than a hue: a solved theme has no reason to
+/// prefer one of the terminal's accents, and every reason to avoid one whose
+/// derived states it cannot predict.
+const NEUTRAL_FILL_SHIFT: u16 = 90;
+
+/// How far a quiet fill (`secondary`) sits from the background — far enough to
+/// read as a control, near enough to stay quiet next to `primary`.
+const QUIET_FILL_SHIFT: u16 = 13;
+
+/// The contrast between two colors, or 0.0 when one cannot be measured — a
+/// value no floor accepts, so an unreadable color can never satisfy a solver.
+fn contrast_or_zero(a: Color, b: Color) -> f64 {
+    contrast(a, b).unwrap_or(0.0)
+}
+
+/// The first blend of `from` toward `toward` that satisfies `ok`, or the whole
+/// way when nothing does.
+///
+/// Solving by walking the same integer percentages [`dim`] blends in is the
+/// point: a color found here is a color the components can reach, rounded
+/// exactly as they round it.
+fn first_blend(from: Color, toward: Color, ok: impl Fn(Color) -> bool) -> Color {
+    (0..=100)
+        .map(|amount| dim(from, toward, amount))
+        .find(|blend| ok(*blend))
+        .unwrap_or_else(|| dim(from, toward, 100))
+}
+
+/// Every neutral a theme is built from, solved together because they constrain
+/// each other.
+///
+/// The well is placed against the background, the rungs climb from the well,
+/// and the text has to clear the furthest of them — while `primary` has to
+/// carry a boundary floor of its own, since the focus ring is derived from it.
+/// [`Layers::solve`] answering `None` is what tells the caller this background
+/// cannot carry a theme, whichever of those demands is the one it cannot meet.
+struct Layers {
+    background: Color,
+    surface: Color,
+    field: Color,
+    secondary: Color,
+    primary: Color,
+    ring: Color,
+    foreground: Color,
+    muted_foreground: Color,
+}
+
+impl Layers {
+    fn solve(background: Color, queried_text: Color, away: Color) -> Option<Self> {
+        let field = solve_well(background, away);
+        let surface = solve_surface(background, field);
+        let rungs = well_rungs(field, away);
+        // A saturated background fails here rather than later: a channel
+        // already at the ceiling cannot move, so `#0080ff` climbs its ladder in
+        // steps of 1.04:1 — present in the arithmetic, invisible on screen.
+        // Refusing the background is what sends the caller back to deepen it.
+        if !(WELL_MIN..=WELL_MAX).contains(&contrast_or_zero(field, background))
+            || !climbs_visibly(background, &[field, rungs[0], rungs[1], rungs[2]])
+        {
+            return None;
+        }
+
+        // Text lands on more than the well: the screen itself and the raised
+        // surface carry it too, and the well's three rungs are the fills that
+        // sit furthest from the background.
+        //
+        // A ghost button's focus and hover fills are not listed. They climb
+        // from the quiet fill by [`FOCUS_SHIFT`] and [`HOVER_SHIFT`], which
+        // stays inside the headroom body text is already pushed past for muted
+        // text to exist below it — the derived sweep is what holds that.
+        let secondary = dim(background, away, QUIET_FILL_SHIFT);
+        let backdrops = [background, surface, rungs[0], rungs[1], rungs[2]];
+
+        // One predicate answers for all the text in the theme. Disabled rows
+        // are in it because they are derived from muted text and dimmed again
+        // from there — the pair that runs out first on a saturated background,
+        // where there is room to dim long past the point the disabled twin
+        // survives.
+        let disabled_well = dim(field, background, DISABLED_DIM);
+        let measured = Backdrops::new(&backdrops);
+        let readable = |text: Color| {
+            measured.worst(text) >= TEXT_FLOOR
+                && contrast_or_zero(dim(text, background, DISABLED_DIM), disabled_well)
+                    >= DISABLED_LEGIBILITY
+        };
+        // Body text is pushed away from the background until it holds, and far
+        // enough past that for muted text to still exist: taking the least push
+        // that clears the floor leaves body text sitting exactly on it, with no
+        // room underneath, and every muted role — list rows at rest,
+        // placeholders, dialog descriptions, toast bodies — collapses onto it.
+        // Coarse to fine again, for the same reason: the least push that works
+        // is what keeps body text closest to what the terminal reported, both
+        // ends have to be tried, and asking every amount of both is the
+        // expensive half of solving a theme.
+        let solved_text = |amount: u16| {
+            [Color::White, Color::Black]
+                .into_iter()
+                .map(|end| dim(queried_text, end, amount))
+                .filter(|text| readable(*text))
+                .find_map(|text| Some((text, recedes_from(text, background, &readable)?)))
+        };
+        let coarse = (0..=20)
+            .map(|step| step * 5)
+            .find(|amount| solved_text(*amount).is_some())?;
+        let (foreground, muted_foreground) =
+            (coarse.saturating_sub(4)..=coarse).find_map(solved_text)?;
+
+        // `primary` is placed, not searched for: the background shifted
+        // [`NEUTRAL_FILL_SHIFT`] toward the far end, which is what makes it a
+        // neutral rather than one of the terminal's accents.
+        //
+        // What holds its floors is the deepening walk this solver runs inside.
+        // The walk's other gate is [`Hues::solve`], where a red has to hold
+        // [`LINE_FLOOR`] on the surface across all three of its fill states,
+        // and every background near the middle of the ramp fails that gate
+        // first — so by the time a background is accepted at all, it is deep
+        // enough that the placed fill has room for a ring and a label. The `?`
+        // below is defence-in-depth: it puts ring-solvability into the same
+        // solvability predicate, so a background that placed a primary with no
+        // workable ring would be deepened rather than returned.
+        let primary = dim(background, away, NEUTRAL_FILL_SHIFT);
+        let ring = ring_of(primary, background, surface)?;
+
+        Some(Self {
+            background,
+            surface,
+            field,
+            secondary,
+            primary,
+            ring,
+            foreground,
+            muted_foreground,
+        })
+    }
+}
+
+/// Muted text for a given body text: the dimmest blend toward the background
+/// that still reads, still recedes, and is still visibly a different color.
+///
+/// Contrast against the worst of several backdrops is not monotone in the
+/// blend: `#00ff40` dips below the floor partway and comes back, so a single
+/// walk stopping at the first failure returns a "muted" text more contrasty
+/// than the body text it came from. The walk is therefore coarse to
+/// fine — a pass in tens finds the dimmest decade that holds, and a fine pass
+/// inside it takes amounts while they hold. Both passes can be stepped over by
+/// a dip, so the answer may sit a few channel steps short of what checking all
+/// hundred amounts would find (measured: 43 of 4000 backgrounds, median 3
+/// steps). What it cannot be is invalid — every amount returned is one
+/// `holds` accepted.
+fn recedes_from(
+    foreground: Color,
+    background: Color,
+    readable: &impl Fn(Color) -> bool,
+) -> Option<Color> {
+    let reach = contrast_or_zero(foreground, background);
+    let holds = |muted: Color| {
+        readable(muted)
+            && contrast_or_zero(muted, background) < reach
+            && contrast_or_zero(muted, foreground) >= MUTED_STEP
+    };
+    // Coarse first, then refine. The answer wanted is the dimmest blend that
+    // holds, and this is asked once per candidate body text while a theme is
+    // being solved — walking all hundred amounts every time made the sweep an
+    // order of magnitude slower than the whole rest of the suite. A coarse pass
+    // finds the window, a fine pass finds the edge inside it, and anything the
+    // coarse pass steps over is a slightly less dim muted, never an invalid one.
+    let coarse = (0..=10)
+        .rev()
+        .map(|step| step * 10)
+        .find(|amount| holds(dim(foreground, background, *amount)))?;
+    (coarse..coarse + 10)
+        .map(|amount| dim(foreground, background, amount))
+        .take_while(|muted| holds(*muted))
+        .last()
+        .or_else(|| Some(dim(foreground, background, coarse)))
+}
+
+/// A focus ring for a given `primary`: softened toward the background like a
+/// preset's, but only as far as it can go while still reading as a boundary
+/// against both the screen and the surface it frames.
+///
+/// `None` means no softening works, including none at all — which is a fact
+/// about `primary`, and why `primary` is solved against this rather than placed
+/// and hoped for.
+fn ring_of(primary: Color, background: Color, surface: Color) -> Option<Color> {
+    (0..=RING_DIM)
+        .map(|softening| dim(primary, background, softening))
+        .take_while(|ring| {
+            contrast_or_zero(*ring, background) >= LINE_FLOOR
+                && contrast_or_zero(*ring, surface) >= LINE_FLOOR
+        })
+        .last()
+}
+
+/// The well: the first tone away from the background that reaches
+/// [`WELL_TARGET`]. The window's floor is 1.10 and this aims past it, because
+/// the surface has to fit underneath.
+fn solve_well(background: Color, away: Color) -> Color {
+    first_blend(background, away, |field| {
+        contrast_or_zero(field, background) >= WELL_TARGET
+    })
+}
+
+/// The surface: the first tone between the background and the well that is
+/// distinct from the background and still leaves the well distinct from it.
+///
+/// Blending toward the well rather than toward an extreme is what keeps it
+/// *between* them on either polarity, which is the ordering the tests assert.
+fn solve_surface(background: Color, field: Color) -> Color {
+    first_blend(background, field, |surface| {
+        contrast_or_zero(surface, background) >= SURFACE_MIN
+            && contrast_or_zero(field, surface) >= WELL_MIN
+    })
+}
+
+/// Whether each of these is a visible step further from the background than the
+/// one before it — the ladder's own invariant, checked while it is being solved
+/// rather than after it is painted.
+fn climbs_visibly(background: Color, ladder: &[Color]) -> bool {
+    let mut previous = background;
+    for rung in ladder {
+        if contrast_or_zero(*rung, previous) < VISIBLE_STEP {
+            return false;
+        }
+        previous = *rung;
+    }
+    true
+}
+
+/// The three fills a list derives from a well, in the order it climbs them.
+/// Solving against these rather than against the well is the difference between
+/// text that reads at rest and text that reads on the cursor row.
+fn well_rungs(field: Color, away: Color) -> [Color; 3] {
+    let focused = dim(field, away, FIELD_FOCUS_SHIFT);
+    [
+        focused,
+        dim(field, away, FIELD_HOVER_SHIFT),
+        dim(focused, away, ROW_FOCUS_SHIFT),
+    ]
+}
+
+/// The worst contrast `text` has against any of `backdrops`.
+///
+/// The backdrops' luminances are computed once and kept, because this is the
+/// crate's innermost loop: solving a theme asks it for hundreds of candidate
+/// texts against the same handful of fills, and each answer is otherwise three
+/// `powf` calls per channel per side.
+struct Backdrops {
+    luminances: Vec<Option<f64>>,
+}
+
+impl Backdrops {
+    fn new(backdrops: &[Color]) -> Self {
+        Self {
+            luminances: backdrops.iter().copied().map(luminance).collect(),
+        }
+    }
+
+    fn worst(&self, text: Color) -> f64 {
+        let Some(text) = luminance(text) else {
+            return 0.0;
+        };
+        self.luminances
+            .iter()
+            .map(|backdrop| match backdrop {
+                Some(backdrop) => (text.max(*backdrop) + 0.05) / (text.min(*backdrop) + 0.05),
+                // The convention [`contrast_or_zero`] keeps: a backdrop with no
+                // channels to measure scores a ratio no floor accepts, so an
+                // unmeasurable color can never satisfy a solver. Every backdrop
+                // a solved theme passes here is derived rgb, so this is the
+                // arm that says what the crate would do rather than one it
+                // reaches.
+                None => 0.0,
+            })
+            .fold(f64::INFINITY, f64::min)
+    }
+}
+
+/// The worst contrast `text` has against any of `backdrops`, for the callers
+/// that ask once rather than in a loop — allocation-free, because the hue
+/// repair asks it a hundred times per role.
+fn worst_against(text: Color, backdrops: &[Color]) -> f64 {
+    let Some(text) = luminance(text) else {
+        return 0.0;
+    };
+    backdrops
+        .iter()
+        .filter_map(|backdrop| luminance(*backdrop))
+        .map(|backdrop| (text.max(backdrop) + 0.05) / (text.min(backdrop) + 0.05))
+        .fold(f64::INFINITY, f64::min)
+}
+
+/// The three fills a control paints: at rest, focused, and hovered.
+fn fill_states(fill: Color, pressed: Color) -> [Color; 3] {
+    [
+        fill,
+        dim(fill, pressed, FOCUS_SHIFT),
+        dim(fill, pressed, HOVER_SHIFT),
+    ]
+}
+
+/// Whether a fill's three states are three visibly different fills.
+///
+/// A fill can fail this by being too close to the end it is pressed toward, and
+/// a saturated one fails it from further away than a neutral does: blending
+/// `#ff0000` toward white moves two channels that barely carry luminance and
+/// leaves the third at the ceiling, so a light theme's red steps 1.01:1 where
+/// its neutrals step 1.29:1. The derivation therefore has to pick a hue that
+/// can move, rather than trusting that any red will do.
+fn steps_visibly(fill: Color, pressed: Color) -> bool {
+    let states = fill_states(fill, pressed);
+    contrast_or_zero(states[0], states[1]) >= 1.05 && contrast_or_zero(states[1], states[2]) >= 1.05
+}
+
+/// A label for a fill: the first candidate that holds [`TEXT_FLOOR`] across all
+/// three of the control's fills, preferring the theme's own tones over the
+/// extremes.
+///
+/// It satisfices rather than maximizes — the candidates are offered in the
+/// order the palette would rather use, and the search stops at the first that
+/// clears, so a label made of the theme's own background wins over a starker
+/// one that measures higher. When nothing clears, the best of them is returned
+/// and the caller's own floor check is what refuses the theme.
+///
+/// Every candidate is scored across the whole trajectory, because a label's
+/// worst moment is not always at rest: the fill moves toward the screen's own
+/// end as it gains focus, so a label on that side loses contrast exactly when
+/// the control is being used.
+fn best_label(fill: Color, pressed: Color, candidates: &[Color]) -> Color {
+    let states = fill_states(fill, pressed);
+    let measured = Backdrops::new(&states);
+    let score = |label: Color| measured.worst(label);
+    // The extremes are written as channels, not as `Color::White`/`Color::Black`:
+    // those are named colors, measured here through the VGA table but painted
+    // as whatever the terminal's ANSI 0 and 15 happen to be — `#073642` on a
+    // Solarized palette. A label proven at 6.2:1 has to be the label that gets
+    // drawn.
+    let extremes = [Color::Rgb(255, 255, 255), Color::Rgb(0, 0, 0)];
+    let mut best = candidates.first().copied().unwrap_or(extremes[0]);
+    for candidate in candidates.iter().copied().chain(extremes) {
+        if score(candidate) > score(best) {
+            best = candidate;
+        }
+        if score(best) >= TEXT_FLOOR {
+            break;
+        }
+    }
+    best
+}
+
+/// The three roles a neutral cannot fill, solved from the terminal's palette
+/// when there is one.
+struct Hues {
+    accent: Color,
+    destructive: Color,
+    warning: Color,
+}
+
+impl Hues {
+    /// ANSI bright red, yellow, and magenta — the palette entries whose meaning
+    /// is fixed by convention rather than by taste.
+    ///
+    /// The convention is not universal: Solarized repurposes the bright half,
+    /// putting orange in slot 9 and a base gray in slot 11, so `warning`
+    /// derives to a gray that clears every floor and stays distinct while
+    /// reading as no warning at all. Trusting the slot may need a saturation
+    /// sanity-check once the palette arrives over OSC 4.
+    const RED: usize = 9;
+    const YELLOW: usize = 11;
+    const MAGENTA: usize = 13;
+
+    fn solve(
+        palette16: Option<&[Color; 16]>,
+        layers: &Layers,
+        away: Color,
+        near: Color,
+    ) -> Option<Self> {
+        let from_palette = |index: usize, seed: Color| {
+            palette16
+                .and_then(|palette| resolve_rgb(palette[index]).map(|_| palette[index]))
+                .unwrap_or(seed)
+        };
+        // A palette's own accents are chosen to be read as text on the
+        // background, which is a weaker requirement than being a fill with a
+        // label on it. Each is walked toward the readable end until it clears
+        // the floors it has to clear, so an unusable hue becomes a usable one
+        // of the same family rather than being replaced by a neutral.
+        //
+        // A hue that is also a fill has to hold the boundary floor in all three
+        // of its states, not just at rest. Focus and hover walk a fill back
+        // toward the screen, and on a light theme that is the direction the
+        // page already is: every real light terminal palette measured put a
+        // hovered delete button under 3:1 on its own surface when only the
+        // resting state was solved for.
+        let repair = |hue: Color, is_a_fill: bool, taken: &[Color]| {
+            (0..=100)
+                .map(|amount| dim(hue, away, amount))
+                .find(|candidate| {
+                    let candidate = *candidate;
+                    if taken.contains(&candidate) {
+                        return false;
+                    }
+                    let states = fill_states(candidate, near);
+                    let shown = if is_a_fill { &states[..] } else { &states[..1] };
+                    shown
+                        .iter()
+                        .all(|state| contrast_or_zero(*state, layers.surface) >= LINE_FLOOR)
+                        && (!is_a_fill
+                            || (steps_visibly(candidate, near)
+                                && worst_against(
+                                    best_label(candidate, near, &[layers.background]),
+                                    &states,
+                                ) >= TEXT_FLOOR))
+                })
+        };
+        // Solved in turn, each refusing the answers already given: a palette
+        // whose red slot holds a yellow repairs both roles to the same color
+        // otherwise, and an error that looks like a warning is worse than
+        // either being slightly off-hue.
+        let destructive = repair(
+            from_palette(Self::RED, Color::Rgb(255, 100, 103)),
+            true,
+            &[],
+        )?;
+        let warning = repair(
+            from_palette(Self::YELLOW, Color::Rgb(250, 204, 21)),
+            false,
+            &[destructive],
+        )?;
+        let accent = repair(
+            from_palette(Self::MAGENTA, Color::Rgb(139, 92, 246)),
+            false,
+            &[destructive, warning],
+        )?;
+        Some(Self {
+            accent,
+            destructive,
+            warning,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::color::{FIELD_FOCUS_LIGHTEN, FOCUS_DARKEN, darken, lighten, resolve_rgb};
-    use crate::{ButtonStyle, ButtonVariant, DialogStyle, ListStyle, TabsStyle, ToasterStyle};
+    use crate::{
+        ButtonStyle, ButtonVariant, DialogStyle, ListStyle, SelectStyle, TabsStyle, ToasterStyle,
+    };
 
-    /// Relative luminance, per WCAG 2.1.
+    /// The crate's own luminance, insisting on a color it can read. Every
+    /// theme measured here paints in colors the derivation solved against the
+    /// same function, so an unreadable one is a bug in the caller, not a case
+    /// to tolerate.
     fn luminance(color: Color) -> f64 {
-        let Color::Rgb(r, g, b) = color else {
-            panic!("expected an rgb color, got {color:?}");
-        };
-        let channel = |v: u8| {
-            let c = f64::from(v) / 255.0;
-            if c <= 0.039_28 {
-                c / 12.92
-            } else {
-                ((c + 0.055) / 1.055).powf(2.4)
-            }
-        };
-        0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+        crate::color::luminance(color).expect("a measured theme color has channels")
     }
 
     fn contrast(a: Color, b: Color) -> f64 {
-        let (a, b) = (luminance(a), luminance(b));
-        (a.max(b) + 0.05) / (a.min(b) + 0.05)
+        crate::color::contrast(a, b).expect("a measured theme pair has channels")
     }
 
     /// A border is a UI boundary, so WCAG 2.1 non-text contrast (1.4.11) asks
@@ -560,21 +1197,18 @@ mod tests {
     /// it is a weaker line — `default_dark`, the reference, is 2.89:1 there —
     /// and pinning that would mean retuning the theme the others are tuned
     /// against.
-    #[test]
-    fn preset_lines_meet_non_text_contrast_where_they_are_drawn() {
-        for theme in measurable_presets() {
-            for (role, line, backdrop) in [
-                ("border", theme.border, theme.background),
-                ("ring", theme.ring, theme.background),
-                ("ring on the surface it frames", theme.ring, theme.surface),
-            ] {
-                let ratio = contrast(line, backdrop);
-                assert!(
-                    ratio >= 3.0,
-                    "{} {role} contrast is {ratio:.2}:1, below the 3:1 floor",
-                    theme.name
-                );
-            }
+    fn check_lines(theme: &Theme) {
+        for (role, line, backdrop) in [
+            ("border", theme.border, theme.background),
+            ("ring", theme.ring, theme.background),
+            ("ring on the surface it frames", theme.ring, theme.surface),
+        ] {
+            let ratio = contrast(line, backdrop);
+            assert!(
+                ratio >= LINE_FLOOR,
+                "{} {role} contrast is {ratio:.2}:1, below the {LINE_FLOOR}:1 floor",
+                theme.name
+            );
         }
     }
 
@@ -587,22 +1221,384 @@ mod tests {
             .filter(|theme| theme.name != "Terminal")
     }
 
+    /// The floors are the numbers they name.
+    ///
+    /// Every check above measures against a constant, which keeps the
+    /// derivation and the tests from drifting apart — but it also means a
+    /// weakened constant weakens both sides at once and nothing notices. These
+    /// are the citations, written down where a mutation has to argue with them.
+    #[test]
+    fn the_floors_are_the_numbers_they_name() {
+        // WCAG 2.1 SC 1.4.3, normal text.
+        assert!((TEXT_FLOOR - 4.5).abs() < f64::EPSILON);
+        // WCAG 2.1 SC 1.4.11, user interface components and graphical objects.
+        assert!((LINE_FLOOR - 3.0).abs() < f64::EPSILON);
+        // The crate's own: the well window, its aim, the dialog split, the
+        // smallest visible change, and what a disabled row keeps.
+        assert!((WELL_MIN - 1.10).abs() < f64::EPSILON);
+        assert!((WELL_MAX - 1.35).abs() < f64::EPSILON);
+        assert!((WELL_TARGET - 1.20).abs() < f64::EPSILON);
+        assert!((SURFACE_MIN - 1.03).abs() < f64::EPSILON);
+        assert!((VISIBLE_STEP - 1.05).abs() < f64::EPSILON);
+        assert!((MUTED_STEP - 1.15).abs() < f64::EPSILON);
+        assert!((DISABLED_LEGIBILITY - 2.0).abs() < f64::EPSILON);
+    }
+
+    /// Every invariant a theme has to hold, whatever produced it.
+    ///
+    /// The checks are written against one theme rather than looped over the
+    /// presets so that a theme nobody authored can be held to the same bar. A
+    /// preset is a claim about taste that has to survive measurement; a derived
+    /// theme is only ever the measurement, so if these pass for every input the
+    /// derivation is correct in the only sense the crate defines.
+    fn check_every_invariant(theme: &Theme) {
+        check_lines(theme);
+        check_well_window(theme);
+        check_surface_ordering(theme);
+        check_well_ladder(theme);
+        check_severity_accents(theme);
+        check_fill_states_stay_on_the_page(theme);
+        check_control_fills(theme);
+        check_select_tracks_the_list(theme);
+        check_muted_recedes(theme);
+        check_accents_are_distinct(theme);
+        check_cursor_is_visible(theme);
+        check_disabled_wells(theme);
+        check_text(theme);
+    }
+
+    #[test]
+    fn every_preset_holds_every_invariant() {
+        for theme in measurable_presets() {
+            check_every_invariant(theme);
+        }
+    }
+
+    /// A terminal palette of the 16 named colors, which resolve through the VGA
+    /// table — the worst realistic input, since its red is `#ff0000` and its
+    /// yellow `#ffff00`.
+    fn vga_palette() -> [Color; 16] {
+        [
+            Color::Black,
+            Color::Red,
+            Color::Green,
+            Color::Yellow,
+            Color::Blue,
+            Color::Magenta,
+            Color::Cyan,
+            Color::Gray,
+            Color::DarkGray,
+            Color::LightRed,
+            Color::LightGreen,
+            Color::LightYellow,
+            Color::LightBlue,
+            Color::LightMagenta,
+            Color::LightCyan,
+            Color::White,
+        ]
+    }
+
+    /// A palette with one hue in all three slots the derivation reads.
+    ///
+    /// Terminals really do ship these — monochrome and near-monochrome themes
+    /// put the same tone in most of the sixteen — and without one the roles
+    /// repair to the same color and nothing says an error may not look exactly
+    /// like a warning.
+    fn monochrome_palette() -> [Color; 16] {
+        [Color::Rgb(200, 180, 40); 16]
+    }
+
+    /// A palette in the register terminals actually ship: muted, mid-luminance
+    /// hues, which are harder than the VGA ones because they start closer to
+    /// the floors they have to clear.
+    fn muted_palette() -> [Color; 16] {
+        let hue = |r, g, b| Color::Rgb(r, g, b);
+        [
+            hue(40, 42, 54),
+            hue(191, 97, 106),
+            hue(163, 190, 140),
+            hue(235, 203, 139),
+            hue(94, 129, 172),
+            hue(180, 142, 173),
+            hue(136, 192, 208),
+            hue(216, 222, 233),
+            hue(76, 86, 106),
+            hue(191, 97, 106),
+            hue(163, 190, 140),
+            hue(235, 203, 139),
+            hue(129, 161, 193),
+            hue(180, 142, 173),
+            hue(143, 188, 187),
+            hue(236, 239, 244),
+        ]
+    }
+
+    /// The (background, foreground) pairs the derivation is swept over.
+    ///
+    /// The named cases are the ones with a story: every preset's own pair, the
+    /// four corners of the polarity square, Solarized Light exactly as a
+    /// terminal reports it, and pairs no palette should be able to impose — a
+    /// foreground equal to its background, two grays a hair apart, and colors
+    /// with no channels at all. The lattice behind them is there to catch what
+    /// nobody thought to name.
+    fn derivation_grid() -> Vec<(Color, Color)> {
+        let mut cases: Vec<(Color, Color)> = Theme::presets()
+            .iter()
+            .map(|theme| (theme.background, theme.foreground))
+            .collect();
+        cases.extend([
+            (Color::Rgb(0, 0, 0), Color::Rgb(255, 255, 255)),
+            (Color::Rgb(255, 255, 255), Color::Rgb(0, 0, 0)),
+            (Color::Rgb(0, 0, 0), Color::Rgb(0, 0, 0)),
+            (Color::Rgb(255, 255, 255), Color::Rgb(255, 255, 255)),
+            // Solarized Light's real pair, 4.13:1 — the case that decided the
+            // low-contrast policy.
+            (Color::Rgb(253, 246, 227), Color::Rgb(101, 123, 131)),
+            // Solarized Dark's real pair, 4.75:1.
+            (Color::Rgb(0, 43, 54), Color::Rgb(131, 148, 150)),
+            (Color::Rgb(128, 128, 128), Color::Rgb(138, 138, 138)),
+            (Color::Rgb(48, 48, 48), Color::Rgb(48, 48, 48)),
+            (Color::Rgb(118, 118, 118), Color::Rgb(120, 120, 120)),
+            (Color::Reset, Color::Reset),
+            (Color::Indexed(4), Color::Indexed(7)),
+        ]);
+        // The pairs that were found violating an invariant before the solvers
+        // learned to answer for them, kept as named cases so a regression is
+        // reported by name rather than by lattice coordinate.
+        cases.extend([
+            (Color::Rgb(177, 179, 15), Color::Rgb(0, 0, 0)),
+            (Color::Rgb(55, 42, 65), Color::Rgb(255, 255, 255)),
+            (Color::Rgb(60, 58, 77), Color::Rgb(255, 255, 255)),
+            (Color::Rgb(0, 255, 64), Color::Rgb(0, 0, 0)),
+            (Color::Rgb(0, 64, 255), Color::Rgb(255, 191, 0)),
+            (Color::Rgb(0, 128, 255), Color::Rgb(255, 127, 0)),
+            (Color::Rgb(46, 52, 64), Color::Rgb(236, 239, 244)),
+        ]);
+        let steps = [0_u8, 64, 128, 192, 255];
+        for red in steps {
+            for green in steps {
+                for blue in steps {
+                    let background = Color::Rgb(red, green, blue);
+                    cases.push((background, Color::Rgb(255 - red, 255 - green, 255 - blue)));
+                    cases.push((background, Color::Rgb(128, 128, 128)));
+                }
+            }
+        }
+        // A seeded walk over the space between the lattice points. The seed is
+        // a literal so the suite runs the same pairs on every machine and every
+        // day: a sweep that changed what it covered between runs would turn a
+        // regression into a coin flip.
+        //
+        // The walk is short because its job is discovery, and what it has
+        // discovered is already above it under its own name. Every pair it
+        // ever failed on is a named case; the walk is what finds the next one,
+        // which costs the suite little when it is this long and would cost it
+        // most of its runtime if it were the sweep.
+        let mut seed = 0x2026_0819_u64;
+        let mut next = move || {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            u8::try_from(seed % 256).unwrap_or(0)
+        };
+        for _ in 0..200 {
+            cases.push((
+                Color::Rgb(next(), next(), next()),
+                Color::Rgb(next(), next(), next()),
+            ));
+        }
+        cases
+    }
+
+    /// The screen stays the caller's, whatever the solvers had to do to make it
+    /// workable.
+    ///
+    /// Passing the floors is not enough on its own: a derivation that gave up
+    /// and returned the crate's own background would pass every one of them
+    /// while throwing away the color the terminal actually reported. So the
+    /// derived background has to be the queried one, or the queried one
+    /// deepened toward its own end.
+    ///
+    /// The expected deepening is spelled out here with its own literal
+    /// comparison rather than by calling [`nearest_to`]. Sharing that function
+    /// with the derivation would make this test agree with whatever the
+    /// derivation believes: moving the light/dark threshold off 0.5 would move
+    /// both sides together and prove nothing.
+    fn check_background_is_the_one_asked_for(theme: &Theme, queried: Color) {
+        let Some(queried) = resolve_rgb(queried).map(|(r, g, b)| Color::Rgb(r, g, b)) else {
+            // A color with no channels is the one input replaced outright,
+            // because there is nothing to deepen.
+            assert_eq!(
+                theme.background,
+                Theme::default_dark().background,
+                "{}: an unreadable background derived something other than the crate's own",
+                theme.name
+            );
+            return;
+        };
+        let own_end = if luminance(queried) > 0.5 {
+            Color::Rgb(255, 255, 255)
+        } else {
+            Color::Rgb(0, 0, 0)
+        };
+        let deepened = (0..=100)
+            .map(|amount| dim(queried, own_end, amount))
+            .any(|candidate| candidate == theme.background);
+        assert!(
+            deepened,
+            "{}: derived {:?} from a queried {queried:?}, which is neither it nor a deepening \
+             of it toward {own_end:?}",
+            theme.name, theme.background
+        );
+        assert_eq!(
+            luminance(theme.background) > 0.5,
+            luminance(queried) > 0.5,
+            "{}: derived a {} background from a {} one",
+            theme.name,
+            if luminance(theme.background) > 0.5 {
+                "light"
+            } else {
+                "dark"
+            },
+            if luminance(queried) > 0.5 {
+                "light"
+            } else {
+                "dark"
+            },
+        );
+    }
+
+    /// A solved theme is made of channels, not names.
+    ///
+    /// Every floor above is measured through the VGA table, which is a
+    /// stand-in: `Color::White` measures as `#ffffff` and paints as whatever
+    /// the terminal's ANSI 15 is — `#fdf6e3` on a Solarized palette. A named
+    /// color anywhere in a derived theme means the ratio that was proven is not
+    /// the ratio on the screen, which is the one thing this whole derivation
+    /// exists to avoid.
+    fn check_theme_is_written_in_channels(theme: &Theme) {
+        for (role, color) in [
+            ("foreground", theme.foreground),
+            ("muted_foreground", theme.muted_foreground),
+            ("background", theme.background),
+            ("surface", theme.surface),
+            ("field", theme.field),
+            ("primary", theme.primary),
+            ("primary_foreground", theme.primary_foreground),
+            ("secondary", theme.secondary),
+            ("secondary_foreground", theme.secondary_foreground),
+            ("accent", theme.accent),
+            ("destructive", theme.destructive),
+            ("destructive_foreground", theme.destructive_foreground),
+            ("warning", theme.warning),
+            ("border", theme.border),
+            ("ring", theme.ring),
+            ("cursor", theme.cursor),
+        ] {
+            assert!(
+                matches!(color, Color::Rgb(_, _, _)),
+                "{}: {role} is {color:?}, a name the terminal owns rather than the channels \
+                 that were measured",
+                theme.name
+            );
+        }
+    }
+
+    /// A hued role stays the palette's hue, walked toward one end.
+    ///
+    /// Without this, which palette slot feeds which role is unpinned: reading
+    /// the red from the yellow's index produces a theme that passes every
+    /// contrast floor and calls a yellow "destructive". The ray is the same
+    /// shape the background check uses — the derivation is only allowed to walk
+    /// a reported color toward an extreme, never to substitute one.
+    fn check_hues_come_from_the_palette(theme: &Theme, palette: &[Color; 16], away: Color) {
+        for (role, derived, slot) in [
+            ("destructive", theme.destructive, 9),
+            ("warning", theme.warning, 11),
+            ("accent", theme.accent, 13),
+        ] {
+            let from_slot = (0..=100)
+                .map(|amount| dim(palette[slot], away, amount))
+                .any(|candidate| candidate == derived);
+            assert!(
+                from_slot,
+                "{}: {role} is {derived:?}, which is not palette slot {slot} ({:?}) walked \
+                 toward {away:?}",
+                theme.name, palette[slot]
+            );
+        }
+    }
+
+    /// The derivation is total: every pair, with or without a palette to take
+    /// hues from, has to produce a theme that passes what the presets pass.
+    ///
+    /// Each derived theme is renamed after the pair that produced it, which
+    /// does two things: a failure names the input, and the name stops matching
+    /// the exceptions `contrast_floor` grants three presets — a solved theme is
+    /// held to 4.5:1 everywhere, because unlike a palette it can always be
+    /// solved further.
+    #[test]
+    fn every_derived_theme_holds_every_invariant() {
+        let (vga, muted, monochrome) = (vga_palette(), muted_palette(), monochrome_palette());
+        for (background, foreground) in derivation_grid() {
+            for (label, palette) in [
+                ("no palette", None),
+                ("vga palette", Some(&vga)),
+                ("muted palette", Some(&muted)),
+                ("monochrome palette", Some(&monochrome)),
+            ] {
+                let mut theme = Theme::adaptive(background, foreground, palette);
+                theme.name = Box::leak(
+                    format!("adaptive({foreground:?} on {background:?}, {label})").into_boxed_str(),
+                );
+                check_every_invariant(&theme);
+                check_background_is_the_one_asked_for(&theme, background);
+                check_theme_is_written_in_channels(&theme);
+                if let Some(palette) = palette {
+                    check_hues_come_from_the_palette(&theme, palette, away_from(theme.background));
+                }
+            }
+        }
+    }
+
+    /// A pair that already works is honored verbatim.
+    ///
+    /// The low-contrast policy is a repair, and a repair that fires when
+    /// nothing is broken is a theme that ignores what the terminal reported.
+    /// The text guard is written to take the *least* push that clears the
+    /// floors, so on a workable pair the least push is none — these five pairs
+    /// are workable, and each has to come back out as it went in.
+    #[test]
+    fn a_workable_foreground_is_returned_unchanged() {
+        for (background, foreground) in [
+            (Color::Rgb(10, 10, 10), Color::Rgb(250, 250, 250)),
+            (Color::Rgb(0, 0, 0), Color::Rgb(255, 255, 255)),
+            (Color::Rgb(255, 255, 255), Color::Rgb(0, 0, 0)),
+            (Color::Rgb(0, 43, 54), Color::Rgb(238, 232, 213)),
+            (Color::Rgb(17, 17, 27), Color::Rgb(205, 214, 244)),
+        ] {
+            let derived = Theme::adaptive(background, foreground, None).foreground;
+            assert_eq!(
+                derived, foreground,
+                "adaptive({foreground:?} on {background:?}) moved a foreground that already \
+                 worked, to {derived:?}"
+            );
+        }
+    }
+
     /// A well at rest must read as a distinct region without competing with the
     /// screen behind it. `default_dark` — the reference the other presets are
     /// tuned against — sits at 1.20:1, and every rung above it spends contrast
     /// the text still needs, so the window is narrow on both sides: below 1.10
     /// the well disappears, above 1.35 it becomes a slab and the ladder on top
     /// of it runs out of room.
-    #[test]
-    fn preset_wells_sit_close_to_their_background() {
-        for theme in measurable_presets() {
-            let ratio = contrast(theme.field, theme.background);
-            assert!(
-                (1.10..=1.35).contains(&ratio),
-                "{} field is {ratio:.2}:1 on its background, outside the 1.10..=1.35 window",
-                theme.name
-            );
-        }
+    fn check_well_window(theme: &Theme) {
+        let ratio = contrast(theme.field, theme.background);
+        assert!(
+            (WELL_MIN..=WELL_MAX).contains(&ratio),
+            "{} field is {ratio:.2}:1 on its background, outside the {WELL_MIN}..={WELL_MAX} window",
+            theme.name
+        );
     }
 
     /// A raised surface is read against a backdrop the modal layer has already
@@ -612,36 +1608,33 @@ mod tests {
     /// declared inside a dialog is lifted out of the dialog exactly as it is
     /// lifted out of the screen, and a surface above the well would invert
     /// that and leave the list looking sunken into the dialog.
-    #[test]
-    fn preset_surfaces_sit_between_the_background_and_the_well() {
-        for theme in measurable_presets() {
-            // The two steps carry different floors because they are found
-            // differently. A dialog has a ring frame around it, pinned at 3:1
-            // above, so its fill only has to be a different color; a well has
-            // no frame at all, so its fill is the whole separation.
-            for (lower, upper, floor, pair) in [
-                (
-                    theme.background,
-                    theme.surface,
-                    1.03,
-                    "surface over background",
-                ),
-                (theme.surface, theme.field, 1.10, "well over surface"),
-            ] {
-                let ratio = contrast(lower, upper);
-                assert!(
-                    ratio >= floor,
-                    "{}: {pair} is {ratio:.3}:1, below the {floor}:1 floor",
-                    theme.name
-                );
-                let lifted = luminance(upper) > luminance(lower);
-                assert_eq!(
-                    lifted,
-                    luminance(theme.background) < 0.5,
-                    "{}: {pair} is lifted the wrong way",
-                    theme.name
-                );
-            }
+    fn check_surface_ordering(theme: &Theme) {
+        // The two steps carry different floors because they are found
+        // differently. A dialog has a ring frame around it, pinned at 3:1
+        // above, so its fill only has to be a different color; a well has
+        // no frame at all, so its fill is the whole separation.
+        for (lower, upper, floor, pair) in [
+            (
+                theme.background,
+                theme.surface,
+                SURFACE_MIN,
+                "surface over background",
+            ),
+            (theme.surface, theme.field, WELL_MIN, "well over surface"),
+        ] {
+            let ratio = contrast(lower, upper);
+            assert!(
+                ratio >= floor,
+                "{}: {pair} is {ratio:.3}:1, below the {floor}:1 floor",
+                theme.name
+            );
+            let lifted = luminance(upper) > luminance(lower);
+            assert_eq!(
+                lifted,
+                luminance(theme.background) < 0.5,
+                "{}: {pair} is lifted the wrong way",
+                theme.name
+            );
         }
     }
 
@@ -663,27 +1656,24 @@ mod tests {
     /// descends toward black. Steps below 1.05:1 are there in the numbers but
     /// not on the screen, which would leave focus or hover with no visible
     /// answer.
-    #[test]
-    fn preset_well_ladders_step_away_from_the_background_in_order() {
-        for theme in measurable_presets() {
-            let light_theme = luminance(theme.background) > 0.5;
-            let mut previous = ("background", theme.background);
-            for (rung, color) in well_ladder(theme) {
-                let climbs = luminance(color) > luminance(previous.1);
-                assert_eq!(
-                    climbs, !light_theme,
-                    "{}: {rung} {color:?} moves the wrong way from {} {:?}",
-                    theme.name, previous.0, previous.1
-                );
-                let step = contrast(color, previous.1);
-                assert!(
-                    step >= 1.05,
-                    "{}: {rung} is only {step:.3}:1 from {}, an invisible step",
-                    theme.name,
-                    previous.0
-                );
-                previous = (rung, color);
-            }
+    fn check_well_ladder(theme: &Theme) {
+        let light_theme = luminance(theme.background) > 0.5;
+        let mut previous = ("background", theme.background);
+        for (rung, color) in well_ladder(theme) {
+            let climbs = luminance(color) > luminance(previous.1);
+            assert_eq!(
+                climbs, !light_theme,
+                "{}: {rung} {color:?} moves the wrong way from {} {:?}",
+                theme.name, previous.0, previous.1
+            );
+            let step = contrast(color, previous.1);
+            assert!(
+                step >= VISIBLE_STEP,
+                "{}: {rung} is only {step:.3}:1 from {}, an invisible step",
+                theme.name,
+                previous.0
+            );
+            previous = (rung, color);
         }
     }
 
@@ -712,7 +1702,7 @@ mod tests {
         match theme.name {
             "Nord" | "Gruvbox" if pair.starts_with("destructive button") => 3.5,
             "Solarized" => 3.4,
-            _ => 4.5,
+            _ => TEXT_FLOOR,
         }
     }
 
@@ -887,50 +1877,197 @@ mod tests {
         accents
     }
 
-    #[test]
-    fn preset_toast_severity_accents_meet_non_text_contrast_on_the_toast() {
-        for theme in measurable_presets() {
-            for (severity, accent, background) in severity_accents(theme) {
-                let ratio = contrast(accent, background);
-                assert!(
-                    ratio >= 3.0,
-                    "{}: the {severity} accent is {ratio:.2}:1 on a toast, below the 3:1 floor",
-                    theme.name
-                );
-            }
+    /// A fill that is also a severity color has to stay on the page in every
+    /// state, not just at rest.
+    ///
+    /// Focus and hover walk a fill toward the screen's own end, and on a light
+    /// theme that is where the page already is: every real light terminal
+    /// palette measured — GitHub Light, Solarized Light, Gruvbox Light,
+    /// Catppuccin Latte, One Half Light, plain white — put a hovered delete
+    /// button between 2.63:1 and 2.69:1 on its own surface while its resting
+    /// state passed.
+    ///
+    /// Nord and Solarized are excused for the same reason they are excused
+    /// elsewhere: their one red is mid-luminance and already sits at 2.74:1 and
+    /// 3.12:1 at rest, so the states below it were never reachable.
+    fn check_fill_states_stay_on_the_page(theme: &Theme) {
+        if matches!(theme.name, "Nord" | "Solarized") {
+            return;
+        }
+        let button = ButtonStyle::from_theme(theme, ButtonVariant::Destructive);
+        let surface = ToasterStyle::from_theme(theme).background;
+        for (state, fill) in [
+            ("at rest", button.background),
+            ("focused", button.focused_background),
+            ("hovered", button.hovered_background),
+        ] {
+            let ratio = contrast(fill, surface);
+            assert!(
+                ratio >= LINE_FLOOR,
+                "{}: the destructive fill {state} is {ratio:.2}:1 on a toast, below the \
+                 {LINE_FLOOR}:1 floor",
+                theme.name
+            );
         }
     }
 
-    /// A control's three fills have to be three visibly different fills, or
-    /// focus and hover have no answer. This is the button counterpart of the
-    /// well ladder's step check, and it is what caps
-    /// [`FOCUS_DARKEN`](crate::color::FOCUS_DARKEN) and its siblings from
-    /// below while the label contrast caps them from above.
-    #[test]
-    fn preset_button_fills_step_visibly_between_states() {
-        for theme in measurable_presets() {
-            for variant in [
-                ButtonVariant::Default,
-                ButtonVariant::Secondary,
-                ButtonVariant::Destructive,
-            ] {
-                let button = ButtonStyle::from_theme(theme, variant);
-                for (step, from, to) in [
-                    ("focus", button.background, button.focused_background),
-                    (
-                        "hover",
-                        button.focused_background,
-                        button.hovered_background,
-                    ),
-                ] {
-                    let ratio = contrast(from, to);
-                    assert!(
-                        ratio >= 1.05,
-                        "{} {variant:?} button: the {step} step is {ratio:.3}:1, an invisible change",
-                        theme.name
-                    );
-                }
-            }
+    /// Muted text has to be muted. It is the crate's most-painted color — every
+    /// ordinary list row, every placeholder, every dialog description, every
+    /// toast body — and if it lands on body text those roles stop being roles:
+    /// a list's rows and its cursor row are then the same color, and the cursor
+    /// row's whole emphasis is the fill under it.
+    fn check_muted_recedes(theme: &Theme) {
+        let step = contrast(theme.foreground, theme.muted_foreground);
+        assert!(
+            step >= MUTED_STEP,
+            "{}: muted text is {step:.3}:1 from body text, below the {MUTED_STEP}:1 \
+             that makes it a second register",
+            theme.name
+        );
+        assert!(
+            contrast(theme.muted_foreground, theme.background)
+                < contrast(theme.foreground, theme.background),
+            "{}: muted text is further from the background than body text",
+            theme.name
+        );
+    }
+
+    /// The three hued roles have to be three colors. A palette whose red slot
+    /// holds a yellow repairs error and warning to the same tone otherwise, and
+    /// an error that looks like a warning is worse than either being off-hue.
+    fn check_accents_are_distinct(theme: &Theme) {
+        for (left, right, pair) in [
+            (theme.destructive, theme.warning, "destructive and warning"),
+            (theme.destructive, theme.accent, "destructive and accent"),
+            (theme.warning, theme.accent, "warning and accent"),
+        ] {
+            assert_ne!(left, right, "{}: {pair} are the same color", theme.name);
+        }
+    }
+
+    /// A caret has to be findable on the screen it blinks on. Nothing paints it
+    /// yet, which is exactly why it is measured: an unpainted role is the one
+    /// that rots.
+    fn check_cursor_is_visible(theme: &Theme) {
+        let ratio = contrast(theme.cursor, theme.background);
+        assert!(
+            ratio >= LINE_FLOOR,
+            "{}: the caret is {ratio:.2}:1 on the background, below the {LINE_FLOOR}:1 floor",
+            theme.name
+        );
+    }
+
+    /// A control's three fills, checked for size *and* direction.
+    ///
+    /// Size alone leaves the direction unpinned — swapping the focus and hover
+    /// amounts, or hardcoding one end of the ramp in a component, changes every
+    /// fill in the crate and moves no measured number. Direction is the sign of
+    /// two successive luminance steps agreeing: whichever way a theme's polarity
+    /// sends a fill, it has to keep going that way.
+    fn check_three_fills(theme: &Theme, role: &str, rest: Color, focused: Color, hovered: Color) {
+        for (step, from, to) in [("focus", rest, focused), ("hover", focused, hovered)] {
+            let ratio = contrast(from, to);
+            assert!(
+                ratio >= VISIBLE_STEP,
+                "{} {role}: the {step} step is {ratio:.3}:1, an invisible change",
+                theme.name
+            );
+        }
+        let (first, second) = (
+            luminance(focused) - luminance(rest),
+            luminance(hovered) - luminance(focused),
+        );
+        assert!(
+            first * second > 0.0,
+            "{} {role}: focus moves {first:+.4} and hover {second:+.4}, so the states turn back \
+             on themselves",
+            theme.name
+        );
+    }
+
+    fn check_control_fills(theme: &Theme) {
+        for (role, variant) in [
+            ("default button", ButtonVariant::Default),
+            ("secondary button", ButtonVariant::Secondary),
+            ("destructive button", ButtonVariant::Destructive),
+        ] {
+            let button = ButtonStyle::from_theme(theme, variant);
+            check_three_fills(
+                theme,
+                role,
+                button.background,
+                button.focused_background,
+                button.hovered_background,
+            );
+        }
+        let tabs = TabsStyle::from_theme(theme);
+        check_three_fills(
+            theme,
+            "selected tab",
+            tabs.selected_background,
+            tabs.selected_focused_background,
+            tabs.selected_hovered_background,
+        );
+        check_three_fills(
+            theme,
+            "tab",
+            tabs.background,
+            tabs.focused_background,
+            tabs.hovered_background,
+        );
+    }
+
+    /// A select is a list wearing a trigger: the two derive the same well from
+    /// the same theme, and a component that hardcoded a direction its sibling
+    /// asks for would show up here as a panel that no longer tracks the list it
+    /// mirrors.
+    fn check_select_tracks_the_list(theme: &Theme) {
+        let list = ListStyle::from_theme(theme);
+        let select = SelectStyle::from_theme(theme);
+        for (role, left, right) in [
+            ("well at rest", select.trigger_background, list.background),
+            (
+                "focused well",
+                select.focused_trigger_background,
+                list.focused_background,
+            ),
+            (
+                "hovered well",
+                select.hovered_trigger_background,
+                list.hovered_background,
+            ),
+            (
+                "cursor row",
+                select.focused_option_background,
+                list.focused_row_background,
+            ),
+            (
+                "disabled well",
+                select.disabled_background,
+                list.disabled_background,
+            ),
+            (
+                "disabled text",
+                select.disabled_foreground,
+                list.disabled_foreground,
+            ),
+        ] {
+            assert_eq!(
+                left, right,
+                "{}: a select's {role} is not the list's",
+                theme.name
+            );
+        }
+    }
+
+    fn check_severity_accents(theme: &Theme) {
+        for (severity, accent, background) in severity_accents(theme) {
+            let ratio = contrast(accent, background);
+            assert!(
+                ratio >= LINE_FLOOR,
+                "{}: the {severity} accent is {ratio:.2}:1 on a toast, below the {LINE_FLOOR}:1 floor",
+                theme.name
+            );
         }
     }
 
@@ -942,51 +2079,45 @@ mod tests {
     /// The pair they form is held to 2:1 rather than the text floor. Disabled
     /// text is exempt from WCAG 1.4.3 and is supposed to recede; what it may
     /// not do is disappear.
-    #[test]
-    fn preset_disabled_wells_read_as_disabled() {
-        for theme in measurable_presets() {
-            let style = ListStyle::from_theme(theme);
-            for (half, enabled, disabled) in [
-                ("fill", style.background, style.disabled_background),
-                ("text", style.foreground, style.disabled_foreground),
-            ] {
-                let ratio = contrast(enabled, disabled);
-                assert!(
-                    ratio >= 1.05,
-                    "{}: the disabled {half} is {ratio:.3}:1 from the enabled one, no change",
-                    theme.name
-                );
-                assert!(
-                    contrast(disabled, theme.background) < contrast(enabled, theme.background),
-                    "{}: the disabled {half} moved away from the background, not toward it",
-                    theme.name
-                );
-            }
-            let legibility = contrast(style.disabled_foreground, style.disabled_background);
+    fn check_disabled_wells(theme: &Theme) {
+        let style = ListStyle::from_theme(theme);
+        for (half, enabled, disabled) in [
+            ("fill", style.background, style.disabled_background),
+            ("text", style.foreground, style.disabled_foreground),
+        ] {
+            let ratio = contrast(enabled, disabled);
             assert!(
-                legibility >= 2.0,
-                "{}: disabled rows are {legibility:.2}:1, past receding into gone",
+                ratio >= VISIBLE_STEP,
+                "{}: the disabled {half} is {ratio:.3}:1 from the enabled one, no change",
+                theme.name
+            );
+            assert!(
+                contrast(disabled, theme.background) < contrast(enabled, theme.background),
+                "{}: the disabled {half} moved away from the background, not toward it",
                 theme.name
             );
         }
+        let legibility = contrast(style.disabled_foreground, style.disabled_background);
+        assert!(
+            legibility >= DISABLED_LEGIBILITY,
+            "{}: disabled rows are {legibility:.2}:1, past receding into gone",
+            theme.name
+        );
     }
 
     /// Text is the thing a palette is allowed to get wrong quietly: a fill that
     /// is one tone off still looks deliberate, while text one tone off is just
     /// hard to read. So every pair a component paints is measured, not only the
     /// ones on the background.
-    #[test]
-    fn preset_text_stays_readable_on_every_fill_it_is_painted_on() {
-        for theme in measurable_presets() {
-            for (pair, foreground, background) in text_pairs(theme) {
-                let floor = contrast_floor(theme, &pair);
-                let ratio = contrast(foreground, background);
-                assert!(
-                    ratio >= floor,
-                    "{}: {pair} is {ratio:.2}:1, below the {floor}:1 floor",
-                    theme.name
-                );
-            }
+    fn check_text(theme: &Theme) {
+        for (pair, foreground, background) in text_pairs(theme) {
+            let floor = contrast_floor(theme, &pair);
+            let ratio = contrast(foreground, background);
+            assert!(
+                ratio >= floor,
+                "{}: {pair} is {ratio:.2}:1, below the {floor}:1 floor",
+                theme.name
+            );
         }
     }
 
@@ -1002,7 +2133,10 @@ mod tests {
         assert_eq!(theme.background, Color::Reset);
         assert!(matches!(theme.surface, Color::Rgb(_, _, _)));
         assert!(matches!(theme.field, Color::Rgb(_, _, _)));
-        assert_ne!(lighten(theme.field, FIELD_FOCUS_LIGHTEN), theme.field);
+        assert_ne!(
+            dim(theme.field, away_from(theme.background), FIELD_FOCUS_SHIFT),
+            theme.field
+        );
         assert_ne!(
             style.disabled_background, style.background,
             "a disabled terminal well is the same fill as an enabled one"
@@ -1027,7 +2161,8 @@ mod tests {
     fn terminal_primary_is_neutral_and_distinct_from_muted_text() {
         let theme = Theme::terminal();
 
-        for color in [theme.primary, darken(theme.primary, FOCUS_DARKEN)] {
+        let pressed = nearest_to(theme.background);
+        for color in [theme.primary, dim(theme.primary, pressed, FOCUS_SHIFT)] {
             let (r, g, b) = resolve_rgb(color).expect("the terminal primary resolves to channels");
             assert!(
                 r == g && g == b,

--- a/docs/docs/components/list.md
+++ b/docs/docs/components/list.md
@@ -187,8 +187,10 @@ on the same frame the pointer arrives.
 
 Colors come from the theme. `.style(...)` overrides them, and the closure gets
 the active theme each render so a derived style follows theme switches. Focus
-lightens the field backdrop subtly; hover lightens it a little further, so the
-pointer remains visible when the list already has keyboard focus.
+separates the field backdrop subtly from the background; hover separates it a
+little further, so the pointer remains visible when the list already has
+keyboard focus. Which way that is comes from the theme: a dark theme's well
+lightens, a light theme's darkens.
 
 ```rust
 use ratcn::ListStyle;

--- a/docs/docs/components/select.md
+++ b/docs/docs/components/select.md
@@ -119,9 +119,9 @@ Select::new(items)
 
 ## Styling
 
-The trigger's default, focus, and hover backdrops match List. Hover is slightly
-lighter than focus, so it remains visible when the trigger already has keyboard
-focus. `SelectStyle` controls trigger, panel, cursor, selection, and disabled
+The trigger's default, focus, and hover backdrops match List. Hover sits one
+step further from the background than focus, so it remains visible when the
+trigger already has keyboard focus. `SelectStyle` controls trigger, panel, cursor, selection, and disabled
 colors. `SelectWidget` is the paint-only ratatui widget for using the same
 appearance without the runtime.
 


### PR DESCRIPTION
Phase A of the adaptive terminal theme (pure core — no I/O, no backend work; the OSC query and the ratatui-termina host move are Phase B).

`Theme::adaptive(background, foreground, palette16)` solves a complete theme around colors someone else chose — a terminal's reported bg/fg, or a browser's computed style. Polarity is read off the background: a light background derives a light theme whose wells sit darker than the screen and deepen under focus and hover, the mirror of the dark ladder. Every derived theme passes the same contrast floors the presets are held to; a property sweep (preset pairs, polarity corners, real low-contrast pairs like Solarized Light's 4.13:1, an RGB lattice, a seeded walk, each with and without palettes) checks it, and independent review swept 50,000 random inputs with zero failures.

The components stop hardcoding shift direction: `lighten`/`darken` per role becomes one rule keyed on the background's polarity (`color::away_from` / `nearest_to`), with the seven existing presets verified pixel-identical before and after. The `*_DARKEN`/`*_LIGHTEN` constant pairs collapse into direction-free `FOCUS_SHIFT`/`HOVER_SHIFT`/`FIELD_*_SHIFT`, and `luminance`/`contrast` are public so the derivation and its tests share one WCAG definition.

Low-contrast palettes are handled by pushing the queried foreground only as far as the floors demand (a workable foreground is returned unchanged — pinned by test), with reserved headroom so muted text keeps a genuine second register. Backgrounds too close to mid-luminance to host a UI are deepened toward their own end, keeping hue and polarity — also pinned.

Went through two adversarial review rounds plus a mutation-testing pass; the fix rounds closed five derivation defects (totality, light-theme fill fade, muted collapse, named-color leak, accent collisions) and pinned the floors, directions, palette-slot semantics, and the sRGB table against the formula it caches.