### PR TITLE
Adaptive theme: query the terminal and wear the answer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,8 @@ jobs:
       - uses: actions/checkout@v7
       # Must match `rust-version` in the workspace Cargo.toml. The `ratzilla`
       # feature needs 1.90 (its beamterm dependencies), so this covers the
-      # default and crossterm builds — the ones a published consumer gets.
+      # default, crossterm, and termina builds — the ones a published consumer
+      # gets on a terminal.
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.88.0
@@ -114,7 +115,7 @@ jobs:
       - name: Tests on the minimum toolchain
         run: |
           cargo --version
-          cargo test -p ratcn --features crossterm --locked
+          cargo test -p ratcn --features crossterm,termina --locked
 
   docs:
     name: Docs site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- A `termina` feature, converting [termina](https://docs.rs/termina) events into
+  `runtime::Event` the way `crossterm` does. Both features can be on at once;
+  neither is default, and `crossterm` is unchanged.
+- `terminal_query::query(&mut terminal)` (feature `termina`) asks the terminal
+  for its own background and foreground and hands back `TerminalColors` for
+  `Theme::adaptive`. Call it in raw mode before the event loop reads anything;
+  it returns `None` when the terminal cannot be asked or will not answer.
 - `Theme::adaptive(background, foreground, palette16)` derives a full theme
   from externally chosen colors (e.g. queried from the terminal). A light
   background yields a light theme, and every derived theme passes the same

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
 name = "ratatui-widgets"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1233,7 @@ dependencies = [
  "criterion",
  "ratatui",
  "ratzilla",
+ "termina",
  "unicode-segmentation",
  "unicode-width",
  "web-sys",
@@ -1476,6 +1488,7 @@ version = "0.0.1"
 dependencies = [
  "gloo-timers",
  "ratatui",
+ "ratatui-termina",
  "ratcn",
  "ratzilla",
 ]
@@ -1650,6 +1663,19 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ strip = "symbols"
 
 [workspace.dependencies]
 ratatui = { version = "0.30.2", default-features = false, features = ["layout-cache", "std"] }
+ratatui-termina = "0.1.0"
 ratzilla = "0.3.1"
 ratcn = { path = "crates/ratcn" }
 demo-shared = { package = "shared", path = "demos/shared" }

--- a/crates/ratcn/Cargo.toml
+++ b/crates/ratcn/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace = true
 [dependencies]
 ratatui.workspace = true
 ratzilla = { workspace = true, optional = true }
+termina = { version = "0.3.3", optional = true }
 unicode-segmentation = "1.13.3"
 unicode-width = "0.2.2"
 
@@ -35,6 +36,7 @@ harness = false
 default = []
 crossterm = ["ratatui/crossterm"]
 ratzilla = ["dep:ratzilla", "dep:web-sys"]
+termina = ["dep:termina"]
 
 [lints.rust]
 ambiguous_negative_literals = "warn"

--- a/crates/ratcn/src/lib.rs
+++ b/crates/ratcn/src/lib.rs
@@ -127,6 +127,8 @@ pub mod linear_nav;
 pub mod list_core;
 pub mod runtime;
 pub mod selection_indicator;
+#[cfg(feature = "termina")]
+pub mod terminal_query;
 pub mod text_width;
 pub mod theme;
 pub mod toast;

--- a/crates/ratcn/src/runtime/event.rs
+++ b/crates/ratcn/src/runtime/event.rs
@@ -1,8 +1,8 @@
 //! Normalized input events.
 //!
 //! The interaction runtime defines its own event vocabulary so components match
-//! one set of types across backends. Conversions from crossterm and ratzilla are
-//! feature-gated (`crossterm`, `ratzilla`).
+//! one set of types across backends. Conversions from crossterm, termina, and
+//! ratzilla are feature-gated (`crossterm`, `termina`, `ratzilla`).
 
 /// An input event, in the runtime's own vocabulary rather than a backend's.
 ///
@@ -773,6 +773,307 @@ mod crossterm_conv {
                 _ => Err(Unsupported),
             }
         }
+    }
+}
+
+#[cfg(feature = "termina")]
+mod termina_conv {
+    use super::{
+        Event, KeyCode, KeyEvent, Modifiers, MouseButton, MouseEvent, MouseKind, ScrollDirection,
+        Unsupported,
+    };
+    use termina::event as tn;
+
+    fn modifiers(held: tn::Modifiers) -> Modifiers {
+        Modifiers {
+            ctrl: held.contains(tn::Modifiers::CONTROL),
+            alt: held.contains(tn::Modifiers::ALT),
+            shift: held.contains(tn::Modifiers::SHIFT),
+        }
+    }
+
+    fn mouse_button(button: tn::MouseButton) -> MouseButton {
+        match button {
+            tn::MouseButton::Left => MouseButton::Left,
+            tn::MouseButton::Right => MouseButton::Right,
+            tn::MouseButton::Middle => MouseButton::Middle,
+        }
+    }
+
+    /// Termina reports zero-based cells, the same space a rendered
+    /// [`Rect`](ratatui::layout::Rect) is in, so the coordinates pass through.
+    impl From<tn::MouseEvent> for MouseEvent {
+        fn from(event: tn::MouseEvent) -> Self {
+            use tn::MouseEventKind as K;
+            let kind = match event.kind {
+                K::Down(b) => MouseKind::Down(mouse_button(b)),
+                K::Up(b) => MouseKind::Up(mouse_button(b)),
+                K::Drag(b) => MouseKind::Drag(mouse_button(b)),
+                K::Moved => MouseKind::Moved,
+                K::ScrollUp => MouseKind::Scroll(ScrollDirection::Up),
+                K::ScrollDown => MouseKind::Scroll(ScrollDirection::Down),
+                K::ScrollLeft => MouseKind::Scroll(ScrollDirection::Left),
+                K::ScrollRight => MouseKind::Scroll(ScrollDirection::Right),
+            };
+            Self {
+                kind,
+                column: event.column,
+                row: event.row,
+                modifiers: modifiers(event.modifiers),
+            }
+        }
+    }
+
+    impl TryFrom<tn::KeyEvent> for KeyEvent {
+        type Error = Unsupported;
+
+        fn try_from(event: tn::KeyEvent) -> Result<Self, Self::Error> {
+            // A repeat is a press the user is still making, so it routes; a
+            // release is the one kind this vocabulary has no place for.
+            if event.kind == tn::KeyEventKind::Release {
+                return Err(Unsupported);
+            }
+            let code = match event.code {
+                tn::KeyCode::Char(c) => KeyCode::Char(c),
+                tn::KeyCode::Function(n) => KeyCode::F(n),
+                tn::KeyCode::Backspace => KeyCode::Backspace,
+                tn::KeyCode::Enter => KeyCode::Enter,
+                tn::KeyCode::Left => KeyCode::Left,
+                tn::KeyCode::Right => KeyCode::Right,
+                tn::KeyCode::Up => KeyCode::Up,
+                tn::KeyCode::Down => KeyCode::Down,
+                tn::KeyCode::Tab => KeyCode::Tab,
+                tn::KeyCode::BackTab => KeyCode::BackTab,
+                tn::KeyCode::Delete => KeyCode::Delete,
+                tn::KeyCode::Home => KeyCode::Home,
+                tn::KeyCode::End => KeyCode::End,
+                tn::KeyCode::PageUp => KeyCode::PageUp,
+                tn::KeyCode::PageDown => KeyCode::PageDown,
+                tn::KeyCode::Escape => KeyCode::Esc,
+                _ => return Err(Unsupported),
+            };
+            Ok(Self {
+                code,
+                modifiers: modifiers(event.modifiers),
+            })
+        }
+    }
+
+    /// Termina keeps terminal *responses* — CSI, OSC, DCS — in the same enum as
+    /// input, so a query reply reaching the app's event loop is an ordinary
+    /// unsupported event rather than the fake keystrokes crossterm invents for
+    /// it.
+    impl TryFrom<termina::Event> for Event {
+        type Error = Unsupported;
+
+        fn try_from(event: termina::Event) -> Result<Self, Self::Error> {
+            match event {
+                termina::Event::Key(key) => KeyEvent::try_from(key).map(Event::Key),
+                termina::Event::Mouse(mouse) => Ok(Event::Mouse(mouse.into())),
+                termina::Event::Paste(s) => Ok(Event::Paste(s)),
+                _ => Err(Unsupported),
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "termina"))]
+mod termina_tests {
+    use super::{
+        Event, KeyCode, KeyEvent, Modifiers, MouseButton, MouseEvent, MouseKind, ScrollDirection,
+        Unsupported,
+    };
+    use termina::event as tn;
+
+    fn key(code: tn::KeyCode, modifiers: tn::Modifiers) -> tn::KeyEvent {
+        tn::KeyEvent::new(code, modifiers)
+    }
+
+    #[test]
+    fn termina_shift_backtab_keeps_normalized_code_and_modifiers() {
+        let event = KeyEvent::try_from(key(tn::KeyCode::BackTab, tn::Modifiers::SHIFT));
+
+        assert_eq!(
+            event,
+            Ok(KeyEvent {
+                code: KeyCode::BackTab,
+                modifiers: Modifiers {
+                    shift: true,
+                    ..Modifiers::NONE
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn terminas_own_names_for_escape_and_function_keys_map_across() {
+        assert_eq!(
+            KeyEvent::try_from(key(tn::KeyCode::Escape, tn::Modifiers::NONE)),
+            Ok(KeyEvent::new(KeyCode::Esc))
+        );
+        assert_eq!(
+            KeyEvent::try_from(key(tn::KeyCode::Function(7), tn::Modifiers::NONE)),
+            Ok(KeyEvent::new(KeyCode::F(7)))
+        );
+    }
+
+    #[test]
+    fn every_modifier_the_vocabulary_names_survives_at_once() {
+        let held = tn::Modifiers::CONTROL | tn::Modifiers::ALT | tn::Modifiers::SHIFT;
+
+        assert_eq!(
+            KeyEvent::try_from(key(tn::KeyCode::Char('K'), held)),
+            Ok(KeyEvent {
+                code: KeyCode::Char('K'),
+                modifiers: Modifiers {
+                    ctrl: true,
+                    alt: true,
+                    shift: true,
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn a_key_release_does_not_convert_but_a_repeat_does() {
+        let held = tn::KeyEvent {
+            code: tn::KeyCode::Char('j'),
+            kind: tn::KeyEventKind::Release,
+            modifiers: tn::Modifiers::NONE,
+            state: tn::KeyEventState::NONE,
+        };
+
+        assert_eq!(KeyEvent::try_from(held), Err(Unsupported));
+        assert_eq!(
+            KeyEvent::try_from(tn::KeyEvent {
+                kind: tn::KeyEventKind::Repeat,
+                ..held
+            }),
+            Ok(KeyEvent::new(KeyCode::Char('j')))
+        );
+    }
+
+    #[test]
+    fn keys_outside_the_vocabulary_stay_unsupported() {
+        for code in [
+            tn::KeyCode::Insert,
+            tn::KeyCode::CapsLock,
+            tn::KeyCode::Menu,
+            tn::KeyCode::Null,
+            tn::KeyCode::Modifier(tn::ModifierKeyCode::LeftShift),
+            tn::KeyCode::Media(tn::MediaKeyCode::Play),
+        ] {
+            assert_eq!(
+                KeyEvent::try_from(key(code, tn::Modifiers::NONE)),
+                Err(Unsupported),
+                "{code:?} has no place in the runtime vocabulary"
+            );
+        }
+    }
+
+    #[test]
+    fn termina_mouse_cells_and_kinds_pass_through_unshifted() {
+        // Every button, because a transposed pair reads correctly from any one
+        // of them: the middle button is its own opposite.
+        let buttons = [
+            (tn::MouseButton::Left, MouseButton::Left),
+            (tn::MouseButton::Right, MouseButton::Right),
+            (tn::MouseButton::Middle, MouseButton::Middle),
+        ];
+
+        for (reported, button) in buttons {
+            let event = MouseEvent::from(tn::MouseEvent {
+                kind: tn::MouseEventKind::Drag(reported),
+                column: 3,
+                row: 4,
+                modifiers: tn::Modifiers::CONTROL,
+            });
+
+            assert_eq!(
+                event,
+                MouseEvent {
+                    kind: MouseKind::Drag(button),
+                    column: 3,
+                    row: 4,
+                    modifiers: Modifiers {
+                        ctrl: true,
+                        ..Modifiers::NONE
+                    },
+                },
+                "termina's {reported:?} is the runtime's {button:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn presses_and_releases_keep_their_button_too() {
+        for (reported, button) in [
+            (tn::MouseButton::Left, MouseButton::Left),
+            (tn::MouseButton::Right, MouseButton::Right),
+            (tn::MouseButton::Middle, MouseButton::Middle),
+        ] {
+            let down = MouseEvent::from(tn::MouseEvent {
+                kind: tn::MouseEventKind::Down(reported),
+                column: 0,
+                row: 0,
+                modifiers: tn::Modifiers::NONE,
+            });
+            let up = MouseEvent::from(tn::MouseEvent {
+                kind: tn::MouseEventKind::Up(reported),
+                column: 0,
+                row: 0,
+                modifiers: tn::Modifiers::NONE,
+            });
+
+            assert_eq!(down.kind, MouseKind::Down(button), "{reported:?} press");
+            assert_eq!(up.kind, MouseKind::Up(button), "{reported:?} release");
+        }
+    }
+
+    #[test]
+    fn all_four_scroll_axes_map_to_their_directions() {
+        let axes = [
+            (tn::MouseEventKind::ScrollUp, ScrollDirection::Up),
+            (tn::MouseEventKind::ScrollDown, ScrollDirection::Down),
+            (tn::MouseEventKind::ScrollLeft, ScrollDirection::Left),
+            (tn::MouseEventKind::ScrollRight, ScrollDirection::Right),
+        ];
+
+        for (reported, direction) in axes {
+            let event = MouseEvent::from(tn::MouseEvent {
+                kind: reported,
+                column: 0,
+                row: 0,
+                modifiers: tn::Modifiers::NONE,
+            });
+            assert_eq!(
+                event.kind,
+                MouseKind::Scroll(direction),
+                "termina's {reported:?} is the runtime's {direction:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_bracketed_paste_arrives_whole() {
+        let event = Event::try_from(termina::Event::Paste("two\nlines".to_owned()));
+
+        assert_eq!(event, Ok(Event::Paste("two\nlines".to_owned())));
+    }
+
+    #[test]
+    fn escape_replies_and_focus_notices_are_not_app_events() {
+        use termina::escape::csi::{Csi, Device};
+
+        // The reply to a startup query, arriving after the query window has
+        // closed: an ignored event, not the burst of fake keystrokes crossterm
+        // turns the same bytes into.
+        let reply = Event::try_from(termina::Event::Csi(Csi::Device(Device::DeviceAttributes(
+            (),
+        ))));
+
+        assert_eq!(reply, Err(Unsupported));
+        assert_eq!(Event::try_from(termina::Event::FocusIn), Err(Unsupported));
     }
 }
 

--- a/crates/ratcn/src/terminal_query.rs
+++ b/crates/ratcn/src/terminal_query.rs
@@ -1,0 +1,780 @@
+//! Asking the terminal what colors it is actually painting with.
+//!
+//! [`Theme::adaptive`](crate::Theme::adaptive) solves a whole theme from a
+//! background and a foreground. This module is where those two colors come
+//! from on a real terminal: one batched query at startup, answered by the
+//! terminal itself, so an app adopts the user's colors instead of guessing at
+//! them.
+//!
+//! ```no_run
+//! use ratcn::{Theme, terminal_query};
+//! use termina::{PlatformTerminal, Terminal as _};
+//!
+//! # fn main() -> std::io::Result<()> {
+//! let mut terminal = PlatformTerminal::new()?;
+//! terminal.enter_raw_mode()?;
+//!
+//! // Before the app's event loop takes its first event: see below.
+//! let theme = match terminal_query::query(&mut terminal)? {
+//!     Some(colors) => Theme::adaptive(
+//!         colors.background,
+//!         colors.foreground,
+//!         colors.palette16.as_ref(),
+//!     ),
+//!     None => Theme::default_dark(),
+//! };
+//! # let _ = theme;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # There is exactly one window for this
+//!
+//! The query writes to the terminal and reads the terminal's answers back out
+//! of the input stream. It must run after raw mode is on — a cooked terminal
+//! buffers the reply until Enter — and before the app has read its first
+//! event, because until the exchange is fenced the app cannot tell a reply
+//! apart from typing. Termina's filtered reads keep any key presses that arrive
+//! meanwhile buffered for the event loop, so an impatient user loses nothing.
+//!
+//! The contract that buys is narrow and worth stating exactly: every reply is
+//! consumed here or left buffered as a *typed* event, so nothing the terminal
+//! says becomes input the app has to recognize and discard. What it is not is a
+//! promise about termina's parser — a read that splits a reply on a lone `ESC`
+//! can still decode the remainder as characters, the shape crossterm turns
+//! every reply into. Realistic terminal writes do not split there, and this
+//! module does not depend on them not doing so.
+//!
+//! # A query that is not answered has to end anyway
+//!
+//! Terminals answer in the order asked, so the exchange ends with a primary
+//! device-attributes request as a fence: when the DA1 reply arrives, whatever
+//! has not answered will not answer, and the query stops without waiting. A
+//! terminal that answers nothing at all — including the fence — stops the query
+//! at a one-second backstop, which is also what catches the terminals that
+//! answered the light/dark query *after* the fence.
+//!
+//! Terminals known to mishandle the exchange are never asked: see [`query`].
+
+use std::{
+    env, io,
+    io::IsTerminal as _,
+    time::{Duration, Instant},
+};
+
+use ratatui::style::Color;
+use termina::{
+    Event, Terminal,
+    escape::{
+        csi::{self, Csi},
+        osc::{ColorOrQuery, DynamicColorNumber, Osc},
+    },
+    style::RgbColor,
+};
+
+/// The batched query, in the order the terminal answers it.
+///
+/// The two color queries are BEL-terminated rather than ST-terminated: every
+/// terminal accepts BEL, and the ones that answer with the terminator they were
+/// sent then answer with BEL too. Replies are accepted with either terminator
+/// regardless, because three terminals mirror neither.
+///
+/// `CSI ? 996 n` is the one-shot light/dark query. The subscription form (DEC
+/// mode 2031, which pushes a notification when the user flips their theme) is
+/// deliberately not enabled here: a subscription outlives this window and
+/// belongs to whoever owns the event loop.
+///
+/// `CSI c` — primary device attributes — is last because it is the fence.
+const QUERIES: &str = "\x1b]10;?\x07\x1b]11;?\x07\x1b[?996n\x1b[c";
+
+/// How long the whole exchange may take, fence or no fence.
+const BACKSTOP: Duration = Duration::from_secs(1);
+
+/// What the terminal reported about its own colors.
+///
+/// Feed [`background`](Self::background), [`foreground`](Self::foreground), and
+/// [`palette16`](Self::palette16) to [`Theme::adaptive`](crate::Theme::adaptive)
+/// to get a theme built around them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct TerminalColors {
+    /// The terminal's default background, from OSC 11.
+    pub background: Color,
+    /// The terminal's default foreground, from OSC 10.
+    pub foreground: Color,
+    /// The terminal's own light/dark verdict, from `CSI ? 996 n`, when it
+    /// answered.
+    ///
+    /// Advisory only. Terminals disagree about whether it describes the palette
+    /// or the desktop theme, and
+    /// [`Theme::adaptive`](crate::Theme::adaptive) reads polarity off
+    /// [`background`](Self::background) anyway — so when the two disagree, the
+    /// background wins, because the background is what the theme is built from.
+    pub dark: Option<bool>,
+    /// The 16 ANSI palette colors, for the accents a theme would otherwise
+    /// invent.
+    ///
+    /// Always [`None`]: OSC 4 is what carries them, and termina 0.3.3's parser
+    /// drops OSC 4 replies rather than typing them. Reading them anyway would
+    /// mean a second reader competing with termina's for the same bytes, which
+    /// is the defect this backend was chosen to avoid.
+    pub palette16: Option<[Color; 16]>,
+}
+
+/// Ask `terminal` for its colors, and wait out the answer.
+///
+/// Returns [`None`] when there is nothing to derive a theme from — the terminal
+/// was not asked, it did not answer, or it answered only in part. Callers fall
+/// back to a preset.
+///
+/// The terminal must already be in raw mode, and nothing may have read an event
+/// from it yet. See the [module documentation](self) for why that window is the
+/// only one.
+///
+/// # Gates
+///
+/// The query is skipped entirely, without writing a byte, when:
+///
+/// - `TERM` is unset or empty, or is `dumb` — no escape sequences at all;
+/// - `TERM` names GNU screen or Eterm — screen answers the DA1 fence out of its
+///   own capabilities while dropping the color queries, so the fence would
+///   close on a reply that proves nothing;
+/// - stdout is not a terminal — the output is being captured or paged, and the
+///   query bytes would land in the capture while a pager races us for the
+///   reply.
+///
+/// # Errors
+///
+/// Returns an I/O error if the query cannot be written, or if reading the
+/// terminal fails. A terminal that simply says nothing is not an error: it is
+/// [`None`].
+pub fn query<T: Terminal>(terminal: &mut T) -> io::Result<Option<TerminalColors>> {
+    exchange(
+        terminal,
+        asked(env::var("TERM").ok().as_deref(), io::stdout().is_terminal()),
+    )
+}
+
+/// The exchange itself, with the gate's verdict handed to it rather than read
+/// here.
+///
+/// Whether this process's stdout is a terminal is not something a test can
+/// arrange — `cargo test` inherits the developer's tty and hands CI a pipe, so
+/// the same assertion would come out differently on the two. Passing the
+/// verdict in is what makes the refusal reachable as a value, and it is the
+/// only reason this is not one function.
+fn exchange<T: Terminal>(terminal: &mut T, asked: bool) -> io::Result<Option<TerminalColors>> {
+    if !asked {
+        return Ok(None);
+    }
+
+    terminal.write_all(QUERIES.as_bytes())?;
+    terminal.flush()?;
+
+    let started = Instant::now();
+    let mut replies = Replies::default();
+    while let Some(remaining) = BACKSTOP.checked_sub(started.elapsed()) {
+        // Filtering on escape sequences leaves key presses buffered for the
+        // event loop rather than eating them to get at the replies.
+        if !terminal.poll(Event::is_escape, Some(remaining))? {
+            break;
+        }
+        if replies.absorb(&terminal.read(Event::is_escape)?) == Fence::Closed {
+            break;
+        }
+    }
+
+    Ok(replies.resolve())
+}
+
+/// Whether this terminal is asked at all. See [`query`]'s gates.
+fn asked(term: Option<&str>, stdout_is_tty: bool) -> bool {
+    stdout_is_tty
+        && match term {
+            None | Some("" | "dumb") => false,
+            Some(term) => !term.starts_with("screen") && !term.starts_with("Eterm"),
+        }
+}
+
+/// Whether the device-attributes fence has closed the exchange.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Fence {
+    Open,
+    Closed,
+}
+
+/// The replies collected so far.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct Replies {
+    background: Option<Color>,
+    foreground: Option<Color>,
+    dark: Option<bool>,
+}
+
+impl Replies {
+    /// Take one event from the terminal, and report whether it was the fence.
+    ///
+    /// Anything else — a stray report, a mouse event, a key press that slipped
+    /// past the filter — is passed over: the exchange ends at the fence or at
+    /// the backstop, never at the first thing it did not recognize.
+    fn absorb(&mut self, event: &Event) -> Fence {
+        match event {
+            Event::Osc(Osc::ChangeDynamicColors(number, colors)) => {
+                if let Some(color) = reported(colors) {
+                    match number {
+                        DynamicColorNumber::TextForegroundColor => self.foreground = Some(color),
+                        DynamicColorNumber::TextBackgroundColor => self.background = Some(color),
+                        _ => {}
+                    }
+                }
+                Fence::Open
+            }
+            Event::Csi(Csi::Mode(csi::Mode::ReportTheme(mode))) => {
+                self.dark = Some(matches!(mode, csi::ThemeMode::Dark));
+                Fence::Open
+            }
+            // Only the private form, `CSI ? … c`, which is what every terminal
+            // actually replies with. A bare `CSI … c` reply would miss the
+            // fence and cost the backstop's second — a stall, not a wrong
+            // answer, since the replies collected so far still stand.
+            Event::Csi(Csi::Device(csi::Device::DeviceAttributes(()))) => Fence::Closed,
+            _ => Fence::Open,
+        }
+    }
+
+    /// Both colors or nothing.
+    ///
+    /// A theme is derived from the pair, so half of it derives nothing. A
+    /// light/dark verdict that arrived without them could still pick between
+    /// two presets by polarity — but that is a preset either way, which is what
+    /// the caller's fallback already is.
+    fn resolve(self) -> Option<TerminalColors> {
+        Some(TerminalColors {
+            background: self.background?,
+            foreground: self.foreground?,
+            dark: self.dark,
+            palette16: None,
+        })
+    }
+}
+
+/// The color out of a dynamic-color reply, if the reply carried one.
+///
+/// A `?` in a reply is the query form echoed back, which says nothing.
+fn reported(colors: &[ColorOrQuery]) -> Option<Color> {
+    colors.iter().find_map(|color| match color {
+        ColorOrQuery::Color(RgbColor { red, green, blue }) => Some(Color::Rgb(*red, *green, *blue)),
+        ColorOrQuery::Query => None,
+    })
+}
+
+/// The exchange, driven from scripted terminal bytes.
+///
+/// Termina's parser is the same one the event reader runs, so a fixture reply
+/// string reaches [`Replies::absorb`] exactly as the terminal's own bytes
+/// would — and none of it needs a terminal.
+#[cfg(test)]
+mod tests {
+    use super::{
+        ColorOrQuery, Csi, Duration, DynamicColorNumber, Event, Fence, Osc, QUERIES, Replies,
+        Terminal, TerminalColors, asked, csi, exchange, io,
+    };
+    use ratatui::style::Color;
+    use std::{cell::RefCell, collections::VecDeque};
+    use termina::Parser;
+
+    /// A terminal that records what was written to it and answers from a script.
+    ///
+    /// Only what [`exchange`] touches is real: the writes, the filtered polls
+    /// and reads, and the timeout each wait was given. `event_reader` is the one
+    /// method whose return type this crate cannot build, and the exchange never
+    /// calls it — it reads through the trait, which is what lets the whole
+    /// exchange be driven with no terminal anywhere.
+    struct FakeTerminal {
+        written: Vec<u8>,
+        /// Replies not yet handed over, oldest first.
+        pending: RefCell<VecDeque<Event>>,
+        /// The timeout each `poll` was given, in order.
+        polls: RefCell<Vec<Option<Duration>>>,
+    }
+
+    impl FakeTerminal {
+        /// A terminal that will answer with whatever `script` parses to.
+        fn answering(script: &str) -> Self {
+            let mut parser = Parser::default();
+            parser.parse(script.as_bytes(), false);
+            let mut pending = VecDeque::new();
+            while let Some(event) = parser.pop() {
+                pending.push_back(event);
+            }
+            Self {
+                written: Vec::new(),
+                pending: RefCell::new(pending),
+                polls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn still_pending(&self) -> Vec<Event> {
+            self.pending.borrow().iter().cloned().collect()
+        }
+    }
+
+    impl io::Write for FakeTerminal {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.written.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Terminal for FakeTerminal {
+        fn enter_raw_mode(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn enter_cooked_mode(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn get_dimensions(&self) -> io::Result<termina::WindowSize> {
+            Ok(termina::WindowSize {
+                cols: 80,
+                rows: 24,
+                pixel_width: None,
+                pixel_height: None,
+            })
+        }
+
+        fn event_reader(&self) -> termina::EventReader {
+            unimplemented!("the exchange reads through `poll` and `read`, never through a reader")
+        }
+
+        fn poll<F: Fn(&Event) -> bool>(
+            &self,
+            filter: F,
+            timeout: Option<Duration>,
+        ) -> io::Result<bool> {
+            self.polls.borrow_mut().push(timeout);
+            Ok(self.pending.borrow().iter().any(filter))
+        }
+
+        fn read<F: Fn(&Event) -> bool>(&self, filter: F) -> io::Result<Event> {
+            let mut pending = self.pending.borrow_mut();
+            match pending.iter().position(filter) {
+                Some(index) => Ok(pending
+                    .remove(index)
+                    .expect("the index came from this queue")),
+                // The real reader blocks here until something matches. Failing
+                // instead is what makes a read let through on the strength of
+                // the wrong filter show up as a failure rather than a hang.
+                None => Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "nothing pending matches the filter",
+                )),
+            }
+        }
+
+        fn set_panic_hook(
+            &mut self,
+            _hook: impl Fn(&mut termina::PlatformHandle) + Send + Sync + 'static,
+        ) {
+        }
+    }
+
+    fn typed(code: char) -> Event {
+        Event::Key(termina::event::KeyEvent::from(
+            termina::event::KeyCode::Char(code),
+        ))
+    }
+
+    #[test]
+    fn a_terminal_that_is_not_to_be_asked_is_never_written_to() {
+        let mut fake = FakeTerminal::answering(ANSWERED);
+
+        let colors = exchange(&mut fake, false).expect("refusing to ask cannot fail");
+
+        assert_eq!(colors, None);
+        assert!(
+            fake.written.is_empty(),
+            "not one byte goes out: {:?}",
+            String::from_utf8_lossy(&fake.written)
+        );
+        assert!(
+            fake.polls.borrow().is_empty(),
+            "and nothing is waited for either"
+        );
+    }
+
+    #[test]
+    fn the_exchange_writes_the_whole_batch_and_reads_the_answer_back() {
+        let mut fake = FakeTerminal::answering(ANSWERED);
+
+        let colors = exchange(&mut fake, true).expect("the terminal answers");
+
+        assert_eq!(String::from_utf8_lossy(&fake.written), QUERIES);
+        assert_eq!(
+            colors,
+            Some(TerminalColors {
+                background: Color::Rgb(26, 27, 38),
+                foreground: Color::Rgb(192, 202, 245),
+                dark: Some(true),
+                palette16: None,
+            })
+        );
+    }
+
+    #[test]
+    fn a_silent_terminal_is_waited_on_for_one_second_and_no_longer() {
+        let mut fake = FakeTerminal::answering("");
+
+        let colors = exchange(&mut fake, true).expect("silence is not an error");
+
+        assert_eq!(colors, None);
+        let polls = fake.polls.borrow();
+        assert_eq!(
+            polls.len(),
+            1,
+            "one bounded wait, and its empty answer ends the exchange: {polls:?}"
+        );
+        let waited = polls[0].expect("the wait is bounded, never indefinite");
+        // Pinned against the literal second rather than against `BACKSTOP`,
+        // which would leave the assertion agreeing with whatever value that
+        // constant happened to take.
+        assert!(
+            waited > Duration::from_millis(900) && waited <= Duration::from_secs(1),
+            "the first wait is the whole backstop, less the time the write took: {waited:?}"
+        );
+    }
+
+    #[test]
+    fn typing_during_the_exchange_is_left_for_the_event_loop() {
+        // A key press that got in ahead of every reply. Reading past it is the
+        // whole point of the filter: consumed here, the keystroke would be
+        // neither an answer nor an event the app ever sees.
+        let mut fake = FakeTerminal::answering(&format!("q{ANSWERED}"));
+
+        let colors = exchange(&mut fake, true).expect("the terminal answers");
+
+        assert!(colors.is_some(), "the replies were found behind the typing");
+        assert_eq!(
+            fake.still_pending(),
+            vec![typed('q')],
+            "the key press is still queued for the event loop to read"
+        );
+    }
+
+    #[test]
+    fn a_terminal_that_delivers_only_typing_is_never_read_from() {
+        // Nothing queued is an escape sequence, so the wait has to come back
+        // empty rather than wake on the typing and read something that is not
+        // a reply at all.
+        let mut fake = FakeTerminal::answering("qz");
+
+        let colors = exchange(&mut fake, true).expect("typing is not an error");
+
+        assert_eq!(colors, None);
+        assert_eq!(
+            fake.still_pending(),
+            vec![typed('q'), typed('z')],
+            "both key presses survive the exchange untouched"
+        );
+    }
+
+    /// Feed `script` through termina's parser and absorb the events it yields,
+    /// stopping at the fence the way [`exchange`] does.
+    fn absorbed(script: &str) -> (Replies, Fence) {
+        let mut parser = Parser::default();
+        parser.parse(script.as_bytes(), false);
+        let mut replies = Replies::default();
+        while let Some(event) = parser.pop() {
+            if replies.absorb(&event) == Fence::Closed {
+                return (replies, Fence::Closed);
+            }
+        }
+        (replies, Fence::Open)
+    }
+
+    /// The colors out of `script`, ignoring the fence.
+    fn colors(script: &str) -> Replies {
+        absorbed(script).0
+    }
+
+    /// A full, well-behaved exchange: both colors, a light/dark verdict, then
+    /// the fence.
+    ///
+    /// The fence goes out as `CSI c` and comes back as `CSI ? … c`: the reply
+    /// carries the private marker and the terminal's capability list, and the
+    /// list varies per terminal, so only the shape can be matched on.
+    const ANSWERED: &str = "\x1b]10;rgb:c0c0/caca/f5f5\x07\
+                            \x1b]11;rgb:1a1a/1b1b/2626\x07\
+                            \x1b[?997;1n\
+                            \x1b[?62;1;6c";
+
+    #[test]
+    fn the_batch_asks_for_both_colors_and_nothing_else() {
+        // Read back through the same parser the terminal's replies go through,
+        // so the OSC numbers and the `?` payload are checked as values rather
+        // than mirrored as literals. `?996n` and `CSI c` are requests termina
+        // has no reply type for, so they do not appear here — the assertions
+        // below cover them.
+        let mut parser = Parser::default();
+        parser.parse(QUERIES.as_bytes(), false);
+        let mut asked_for = Vec::new();
+        while let Some(event) = parser.pop() {
+            asked_for.push(event);
+        }
+
+        assert_eq!(
+            asked_for,
+            vec![
+                Event::Osc(Osc::ChangeDynamicColors(
+                    DynamicColorNumber::TextForegroundColor,
+                    vec![ColorOrQuery::Query]
+                )),
+                Event::Osc(Osc::ChangeDynamicColors(
+                    DynamicColorNumber::TextBackgroundColor,
+                    vec![ColorOrQuery::Query]
+                )),
+            ]
+        );
+    }
+
+    #[test]
+    fn the_light_dark_query_comes_second_to_last_and_the_fence_last() {
+        // The fence only fences what precedes it, so its position is the
+        // protocol: anything asked after it would be answered after the
+        // exchange has already been declared over.
+        let tail = format!(
+            "{}{}",
+            Csi::Mode(csi::Mode::QueryTheme),
+            Csi::Device(csi::Device::RequestPrimaryDeviceAttributes)
+        );
+
+        assert!(
+            QUERIES.ends_with(&tail),
+            "the batch must end `?996n` then DA1: {QUERIES:?}"
+        );
+    }
+
+    #[test]
+    fn the_color_queries_go_out_bell_terminated() {
+        // Every terminal accepts BEL, and the ones that mirror the terminator
+        // they were sent then answer with BEL too. Two queries, two bells.
+        assert_eq!(
+            QUERIES.matches('\x07').count(),
+            2,
+            "both color queries end in BEL rather than ST: {QUERIES:?}"
+        );
+    }
+
+    #[test]
+    fn a_terminal_whose_output_is_captured_is_never_asked() {
+        // The query bytes would land in the capture, and whatever is paging
+        // that capture would race us for the reply.
+        assert!(asked(Some("xterm-256color"), true));
+        assert!(!asked(Some("xterm-256color"), false));
+        assert!(!asked(Some("dumb"), false));
+    }
+
+    #[test]
+    fn a_terminal_that_answers_everything_yields_both_colors_and_the_verdict() {
+        let (replies, fence) = absorbed(ANSWERED);
+
+        assert_eq!(fence, Fence::Closed);
+        assert_eq!(
+            replies.resolve(),
+            Some(TerminalColors {
+                foreground: Color::Rgb(192, 202, 245),
+                background: Color::Rgb(26, 27, 38),
+                dark: Some(true),
+                palette16: None,
+            })
+        );
+    }
+
+    #[test]
+    fn rgb_channels_are_scaled_to_eight_bits_at_every_width() {
+        // `rgb:` channels are 1 to 4 hex digits each, scaled to the full range:
+        // `c0c0`, `c0`, and `c` all mean the same channel value.
+        for reply in [
+            "\x1b]11;rgb:c0c0/caca/f5f5\x07",
+            "\x1b]11;rgb:c0/ca/f5\x07",
+            "\x1b]11;rgb:c00/ca0/f50\x07",
+        ] {
+            assert!(
+                colors(reply).background.is_some(),
+                "a channel width the terminal may use: {reply:?}"
+            );
+        }
+        assert_eq!(
+            colors("\x1b]11;rgb:c0/ca/f5\x07").background,
+            Some(Color::Rgb(192, 202, 245))
+        );
+        assert_eq!(
+            colors("\x1b]11;rgb:f/0/8\x07").background,
+            Some(Color::Rgb(255, 0, 136)),
+            "one digit per channel spans the whole range, not the bottom of it"
+        );
+    }
+
+    #[test]
+    fn hash_replies_are_read_as_colors_too() {
+        // The other format `XParseColor` accepts. Six digits is the one width
+        // where scaling and left-alignment cannot disagree, and it is the width
+        // terminals actually reply in.
+        assert_eq!(
+            colors("\x1b]11;#1a1b26\x07").background,
+            Some(Color::Rgb(26, 27, 38))
+        );
+        assert_eq!(
+            colors("\x1b]11;#1a1a1b1b2626\x07").background,
+            Some(Color::Rgb(26, 27, 38))
+        );
+    }
+
+    #[test]
+    fn a_three_digit_hash_reply_is_scaled_rather_than_left_aligned() {
+        // The trap in the `#` format: `XParseColor` left-*aligns* its digits
+        // rather than scaling them, so `#3a7` is `#3000a0007000` — (48, 160,
+        // 112) — where the `rgb:` rule gives (51, 170, 119). Termina 0.3.3
+        // scales both formats, and it owns the parse: the reply reaches this
+        // crate already decoded, and recovering the raw payload would mean a
+        // second reader racing termina's for the same bytes.
+        //
+        // Only six digits is exact under both rules. Nine and twelve differ by
+        // at most one part in 255 (`#010000000000` is 0 scaled and 1 aligned);
+        // three, below, differs by up to fifteen.
+        assert_eq!(
+            colors("\x1b]11;#3a7\x07").background,
+            Some(Color::Rgb(51, 170, 119)),
+            "this pins termina 0.3.3's parse, not `XParseColor`'s rule — if it \
+             ever starts left-aligning, this failing is upstream changing its \
+             answer and not a fault to hunt for here"
+        );
+    }
+
+    #[test]
+    fn both_string_terminators_end_a_reply() {
+        let bel = colors("\x1b]11;rgb:1a1a/1b1b/2626\x07").background;
+        let st = colors("\x1b]11;rgb:1a1a/1b1b/2626\x1b\\").background;
+
+        assert_eq!(bel, Some(Color::Rgb(26, 27, 38)));
+        assert_eq!(st, bel, "the terminator is not part of the answer");
+    }
+
+    #[test]
+    fn foreground_and_background_land_in_their_own_slots() {
+        let replies = colors("\x1b]10;rgb:c0c0/caca/f5f5\x07\x1b]11;rgb:1a1a/1b1b/2626\x07");
+
+        assert_eq!(replies.foreground, Some(Color::Rgb(192, 202, 245)));
+        assert_eq!(replies.background, Some(Color::Rgb(26, 27, 38)));
+    }
+
+    #[test]
+    fn the_light_dark_query_is_read_both_ways_round() {
+        assert_eq!(colors("\x1b[?997;1n").dark, Some(true));
+        assert_eq!(colors("\x1b[?997;2n").dark, Some(false));
+    }
+
+    #[test]
+    fn the_fence_ends_the_exchange_and_nothing_after_it_is_read() {
+        // A terminal that answers the fence but not the colors has said all it
+        // is going to; a reply arriving afterwards is not ours to wait for.
+        let (replies, fence) = absorbed("\x1b[?6c\x1b]11;rgb:1a1a/1b1b/2626\x07\x1b[?997;1n");
+
+        assert_eq!(fence, Fence::Closed);
+        assert_eq!(replies, Replies::default());
+        assert_eq!(replies.resolve(), None);
+    }
+
+    #[test]
+    fn replies_the_fence_did_not_cover_are_kept() {
+        let (replies, fence) = absorbed("\x1b]11;rgb:1a1a/1b1b/2626\x07\x1b[?6c");
+
+        assert_eq!(fence, Fence::Closed);
+        assert_eq!(replies.background, Some(Color::Rgb(26, 27, 38)));
+    }
+
+    #[test]
+    fn unrecognized_traffic_between_replies_is_passed_over() {
+        // A key press the user got in early, a cursor-position report meant for
+        // someone else, and an OSC termina does not type at all — none of them
+        // may end the exchange or displace a reply.
+        let (replies, fence) = absorbed(
+            "\x1b]10;rgb:c0c0/caca/f5f5\x07\
+             q\
+             \x1b[10;5R\
+             \x1b]4;1;rgb:ffff/0000/0000\x07\
+             \x1b]11;rgb:1a1a/1b1b/2626\x07\
+             \x1b[?62;1;6c",
+        );
+
+        assert_eq!(fence, Fence::Closed);
+        assert!(replies.resolve().is_some());
+    }
+
+    #[test]
+    fn a_terminal_that_says_nothing_resolves_to_nothing() {
+        let (replies, fence) = absorbed("");
+
+        assert_eq!(fence, Fence::Open, "no fence, so the backstop is what ends");
+        assert_eq!(replies.resolve(), None);
+    }
+
+    #[test]
+    fn a_light_dark_verdict_with_no_colors_behind_it_is_not_a_theme() {
+        let replies = colors("\x1b[?997;2n");
+
+        assert_eq!(replies.dark, Some(false));
+        assert_eq!(replies.resolve(), None);
+    }
+
+    #[test]
+    fn one_color_without_the_other_is_not_a_theme() {
+        assert_eq!(colors("\x1b]11;rgb:1a1a/1b1b/2626\x07").resolve(), None);
+        assert_eq!(colors("\x1b]10;rgb:c0c0/caca/f5f5\x07").resolve(), None);
+    }
+
+    #[test]
+    fn a_query_echoed_back_instead_of_answered_carries_no_color() {
+        assert_eq!(colors("\x1b]11;?\x07").background, None);
+    }
+
+    #[test]
+    fn a_dynamic_color_this_query_never_asked_for_is_not_a_theme_color() {
+        // OSC 12 is the cursor color, and OSC 17 the selection highlight —
+        // both typed by termina, neither asked for here. Taking the first
+        // dynamic color that turns up would let an unrelated answer, or a
+        // reply to somebody else's earlier query, become the screen.
+        let stray = colors(
+            "\x1b]12;rgb:ffff/0000/0000\x07\
+             \x1b]17;rgb:0000/ffff/0000\x07",
+        );
+
+        assert_eq!(stray, Replies::default());
+        assert_eq!(stray.resolve(), None);
+    }
+
+    #[test]
+    fn only_the_terminals_that_can_answer_are_asked() {
+        for term in ["xterm-256color", "foot", "wezterm", "tmux-256color"] {
+            assert!(asked(Some(term), true), "{term} answers escape queries");
+        }
+        // Both refusals are prefixes, so both need a name that only a prefix
+        // match catches: `screen.xterm-256color` and `Eterm-color`.
+        for term in [
+            "dumb",
+            "",
+            "screen",
+            "screen.xterm-256color",
+            "Eterm",
+            "Eterm-color",
+        ] {
+            assert!(!asked(Some(term), true), "{term} must not be asked");
+        }
+        assert!(!asked(None, true), "an unset TERM promises nothing");
+    }
+}

--- a/demos/barchart-horizontal/Cargo.toml
+++ b/demos/barchart-horizontal/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/barchart/Cargo.toml
+++ b/demos/barchart/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/button-large/Cargo.toml
+++ b/demos/button-large/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/button-small/Cargo.toml
+++ b/demos/button-small/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/dialog/Cargo.toml
+++ b/demos/dialog/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/drag/Cargo.toml
+++ b/demos/drag/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/effects/Cargo.toml
+++ b/demos/effects/Cargo.toml
@@ -21,6 +21,5 @@ wasm-bindgen-futures.workspace = true
 web-sys.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true
 ureq.workspace = true

--- a/demos/kanban/Cargo.toml
+++ b/demos/kanban/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/landing/Cargo.toml
+++ b/demos/landing/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/landing/src/main.rs
+++ b/demos/landing/src/main.rs
@@ -70,7 +70,7 @@ enum AppMsg {
 }
 
 fn main() -> io::Result<()> {
-    demo_shared::run(App::new())
+    demo_shared::run_lazy(App::new)
 }
 
 impl App {

--- a/demos/landing/src/tiles/themes.rs
+++ b/demos/landing/src/tiles/themes.rs
@@ -1,5 +1,7 @@
 //! Theme picker tile and its focused/selected rows.
 
+use std::sync::OnceLock;
+
 use ratatui::{
     layout::{Constraint, Layout},
     style::{Modifier, Style},
@@ -12,7 +14,30 @@ use crate::{AppMsg, AppState};
 use super::shared::declare_tile_panel;
 
 pub const ID: &str = "themes";
-const THEMES: &[Theme] = Theme::presets();
+
+/// `resolved` first, then every preset it does not already stand for.
+///
+/// A name is the picker's identity — it is what a row is keyed and matched by —
+/// so a preset the resolved theme duplicates by name is dropped rather than
+/// listed twice. That happens exactly when the terminal could not be asked and
+/// the resolved theme *is* a preset; when it was asked, the solved theme is
+/// named `Adaptive`, nothing is dropped, and the list is one longer.
+fn ordered(resolved: Theme) -> Vec<Theme> {
+    std::iter::once(resolved)
+        .chain(
+            Theme::presets()
+                .iter()
+                .filter(|preset| preset.name != resolved.name)
+                .copied(),
+        )
+        .collect()
+}
+
+/// The picker's themes, settled once for the process.
+fn themes() -> &'static [Theme] {
+    static THEMES: OnceLock<Vec<Theme>> = OnceLock::new();
+    THEMES.get_or_init(|| ordered(*demo_shared::theme()))
+}
 
 pub struct State {
     focused: Option<&'static str>,
@@ -22,8 +47,8 @@ pub struct State {
 impl Default for State {
     fn default() -> Self {
         Self {
-            focused: Some(THEMES[0].name),
-            selected: THEMES[0].name,
+            focused: Some(themes()[0].name),
+            selected: themes()[0].name,
         }
     }
 }
@@ -46,7 +71,7 @@ impl State {
     }
 
     pub fn theme(&self) -> Theme {
-        THEMES
+        themes()
             .iter()
             .find(|theme| theme.name == self.selected)
             .copied()
@@ -57,8 +82,8 @@ impl State {
 pub fn declare(ctx: &mut DeclareCtx<'_, AppState, AppMsg>) {
     let area = ctx.area();
     let controls_disabled = ctx.state().controls_disabled;
-    let themes = List::new(
-        THEMES
+    let picker = List::new(
+        themes()
             .iter()
             .map(|theme| ListItem::new(theme.name, theme.name)),
     )
@@ -76,7 +101,7 @@ pub fn declare(ctx: &mut DeclareCtx<'_, AppState, AppMsg>) {
     let [header_area, intro_area, list_area] = Layout::vertical([
         Constraint::Length(1),
         Constraint::Length(3),
-        Constraint::Length(THEMES.len() as u16),
+        Constraint::Length(themes().len() as u16),
     ])
     .spacing(1)
     .areas(inner);
@@ -90,10 +115,88 @@ pub fn declare(ctx: &mut DeclareCtx<'_, AppState, AppMsg>) {
         header_area,
     );
     ctx.paint_widget(
-        Paragraph::new("Ratcn includes seven preset themes and supports custom themes.")
-            .style(Style::default().fg(theme.muted_foreground))
-            .wrap(Wrap { trim: true }),
+        Paragraph::new(
+            "Ratcn includes seven preset themes, supports custom themes, and solves \
+             one from your terminal's colors.",
+        )
+        .style(Style::default().fg(theme.muted_foreground))
+        .wrap(Wrap { trim: true }),
         intro_area,
     );
-    ctx.component("themes", themes, list_area);
+    ctx.component("themes", picker, list_area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{State, ordered, themes};
+    use ratatui::style::Color;
+    use ratcn::Theme;
+
+    fn names(themes: &[Theme]) -> Vec<&'static str> {
+        themes.iter().map(|theme| theme.name).collect()
+    }
+
+    fn presets() -> Vec<&'static str> {
+        names(Theme::presets())
+    }
+
+    /// A theme no preset can be: solved from a terminal's own colors, so it is
+    /// named `Adaptive` and shares its name with nothing in `presets()`. This
+    /// is the case the tests cannot reach through [`themes`], because without a
+    /// terminal to ask the resolved theme *is* a preset.
+    fn solved() -> Theme {
+        Theme::adaptive(Color::Rgb(253, 246, 227), Color::Rgb(101, 123, 131), None)
+    }
+
+    #[test]
+    fn a_solved_theme_leads_the_list_and_costs_no_preset() {
+        let listed = ordered(solved());
+
+        assert_eq!(
+            listed.first().map(|theme| theme.name),
+            Some("Adaptive"),
+            "the theme this terminal resolved to is the one the picker opens on"
+        );
+        assert_eq!(
+            names(&listed[1..]),
+            presets(),
+            "every preset still follows it, in the order `presets()` fixed"
+        );
+    }
+
+    #[test]
+    fn a_resolved_theme_that_is_already_a_preset_replaces_it_rather_than_joining_it() {
+        // The fallback case: the terminal could not be asked, so the resolved
+        // theme is one of the presets and must not appear twice.
+        let duplicated = Theme::presets()[2];
+        let listed = ordered(duplicated);
+        let listed = names(&listed);
+
+        assert_eq!(listed.first(), Some(&duplicated.name), "it still leads");
+        assert_eq!(
+            listed.len(),
+            Theme::presets().len(),
+            "it replaced its own entry rather than lengthening the list: {listed:?}"
+        );
+        let mut unique = listed.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(
+            listed.len(),
+            unique.len(),
+            "a name is what a row is keyed by, so it can only appear once: {listed:?}"
+        );
+        for preset in presets() {
+            assert!(listed.contains(&preset), "{preset} is still listed");
+        }
+    }
+
+    #[test]
+    fn the_picker_opens_on_the_theme_at_the_head_of_its_own_list() {
+        // A wiring pin only: with no terminal to ask, the resolved theme is
+        // itself a preset, so this cannot tell `ordered` apart from `presets()`
+        // by construction. What `ordered` actually does is pinned above.
+        assert_eq!(State::default().selected, themes()[0].name);
+        assert_eq!(themes(), ordered(*demo_shared::theme()));
+    }
 }

--- a/demos/ledger93/Cargo.toml
+++ b/demos/ledger93/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/list-multi/Cargo.toml
+++ b/demos/list-multi/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/list-multi/src/main.rs
+++ b/demos/list-multi/src/main.rs
@@ -14,7 +14,7 @@ use ratatui::{
     widgets::Paragraph,
 };
 use ratcn::{
-    List, ListItem, Theme,
+    List, ListItem,
     runtime::{Event, EventResult, FocusState, Ratcn, TabWrap},
 };
 
@@ -33,7 +33,6 @@ const TOPICS: [&str; 10] = [
 const LIST_WIDTH: u16 = 34;
 const LIST_HEIGHT: u16 = 8;
 const CONTENT_HEIGHT: u16 = LIST_HEIGHT + 2;
-const THEME: Theme = Theme::default_dark();
 
 mod ids {
     pub const LIST: &str = "topics";
@@ -93,7 +92,7 @@ impl App {
 
 impl demo_shared::Demo for App {
     fn background(&self) -> Color {
-        THEME.background
+        demo_shared::theme().background
     }
 
     fn handle_event(&mut self, event: Event) -> bool {
@@ -109,12 +108,13 @@ impl demo_shared::Demo for App {
 
     fn draw(&mut self, frame: &mut Frame) {
         let area = frame.area();
+        let theme = demo_shared::theme();
         frame
             .buffer_mut()
-            .set_style(area, Style::default().bg(THEME.background));
+            .set_style(area, Style::default().bg(theme.background));
 
         let state = &self.state;
-        self.ratcn.render(frame, state, &THEME, |ctx| {
+        self.ratcn.render(frame, state, theme, |ctx| {
             let muted = ctx.theme.muted_foreground;
             let list = List::new(TOPICS.map(|label| ListItem::new(label, label)))
                 .item_focus(|s: &AppState| s.focused_topic, Msg::TopicFocusChanged)

--- a/demos/list-people/Cargo.toml
+++ b/demos/list-people/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/list/Cargo.toml
+++ b/demos/list/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/list/src/main.rs
+++ b/demos/list/src/main.rs
@@ -15,7 +15,7 @@ use ratatui::{
     widgets::Paragraph,
 };
 use ratcn::{
-    List, ListItem, Theme,
+    List, ListItem,
     runtime::{Event, EventResult, FocusState, Ratcn, TabWrap},
 };
 
@@ -40,7 +40,6 @@ const FOLDERS: [&str; 16] = [
 const LIST_WIDTH: u16 = 30;
 const LIST_HEIGHT: u16 = 8;
 const CONTENT_HEIGHT: u16 = LIST_HEIGHT + 3;
-const THEME: Theme = Theme::default_dark();
 
 /// Child ids, named once so declarations and retained identity can't drift.
 mod ids {
@@ -99,7 +98,7 @@ impl App {
 
 impl demo_shared::Demo for App {
     fn background(&self) -> Color {
-        THEME.background
+        demo_shared::theme().background
     }
 
     fn handle_event(&mut self, event: Event) -> bool {
@@ -115,11 +114,12 @@ impl demo_shared::Demo for App {
 
     fn draw(&mut self, frame: &mut Frame) {
         let area = frame.area();
+        let theme = demo_shared::theme();
         frame
             .buffer_mut()
-            .set_style(area, Style::default().bg(THEME.background));
+            .set_style(area, Style::default().bg(theme.background));
         let state = &self.state;
-        self.ratcn.render(frame, state, &THEME, |ctx| {
+        self.ratcn.render(frame, state, theme, |ctx| {
             let muted = ctx.theme.muted_foreground;
             let list = List::new(FOLDERS.map(|label| ListItem::new(label, label)))
                 .item_focus(

--- a/demos/panels/Cargo.toml
+++ b/demos/panels/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/select/Cargo.toml
+++ b/demos/select/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/shared/Cargo.toml
+++ b/demos/shared/Cargo.toml
@@ -14,5 +14,5 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn = { workspace = true, features = ["termina"] }
+ratatui-termina.workspace = true

--- a/demos/shared/src/lib.rs
+++ b/demos/shared/src/lib.rs
@@ -11,12 +11,49 @@
 //! resize. Nothing else. An idle demo costs one blocked read natively, and
 //! nothing at all in the browser.
 
-use std::{io, time::Duration};
+use std::{io, sync::OnceLock, time::Duration};
 
-#[cfg(not(target_arch = "wasm32"))]
-use ratatui::crossterm::event::Event as CrosstermEvent;
 use ratatui::{Frame, Terminal, backend::Backend, style::Color};
-use ratcn::runtime::Event;
+#[cfg(not(target_arch = "wasm32"))]
+use ratatui_termina::{
+    TerminaBackend,
+    termina::{
+        Event as TerminalEvent, EventReader, PlatformTerminal, Terminal as _,
+        escape::csi::{Csi, DecPrivateMode, DecPrivateModeCode, Mode},
+    },
+};
+use ratcn::{Theme, runtime::Event};
+
+/// The theme every demo paints with.
+///
+/// Natively it is solved from the colors this terminal reported about itself,
+/// so the demos sit in the user's own palette rather than next to it. In the
+/// browser, and on a terminal that could not be asked, it is a preset.
+///
+/// It is resolved once, natively, before the demo is built. A demo built by
+/// `main` and handed to [`run`] has therefore already been built by then, so it
+/// must read this per frame rather than at construction; a demo that has to
+/// read it while being built is built by [`run_lazy`] instead, after the
+/// terminal has answered.
+#[must_use]
+pub fn theme() -> &'static Theme {
+    THEME.get_or_init(fallback_theme)
+}
+
+/// Resolved by the native [`run_lazy`]; never set in the browser.
+static THEME: OnceLock<Theme> = OnceLock::new();
+
+/// The theme to paint with when the terminal's own colors are unknown.
+///
+/// A preset that names every color, rather than [`Theme::terminal`]: the
+/// fallback runs exactly when the polarity of the screen is unknown, and the
+/// `terminal` preset pairs [`Color::Reset`] text with concrete dark wells —
+/// which on a light terminal is near-black text on a near-black fill. A theme
+/// that names its colors is at least legible on every terminal, whichever way
+/// round that terminal is.
+fn fallback_theme() -> Theme {
+    Theme::default_dark()
+}
 
 /// The shortest wait worth honoring: a wake sooner than the display refreshes
 /// cannot show anything new. [`Demo::wake`] values this small or smaller mean
@@ -75,29 +112,173 @@ pub trait Demo {
 
 /// Run `demo` until it quits (natively) or forever (in the browser).
 ///
+/// The demo already exists, so it was built before the terminal was asked about
+/// its colors. That is fine for a demo whose theme is a constant, and wrong for
+/// one that reads [`theme`] while being built — which panics here rather than
+/// silently painting the fallback. Those demos use [`run_lazy`].
+///
 /// # Errors
 ///
 /// Returns an I/O error if the terminal or the browser canvas cannot be set up,
 /// and natively if drawing or reading input fails.
-#[cfg(not(target_arch = "wasm32"))]
-pub fn run<D: Demo + 'static>(mut demo: D) -> io::Result<()> {
-    ratatui::run(|terminal| {
-        let modes = ratcn::crossterm::InputModes::new();
-        let modes = if D::INPUT {
-            modes.mouse_capture()
-        } else {
-            modes
-        };
-        let modes = if D::PASTE {
-            modes.bracketed_paste()
-        } else {
-            modes
-        };
-        // RAII: the modes are restored on every exit path, `?` and panic alike.
-        let _input_modes = modes.enable()?;
+pub fn run<D: Demo + 'static>(demo: D) -> io::Result<()> {
+    run_lazy(move || demo)
+}
 
-        drive(&mut demo, terminal, &mut TerminalEvents)
-    })
+/// Run the demo `build` returns, building it only once [`theme`] can answer.
+///
+/// The theme is resolved from the terminal inside this call, and a demo that
+/// reads it while being built has to be built after that — a picker seeding its
+/// selection from the theme list, a widget caching a color. `build` runs at the
+/// one moment where the terminal is open, the query has been answered, and no
+/// frame has been drawn.
+///
+/// # Errors
+///
+/// The same as [`run`].
+#[cfg(not(target_arch = "wasm32"))]
+pub fn run_lazy<D: Demo + 'static>(build: impl FnOnce() -> D) -> io::Result<()> {
+    let mut output = PlatformTerminal::new()?;
+    // Raw mode first: nothing below reads a reply that the line discipline
+    // would otherwise hold back until Enter.
+    output.enter_raw_mode()?;
+    // Termina restores raw mode after this hook runs, so the hook owes only the
+    // modes this host turns on below. It writes through a handle of its own,
+    // which is why it can run while the session is being unwound.
+    let modes = modes(D::INPUT, D::PASTE);
+    output.set_panic_hook({
+        let modes = modes.clone();
+        move |handle| {
+            let _ = restore_modes(handle, &modes);
+        }
+    });
+
+    // The one window the query has: raw mode is on and no event reader has
+    // taken a byte yet, so the terminal's answers are the only thing in the
+    // stream that is not the user typing. It happens before the alternate
+    // screen so a slow terminal is answered against the shell the user can
+    // still see, rather than behind a blank screen.
+    assert!(
+        THEME.set(queried_theme(&mut output)).is_ok(),
+        "the theme must be resolved before any demo code reads it: a demo that \
+         reads `theme()` while being built belongs in `run_lazy`, not `run`"
+    );
+
+    let events = output.event_reader();
+    // `Terminal::new` measures the grid and can fail. It runs while the modes
+    // are still off, so there is nothing to restore if it does — which is why
+    // the session takes them on afterwards and not before.
+    let session = Session {
+        terminal: Terminal::new(TerminaBackend::new(output))?,
+        modes,
+    };
+    let mut session = session.enable()?;
+
+    let mut demo = build();
+    drive(
+        &mut demo,
+        &mut session.terminal,
+        &mut TerminalEvents(events),
+    )
+}
+
+/// The native host's terminal, holding the modes it switched on.
+///
+/// Dropping it switches them back off. That is what covers every path out of
+/// [`run_lazy`] once the modes are on — a `?`, the quit key, or an unwinding
+/// panic — so the user never gets their shell back inside the alternate screen
+/// with the mouse still captured. Errors while restoring are dropped: `Drop`
+/// has nowhere to report them and the process is on its way out anyway.
+#[cfg(not(target_arch = "wasm32"))]
+struct Session {
+    terminal: Terminal<TerminaBackend<PlatformTerminal>>,
+    modes: Vec<DecPrivateModeCode>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Session {
+    /// Switch the modes on. A failure part-way through still restores, because
+    /// the guard already owns them: resetting a mode that never went on is
+    /// what the terminal does with any mode it does not know.
+    fn enable(mut self) -> io::Result<Self> {
+        set_modes(self.terminal.backend_mut(), &self.modes)?;
+        Ok(self)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for Session {
+    fn drop(&mut self) {
+        let _ = restore_modes(self.terminal.backend_mut(), &self.modes);
+    }
+}
+
+/// Solve a theme from the colors the terminal reports about itself.
+///
+/// A terminal that cannot be asked, will not answer, or answers only in part
+/// gets the [`fallback_theme`]. So does one whose reply could not be read: the
+/// same terminal is about to be drawn on, and if it is broken enough to fail
+/// here the frame will say so.
+#[cfg(not(target_arch = "wasm32"))]
+fn queried_theme(terminal: &mut PlatformTerminal) -> Theme {
+    match ratcn::terminal_query::query(terminal) {
+        Ok(Some(colors)) => Theme::adaptive(
+            colors.background,
+            colors.foreground,
+            colors.palette16.as_ref(),
+        ),
+        Ok(None) | Err(_) => fallback_theme(),
+    }
+}
+
+/// The terminal modes the host switches on, in the order it switches them on.
+///
+/// Termina deliberately manages none of these: they are protocol, and the
+/// application decides. Restoring walks the list back off in reverse.
+#[cfg(not(target_arch = "wasm32"))]
+fn modes(input: bool, paste: bool) -> Vec<DecPrivateModeCode> {
+    use DecPrivateModeCode as M;
+
+    let mut modes = vec![M::ClearAndEnableAlternateScreen];
+    if input {
+        // Presses, motion with a button held, motion without one, and SGR
+        // coordinates — without the last, a click past column 223 cannot be
+        // encoded at all.
+        modes.extend([
+            M::MouseTracking,
+            M::ButtonEventMouse,
+            M::AnyEventMouse,
+            M::SGRMouse,
+        ]);
+    }
+    if paste {
+        modes.push(M::BracketedPaste);
+    }
+    modes
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn set_modes(out: &mut impl io::Write, modes: &[DecPrivateModeCode]) -> io::Result<()> {
+    for &code in modes {
+        let mode = DecPrivateMode::Code(code);
+        write!(out, "{}", Csi::Mode(Mode::SetDecPrivateMode(mode)))?;
+    }
+    out.flush()
+}
+
+/// Switch the modes back off, newest first, and show the cursor.
+///
+/// A frame interrupted between hiding the cursor and showing it again leaves it
+/// hidden, and a hidden cursor is invisible in the shell the user comes back to.
+#[cfg(not(target_arch = "wasm32"))]
+fn restore_modes(out: &mut impl io::Write, modes: &[DecPrivateModeCode]) -> io::Result<()> {
+    for &code in modes.iter().rev() {
+        let mode = DecPrivateMode::Code(code);
+        write!(out, "{}", Csi::Mode(Mode::ResetDecPrivateMode(mode)))?;
+    }
+    let cursor = DecPrivateMode::Code(DecPrivateModeCode::ShowCursor);
+    write!(out, "{}", Csi::Mode(Mode::SetDecPrivateMode(cursor)))?;
+    out.flush()
 }
 
 /// Where the native host's waiting happens.
@@ -108,24 +289,25 @@ pub fn run<D: Demo + 'static>(mut demo: D) -> io::Result<()> {
 trait Events {
     /// Wait for the next event, for at most `timeout` — indefinitely when it is
     /// [`None`]. `Ok(None)` means the wait ran out with nothing to route.
-    fn next(&mut self, timeout: Option<Duration>) -> io::Result<Option<CrosstermEvent>>;
+    fn next(&mut self, timeout: Option<Duration>) -> io::Result<Option<TerminalEvent>>;
 }
 
 /// The terminal itself: poll when there is a deadline, block when there is not.
 #[cfg(not(target_arch = "wasm32"))]
-struct TerminalEvents;
+struct TerminalEvents(EventReader);
 
 #[cfg(not(target_arch = "wasm32"))]
 impl Events for TerminalEvents {
-    fn next(&mut self, timeout: Option<Duration>) -> io::Result<Option<CrosstermEvent>> {
-        use ratatui::crossterm::event;
-
+    fn next(&mut self, timeout: Option<Duration>) -> io::Result<Option<TerminalEvent>> {
+        // Everything is taken, escape replies included: a reply that outran the
+        // startup query's fence is one this host has no use for, and leaving it
+        // buffered would only hand it to the next read.
         if let Some(timeout) = timeout
-            && !event::poll(timeout)?
+            && !self.0.poll(Some(timeout), |_| true)?
         {
             return Ok(None);
         }
-        event::read().map(Some)
+        self.0.read(|_| true).map(Some)
     }
 }
 
@@ -166,7 +348,7 @@ where
         }
         // A resize is not an app event: the new size reaches the demo as the
         // next frame's area, so all the host owes it is that frame.
-        stale |= matches!(event, CrosstermEvent::Resize(..));
+        stale |= matches!(event, TerminalEvent::WindowResized(..));
         if let Ok(event) = Event::try_from(event) {
             stale |= demo.handle_event(event);
         }
@@ -193,29 +375,32 @@ where
     Ok(terminal.size()? != drawn)
 }
 
-/// Run `demo` in the browser. Returns once the host is wired up; the demo keeps
-/// running on browser events and animation frames.
+/// Run the demo `build` returns in the browser. Returns once the host is wired
+/// up; the demo keeps running on browser events and animation frames.
+///
+/// There is no terminal to ask here, so [`theme`] already answers and `build`
+/// runs immediately.
 ///
 /// # Errors
 ///
 /// Returns an I/O error if the canvas backend or one of the listeners cannot be
 /// installed.
 #[cfg(target_arch = "wasm32")]
-pub fn run<D: Demo + 'static>(demo: D) -> io::Result<()> {
-    web_host::start(demo)
+pub fn run_lazy<D: Demo + 'static>(build: impl FnOnce() -> D) -> io::Result<()> {
+    web_host::start(build())
 }
 
 /// Ctrl+C, the demos' quit key.
 #[cfg(not(target_arch = "wasm32"))]
-fn is_quit(event: &CrosstermEvent) -> bool {
-    use ratatui::crossterm::event::{KeyCode, KeyEventKind, KeyModifiers};
+fn is_quit(event: &TerminalEvent) -> bool {
+    use ratatui_termina::termina::event::{KeyCode, KeyEventKind, Modifiers};
 
     matches!(
         event,
-        CrosstermEvent::Key(key)
+        TerminalEvent::Key(key)
             if key.kind == KeyEventKind::Press
                 && key.code == KeyCode::Char('c')
-                && key.modifiers.contains(KeyModifiers::CONTROL)
+                && key.modifiers.contains(Modifiers::CONTROL)
     )
 }
 
@@ -538,13 +723,16 @@ mod tests {
     use ratatui::{
         backend::{ClearType, TestBackend, WindowSize},
         buffer::Cell,
-        crossterm::event::{KeyCode, KeyEvent as CrosstermKeyEvent, KeyModifiers},
         layout::{Position, Size},
+    };
+    use ratatui_termina::termina::{
+        WindowSize as TerminalSize,
+        event::{KeyCode, KeyEvent as TerminalKeyEvent, Modifiers},
     };
 
     use super::{
-        ANIMATION_FRAME, Backend, Color, CrosstermEvent, Demo, Duration, Event, Events, Frame,
-        Terminal, draw_frame, drive, io,
+        ANIMATION_FRAME, Backend, Color, Demo, Duration, Event, Events, Frame, Terminal,
+        TerminalEvent, draw_frame, drive, io,
     };
 
     /// A [`TestBackend`] that reports a native host's error type, and that can
@@ -666,13 +854,13 @@ mod tests {
     /// The waits the host performs, scripted: one entry answers one wait.
     struct Script {
         /// `Some(event)` hands an event over; `None` is a wait that ran out.
-        steps: VecDeque<Option<CrosstermEvent>>,
+        steps: VecDeque<Option<TerminalEvent>>,
         /// The timeout the host asked for, per wait, in order.
         waits: Vec<Option<Duration>>,
     }
 
     impl Script {
-        fn new(steps: impl IntoIterator<Item = Option<CrosstermEvent>>) -> Self {
+        fn new(steps: impl IntoIterator<Item = Option<TerminalEvent>>) -> Self {
             Self {
                 steps: steps.into_iter().collect(),
                 waits: Vec::new(),
@@ -681,25 +869,31 @@ mod tests {
     }
 
     impl Events for Script {
-        fn next(&mut self, timeout: Option<Duration>) -> io::Result<Option<CrosstermEvent>> {
+        fn next(&mut self, timeout: Option<Duration>) -> io::Result<Option<TerminalEvent>> {
             self.waits.push(timeout);
             // A spent script quits, so the loop returns instead of running on.
             Ok(self.steps.pop_front().unwrap_or_else(|| Some(quit())))
         }
     }
 
-    fn key(code: char) -> CrosstermEvent {
-        CrosstermEvent::Key(CrosstermKeyEvent::new(
-            KeyCode::Char(code),
-            KeyModifiers::NONE,
+    fn key(code: char) -> TerminalEvent {
+        TerminalEvent::Key(TerminalKeyEvent::new(KeyCode::Char(code), Modifiers::NONE))
+    }
+
+    fn quit() -> TerminalEvent {
+        TerminalEvent::Key(TerminalKeyEvent::new(
+            KeyCode::Char('c'),
+            Modifiers::CONTROL,
         ))
     }
 
-    fn quit() -> CrosstermEvent {
-        CrosstermEvent::Key(CrosstermKeyEvent::new(
-            KeyCode::Char('c'),
-            KeyModifiers::CONTROL,
-        ))
+    fn resize(cols: u16, rows: u16) -> TerminalEvent {
+        TerminalEvent::WindowResized(TerminalSize {
+            cols,
+            rows,
+            pixel_width: None,
+            pixel_height: None,
+        })
     }
 
     /// Run the host over `script` and hand back the terminal it drew on.
@@ -711,6 +905,29 @@ mod tests {
         let mut terminal = Terminal::new(backend).expect("the test backend opens");
         drive(probe, &mut terminal, script).expect("the scripted host reaches the quit key");
         terminal
+    }
+
+    #[test]
+    fn the_fallback_theme_leaves_no_color_to_the_terminal() {
+        // It is chosen exactly when the terminal's polarity is unknown, so a
+        // `Color::Reset` in it would be a color picked by a terminal the rest
+        // of the theme was not solved for: `Theme::terminal`'s Reset text on
+        // its concrete dark wells is near-black on near-black once the screen
+        // turns out to be light.
+        //
+        // Read through `theme()`, not `fallback_theme()`, so this also pins
+        // what an unasked terminal gets: no query has run in a test process.
+        let theme = super::theme();
+        assert_eq!(*theme, super::fallback_theme());
+
+        for (role, color) in [
+            ("foreground", theme.foreground),
+            ("background", theme.background),
+            ("surface", theme.surface),
+            ("field", theme.field),
+        ] {
+            assert_ne!(color, Color::Reset, "{role} is named, not inherited");
+        }
     }
 
     #[test]
@@ -771,7 +988,7 @@ mod tests {
     #[test]
     fn a_resize_draws_even_though_the_demo_never_sees_it() {
         let mut probe = Probe::default();
-        let mut script = Script::new([Some(CrosstermEvent::Resize(30, 10))]);
+        let mut script = Script::new([Some(resize(30, 10))]);
 
         run_scripted(&mut probe, HostBackend::new(20, 5), &mut script);
 

--- a/demos/tabs-automatic/Cargo.toml
+++ b/demos/tabs-automatic/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/tabs-basic/Cargo.toml
+++ b/demos/tabs-basic/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/tabs-disabled/Cargo.toml
+++ b/demos/tabs-disabled/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/tabs-large/Cargo.toml
+++ b/demos/tabs-large/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/toast/Cargo.toml
+++ b/demos/toast/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/tooltip/Cargo.toml
+++ b/demos/tooltip/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true

--- a/demos/wizard/Cargo.toml
+++ b/demos/wizard/Cargo.toml
@@ -14,5 +14,4 @@ ratcn = { workspace = true, features = ["ratzilla"] }
 ratzilla.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ratcn = { workspace = true, features = ["crossterm"] }
-ratatui = { workspace = true, features = ["crossterm"] }
+ratcn.workspace = true


### PR DESCRIPTION
Phase B of the adaptive terminal theme (Phase C — live re-theming via mode 2031 — remains).

The library gains a `termina` feature: an event-conversion module for the [ratatui-termina](https://crates.io/crates/ratatui-termina) backend (line-for-line equivalent to the crossterm one), plus `ratcn::terminal_query` — a startup query that asks the terminal for its real foreground, background, and light/dark mode (OSC 10/11 + `CSI ?996n`, DA1-fenced, 1s backstop, BEL-terminated with either terminator accepted). Its reply handling is a pure state machine tested against byte fixtures; the written bytes are pinned through termina's own parser and encoder; pre-flight gates skip terminals that can't answer (`TERM=dumb`/`screen*`/`Eterm*`, non-tty output). The `crossterm` and `ratzilla` features are untouched — downstream users are unaffected.

The demo host moves from `ratatui::run`+crossterm to ratatui-termina: raw mode → query → alt screen → modes, with an RAII session guard restoring every mode on all exit paths (`?`, quit, and panic alike — a fallible step now fails before any mode is on). On a successful query the demos get `Theme::adaptive(bg, fg, None)`; on gate/timeout they fall back to `default_dark` (the `terminal` preset's dark wells would be illegible on an unqueryable light screen — pinned by test). The list, multiselect, and landing demos consume it; landing's picker leads with the resolved theme.

Verified under live ptys across 26+ adversarial scenarios (reply permutations, split reads, echoing terminals, keys/mouse/paste typed during the query — all buffered, never lost; silent terminal exits the backstop at 1.001s), plus tmux and Solarized Light end-to-end deriving the mirrored light theme. Three adversarial review rounds; MSRV job strengthened to `--features crossterm,termina` (still 1.88).

Known limits, documented in code: OSC 4 (real ANSI palette) is deferred — termina 0.3.3 drops those replies, so the derivation runs on bg/fg alone; termina scales `#RGB` replies where XParseColor left-aligns (only the rare 3-digit form diverges visibly — pinned as an upstream tripwire).