### PR TITLE
Adaptive theme: follow the terminal when it changes its mind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   for its own background and foreground and hands back `TerminalColors` for
   `Theme::adaptive`. Call it in raw mode before the event loop reads anything;
   it returns `None` when the terminal cannot be asked or will not answer.
+- `terminal_query::ThemeWatch` (feature `termina`) follows a terminal that
+  reports its own theme changes: hand it every event, call `step` once a pass,
+  and it debounces, re-asks for the colors, and hands back the new ones. Switch
+  DEC mode 2031 on for any terminal `query` answered, and off before handing back.
 - `Theme::adaptive(background, foreground, palette16)` derives a full theme
   from externally chosen colors (e.g. queried from the terminal). A light
   background yields a light theme, and every derived theme passes the same

--- a/crates/ratcn/src/terminal_query.rs
+++ b/crates/ratcn/src/terminal_query.rs
@@ -51,8 +51,13 @@
 //! device-attributes request as a fence: when the DA1 reply arrives, whatever
 //! has not answered will not answer, and the query stops without waiting. A
 //! terminal that answers nothing at all — including the fence — stops the query
-//! at a one-second backstop, which is also what catches the terminals that
-//! answered the light/dark query *after* the fence.
+//! at a one-second backstop.
+//!
+//! The fence is what ends a normal exchange, so an answer that arrives *after*
+//! it is simply lost — that is what a fence is for, and the backstop does not
+//! rescue it. Ghostty answered the light/dark query out of order until January
+//! 2026 and would have lost its verdict here. Nothing depends on that verdict:
+//! it is advisory, and the colors are what a theme is built from.
 //!
 //! Terminals known to mishandle the exchange are never asked: see [`query`].
 
@@ -187,6 +192,222 @@ fn exchange<T: Terminal>(terminal: &mut T, asked: bool) -> io::Result<Option<Ter
     Ok(replies.resolve())
 }
 
+/// The re-query a notification triggers: the two colors, and no fence.
+///
+/// Nothing is left for a fence to decide. The terminal answered these once
+/// already — that is what got the subscription switched on — so what bounds
+/// this exchange is [`ThemeWatch`]'s own deadline, not a reply that says the
+/// rest will never come.
+const REQUERY: &str = "\x1b]10;?\x07\x1b]11;?\x07";
+
+/// How long notifications are collected before the colors are asked for.
+///
+/// Terminals send these in bursts — one per palette slot on some, one per
+/// transition step on others — and each one would otherwise cost a round trip
+/// and a repaint.
+const DEBOUNCE: Duration = Duration::from_millis(100);
+
+/// Follows a terminal that reports its own theme changes, and works out what
+/// the app should look like afterwards.
+///
+/// Switch on DEC mode 2031 once [`query`] has answered, then hand this every
+/// event the loop reads and call [`step`](Self::step) once per pass. It asks
+/// the terminal for its colors again when a change settles, and hands back the
+/// new ones when they arrive. Switch the mode off again before the terminal is
+/// handed back.
+///
+/// It never blocks and owns no thread: the host keeps waiting on its own event
+/// source, shortening the wait to [`wake`](Self::wake) when there is a deadline
+/// to meet.
+///
+/// # Which terminals to switch the mode on for
+///
+/// Any terminal that answered the startup query at all. There is no way to ask
+/// mode 2031 whether it is supported: DECRQM would be the direct test, and
+/// termina 0.3.3's parser types DECRPM replies for modes 2026 and 2027 only,
+/// dropping mode 2031's at every reported value — the answer can be written but
+/// never read.
+///
+/// The light/dark query is *not* the signal either, tempting as it looks. The
+/// specification defines `CSI ? 996 n` and mode 2031 as separate capabilities
+/// and mandates neither from the other, and the query is the more widely
+/// implemented of the two; a terminal whose verdict merely arrived after the
+/// startup fence would be written off despite supporting everything.
+///
+/// Switching the mode on where it is not supported costs nothing: `DECSET`
+/// solicits no reply, and a terminal that does not know a private mode ignores
+/// it. The notification that never comes is the same silence as not asking.
+///
+/// # Example
+///
+/// The shape of a host loop. Note that `wake` returning [`None`] means the
+/// watch owes nothing — which is a wait with no timeout, not a wait of zero —
+/// and that a poll which times out must not be followed by a read.
+///
+/// ```no_run
+/// use std::time::Instant;
+///
+/// use ratcn::{Theme, terminal_query::ThemeWatch};
+/// use termina::{PlatformTerminal, Terminal as _};
+///
+/// # fn main() -> std::io::Result<()> {
+/// let mut terminal = PlatformTerminal::new()?;
+/// terminal.enter_raw_mode()?;
+/// let reader = terminal.event_reader();
+/// let mut watch = ThemeWatch::new();
+///
+/// loop {
+///     // Wait for input, but never past the watch's next deadline.
+///     let ready = reader.poll(watch.wake(Instant::now()), |_| true)?;
+///     if ready {
+///         let event = reader.read(|_| true)?;
+///         watch.absorb(&event, Instant::now());
+///         // ... and route `event` to the app as usual.
+///     }
+///     if let Some(colors) = watch.step(&mut terminal, Instant::now())? {
+///         let _theme = Theme::adaptive(colors.background, colors.foreground, None);
+///     }
+///     # break;
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct ThemeWatch {
+    state: Watching,
+}
+
+/// Where the watch is in the notification-to-new-colors round trip.
+#[derive(Debug)]
+enum Watching {
+    /// Nothing has happened, and nothing is owed.
+    Idle,
+    /// A change was reported. Everything that arrives before `due` is the same
+    /// change still settling.
+    Collapsing { due: Instant },
+    /// The colors have been asked for again, and the answer is owed by
+    /// `deadline`.
+    Awaiting { deadline: Instant, replies: Replies },
+}
+
+impl Default for ThemeWatch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ThemeWatch {
+    /// A watch with nothing pending.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            state: Watching::Idle,
+        }
+    }
+
+    /// Note one event read from the terminal.
+    ///
+    /// Events that are neither a change notification nor a reply this watch is
+    /// waiting for are ignored, so a host can hand it everything it reads
+    /// without sorting first — and hand the same event on to the app, which is
+    /// what keeps a keystroke that arrived mid-exchange a keystroke.
+    pub fn absorb(&mut self, event: &Event, now: Instant) {
+        match event {
+            // The notification carries a light/dark value of its own, and it is
+            // deliberately not read: terminals disagree over whether it
+            // describes the palette or the desktop, so it says *that* something
+            // changed and never *what* it changed to. The colors come from the
+            // re-query.
+            //
+            // A `CSI ? 997 ; N n` that is not a notification at all — the
+            // startup query's own verdict, arriving after the fence gave up on
+            // it — is indistinguishable from one, and costs a re-query that
+            // reports the colors already showing. That is the accepted price:
+            // it corrects itself, and the alternative is a subscription that
+            // second-guesses the terminal.
+            Event::Csi(Csi::Mode(csi::Mode::ReportTheme(_))) => {
+                // A window already open is not pushed back. Extending it on
+                // every notification would let a terminal that keeps sending
+                // hold the re-query off indefinitely; collapsing into a fixed
+                // window instead guarantees the round trip happens, and a
+                // change that lands after it opens a window of its own.
+                if !matches!(self.state, Watching::Collapsing { .. }) {
+                    self.state = Watching::Collapsing {
+                        due: deadline(now, DEBOUNCE),
+                    };
+                }
+            }
+            // Anything collected before this notification described the theme
+            // the terminal has just left, so it is dropped with the state.
+            event => {
+                if let Watching::Awaiting { replies, .. } = &mut self.state {
+                    let _fence = replies.absorb(event);
+                }
+            }
+        }
+    }
+
+    /// How long the host may wait before calling [`step`](Self::step) again, or
+    /// [`None`] when nothing is pending and the wait is the app's to decide.
+    #[must_use]
+    pub fn wake(&self, now: Instant) -> Option<Duration> {
+        match self.state {
+            Watching::Idle => None,
+            Watching::Collapsing { due: at } | Watching::Awaiting { deadline: at, .. } => {
+                Some(at.saturating_duration_since(now))
+            }
+        }
+    }
+
+    /// Advance the watch, writing the re-query to `out` when one comes due.
+    ///
+    /// Returns the terminal's new colors on the pass that completes them. A
+    /// terminal that stops answering costs one bounded wait and is then dropped
+    /// quietly: the colors already on screen are the last ones it stood behind,
+    /// which is a better answer than none.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the re-query cannot be written.
+    pub fn step<W: io::Write>(
+        &mut self,
+        out: &mut W,
+        now: Instant,
+    ) -> io::Result<Option<TerminalColors>> {
+        match &mut self.state {
+            Watching::Idle => Ok(None),
+            Watching::Collapsing { due } => {
+                if now < *due {
+                    return Ok(None);
+                }
+                out.write_all(REQUERY.as_bytes())?;
+                out.flush()?;
+                self.state = Watching::Awaiting {
+                    deadline: deadline(now, BACKSTOP),
+                    replies: Replies::default(),
+                };
+                Ok(None)
+            }
+            Watching::Awaiting { deadline, replies } => {
+                if let Some(colors) = replies.resolve() {
+                    self.state = Watching::Idle;
+                    return Ok(Some(colors));
+                }
+                if now >= *deadline {
+                    self.state = Watching::Idle;
+                }
+                Ok(None)
+            }
+        }
+    }
+}
+
+/// `now + span`, saturating to `now` at the end of the clock rather than
+/// panicking — a deadline already reached is the safe direction.
+fn deadline(now: Instant, span: Duration) -> Instant {
+    now.checked_add(span).unwrap_or(now)
+}
+
 /// Whether this terminal is asked at all. See [`query`]'s gates.
 fn asked(term: Option<&str>, stdout_is_tty: bool) -> bool {
     stdout_is_tty
@@ -276,11 +497,11 @@ fn reported(colors: &[ColorOrQuery]) -> Option<Color> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ColorOrQuery, Csi, Duration, DynamicColorNumber, Event, Fence, Osc, QUERIES, Replies,
-        Terminal, TerminalColors, asked, csi, exchange, io,
+        ColorOrQuery, Csi, Duration, DynamicColorNumber, Event, Fence, Osc, QUERIES, REQUERY,
+        Replies, Terminal, TerminalColors, ThemeWatch, asked, csi, exchange, io,
     };
     use ratatui::style::Color;
-    use std::{cell::RefCell, collections::VecDeque};
+    use std::{cell::RefCell, collections::VecDeque, time::Instant};
     use termina::Parser;
 
     /// A terminal that records what was written to it and answers from a script.
@@ -388,6 +609,310 @@ mod tests {
         Event::Key(termina::event::KeyEvent::from(
             termina::event::KeyCode::Char(code),
         ))
+    }
+
+    /// Everything the watch is told, at a time the test names. No clock is read
+    /// anywhere in here: `t0` is a fixed origin and every deadline is an offset
+    /// from it, so the state machine is exercised at exact instants.
+    struct Watched {
+        watch: ThemeWatch,
+        written: Vec<u8>,
+        t0: Instant,
+    }
+
+    impl Watched {
+        fn new() -> Self {
+            Self {
+                watch: ThemeWatch::new(),
+                written: Vec::new(),
+                t0: Instant::now(),
+            }
+        }
+
+        fn at(&self, millis: u64) -> Instant {
+            self.t0 + Duration::from_millis(millis)
+        }
+
+        /// Feed everything `script` parses to, as arriving at `millis`.
+        fn feed(&mut self, millis: u64, script: &str) {
+            let mut parser = Parser::default();
+            parser.parse(script.as_bytes(), false);
+            while let Some(event) = parser.pop() {
+                self.watch.absorb(&event, self.at(millis));
+            }
+        }
+
+        fn step(&mut self, millis: u64) -> Option<TerminalColors> {
+            let at = self.at(millis);
+            self.watch
+                .step(&mut self.written, at)
+                .expect("writing to a vector cannot fail")
+        }
+
+        fn wake(&self, millis: u64) -> Option<Duration> {
+            self.watch.wake(self.at(millis))
+        }
+
+        /// How many re-queries have gone out.
+        fn requeries(&self) -> usize {
+            String::from_utf8_lossy(&self.written)
+                .matches(REQUERY)
+                .count()
+        }
+    }
+
+    /// The reply to a re-query: the two colors, no verdict and no fence.
+    const RETHEMED: &str = "\x1b]10;rgb:6565/7b7b/8383\x07\x1b]11;rgb:fdfd/f6f6/e3e3\x07";
+
+    /// A change notification. The value it carries is never read.
+    const NOTIFIED: &str = "\x1b[?997;2n";
+
+    #[test]
+    fn a_lost_light_dark_verdict_costs_nothing_but_the_verdict() {
+        // The verdict and the subscription are separate capabilities, and the
+        // verdict is the more widely implemented of the two — so a terminal
+        // whose verdict was lost to the fence still answers the colors, and is
+        // still worth subscribing to. Nothing here reads `dark` to decide.
+        let both = absorbed(ANSWERED).0.resolve().expect("both colors");
+        let lost_verdict = absorbed("\x1b]10;rgb:c0c0/caca/f5f5\x07\x1b]11;rgb:1a1a/1b1b/2626\x07")
+            .0
+            .resolve()
+            .expect("both colors");
+
+        assert_eq!(both.dark, Some(true));
+        assert_eq!(lost_verdict.dark, None);
+        assert_eq!(
+            (both.background, both.foreground),
+            (lost_verdict.background, lost_verdict.foreground),
+            "the colors a theme is built from are the same either way"
+        );
+    }
+
+    #[test]
+    fn a_watch_with_nothing_pending_asks_for_no_wait_and_writes_nothing() {
+        let mut watched = Watched::new();
+
+        assert_eq!(watched.wake(0), None, "the wait is the app's to decide");
+        assert_eq!(watched.step(0), None);
+        assert!(watched.written.is_empty());
+    }
+
+    #[test]
+    fn a_notification_is_re_queried_once_the_window_closes() {
+        let mut watched = Watched::new();
+
+        watched.feed(0, NOTIFIED);
+        assert_eq!(
+            watched.wake(0),
+            Some(Duration::from_millis(100)),
+            "the host is asked to come back when the window closes"
+        );
+        assert_eq!(watched.step(50), None, "still settling");
+        assert_eq!(watched.requeries(), 0, "and nothing has gone out");
+
+        assert_eq!(watched.step(100), None, "the re-query goes out, unanswered");
+        assert_eq!(watched.requeries(), 1);
+        assert_eq!(
+            String::from_utf8_lossy(&watched.written),
+            REQUERY,
+            "what goes out is the re-query and nothing else"
+        );
+    }
+
+    #[test]
+    fn the_re_query_asks_for_the_two_colors_and_fences_nothing() {
+        // Read back through the parser the replies come through, so the OSC
+        // numbers and the `?` payload are checked as values. Pinned
+        // independently of `REQUERY` itself: an assertion written against the
+        // constant would agree with whatever the constant said.
+        let mut parser = Parser::default();
+        parser.parse(REQUERY.as_bytes(), false);
+        let mut asked_for = Vec::new();
+        while let Some(event) = parser.pop() {
+            asked_for.push(event);
+        }
+
+        assert_eq!(
+            asked_for,
+            vec![
+                Event::Osc(Osc::ChangeDynamicColors(
+                    DynamicColorNumber::TextForegroundColor,
+                    vec![ColorOrQuery::Query]
+                )),
+                Event::Osc(Osc::ChangeDynamicColors(
+                    DynamicColorNumber::TextBackgroundColor,
+                    vec![ColorOrQuery::Query]
+                )),
+            ]
+        );
+        assert_eq!(
+            REQUERY.matches('\x07').count(),
+            2,
+            "both go out BEL-terminated, as at startup: {REQUERY:?}"
+        );
+
+        let fence = Csi::Device(csi::Device::RequestPrimaryDeviceAttributes).to_string();
+        assert!(
+            !REQUERY.contains(&fence),
+            "nothing is left for a fence to decide — the terminal answered these \
+             once already — and its reply would only arrive as an event no one \
+             is waiting for: {REQUERY:?}"
+        );
+    }
+
+    #[test]
+    fn a_burst_of_notifications_costs_exactly_one_re_query() {
+        // Terminals send one per palette slot, or one per transition step.
+        let mut watched = Watched::new();
+
+        for arrival in [0, 5, 12, 30, 99] {
+            watched.feed(arrival, NOTIFIED);
+        }
+        watched.step(100);
+
+        assert_eq!(watched.requeries(), 1, "the window collapsed all five");
+    }
+
+    #[test]
+    fn a_window_already_open_is_not_pushed_back_by_more_notifications() {
+        // Extending on every notification would let a terminal that keeps
+        // sending hold the re-query off for as long as it liked.
+        let mut watched = Watched::new();
+
+        watched.feed(0, NOTIFIED);
+        for arrival in [40, 80, 95] {
+            watched.feed(arrival, NOTIFIED);
+        }
+        watched.step(100);
+
+        assert_eq!(
+            watched.requeries(),
+            1,
+            "the window still closed a hundred milliseconds after it opened"
+        );
+    }
+
+    #[test]
+    fn the_replies_to_a_re_query_become_the_terminals_new_colors() {
+        let mut watched = Watched::new();
+
+        watched.feed(0, NOTIFIED);
+        assert_eq!(watched.step(100), None, "the re-query is out");
+        watched.feed(120, RETHEMED);
+
+        assert_eq!(
+            watched.step(120),
+            Some(TerminalColors {
+                background: Color::Rgb(253, 246, 227),
+                foreground: Color::Rgb(101, 123, 131),
+                dark: None,
+                palette16: None,
+            }),
+            "a re-query asks for colors alone, so it brings back no verdict"
+        );
+        assert_eq!(watched.wake(120), None, "and the watch is idle again");
+    }
+
+    #[test]
+    fn half_an_answer_is_not_a_theme_and_the_watch_gives_up_on_its_own() {
+        let mut watched = Watched::new();
+
+        watched.feed(0, NOTIFIED);
+        watched.step(100);
+        watched.feed(150, "\x1b]11;rgb:fdfd/f6f6/e3e3\x07");
+
+        assert_eq!(watched.step(200), None, "one color derives nothing");
+        assert!(
+            watched.wake(200).is_some(),
+            "the answer is still owed, so the host still has a deadline"
+        );
+        assert_eq!(
+            watched.step(1_200),
+            None,
+            "the terminal stopped answering, and the colors on screen stand"
+        );
+        assert_eq!(
+            watched.wake(1_200),
+            None,
+            "the watch let it go rather than waiting on it forever"
+        );
+    }
+
+    #[test]
+    fn a_terminal_that_never_answers_at_all_is_dropped_after_one_bounded_wait() {
+        let mut watched = Watched::new();
+
+        watched.feed(0, NOTIFIED);
+        watched.step(100);
+
+        assert_eq!(watched.step(1_099), None, "still inside the wait");
+        assert!(watched.wake(1_099).is_some());
+        assert_eq!(watched.step(1_100), None);
+        assert_eq!(watched.wake(1_100), None, "one second after the re-query");
+        assert_eq!(watched.requeries(), 1, "and it was not retried");
+    }
+
+    #[test]
+    fn typing_and_unrelated_reports_pass_the_watch_by() {
+        let mut watched = Watched::new();
+
+        watched.feed(0, NOTIFIED);
+        watched.step(100);
+        // A keystroke, a cursor-position report meant for someone else, and a
+        // dynamic color nobody asked for.
+        watched.feed(110, "q\x1b[10;5R\x1b]12;rgb:ffff/0000/0000\x07");
+
+        assert_eq!(watched.step(110), None, "none of that is an answer");
+        watched.feed(120, RETHEMED);
+        assert!(
+            watched.step(120).is_some(),
+            "and none of it displaced the real one"
+        );
+    }
+
+    #[test]
+    fn a_second_change_mid_exchange_starts_over_rather_than_mixing_answers() {
+        let mut watched = Watched::new();
+
+        watched.feed(0, NOTIFIED);
+        watched.step(100);
+        // Half the answer to the first re-query, and then the user flips again.
+        watched.feed(110, "\x1b]11;rgb:1a1a/1b1b/2626\x07");
+        watched.feed(120, NOTIFIED);
+
+        assert_eq!(watched.step(120), None, "the window is open again");
+        assert_eq!(watched.step(220), None, "and a second re-query goes out");
+        assert_eq!(watched.requeries(), 2);
+
+        // Only one color arrives this time. If the discarded half had been kept
+        // it would complete a theme out of two different terminals.
+        watched.feed(230, "\x1b]10;rgb:6565/7b7b/8383\x07");
+        assert_eq!(
+            watched.step(230),
+            None,
+            "the pre-flip half was dropped with the state it described"
+        );
+    }
+
+    #[test]
+    fn the_notifications_own_light_dark_value_is_never_read_as_a_color() {
+        // `CSI ?997;2n` says light, and it is only ever a trigger: the terminals
+        // that send it disagree about whether it describes the palette or the
+        // desktop.
+        let mut dark_notice = Watched::new();
+        dark_notice.feed(0, "\x1b[?997;1n");
+        dark_notice.step(100);
+        dark_notice.feed(110, RETHEMED);
+
+        let colors = dark_notice.step(110).expect("the re-query was answered");
+
+        assert_eq!(
+            colors.background,
+            Color::Rgb(253, 246, 227),
+            "the background is the one the re-query brought back, not the one \
+             the notification implied"
+        );
+        assert_eq!(colors.dark, None);
     }
 
     #[test]

--- a/demos/landing/src/tiles/themes.rs
+++ b/demos/landing/src/tiles/themes.rs
@@ -1,7 +1,5 @@
 //! Theme picker tile and its focused/selected rows.
 
-use std::sync::OnceLock;
-
 use ratatui::{
     layout::{Constraint, Layout},
     style::{Modifier, Style},
@@ -33,12 +31,6 @@ fn ordered(resolved: Theme) -> Vec<Theme> {
         .collect()
 }
 
-/// The picker's themes, settled once for the process.
-fn themes() -> &'static [Theme] {
-    static THEMES: OnceLock<Vec<Theme>> = OnceLock::new();
-    THEMES.get_or_init(|| ordered(*demo_shared::theme()))
-}
-
 pub struct State {
     focused: Option<&'static str>,
     selected: &'static str,
@@ -46,9 +38,10 @@ pub struct State {
 
 impl Default for State {
     fn default() -> Self {
+        let opening = ordered(demo_shared::theme())[0].name;
         Self {
-            focused: Some(themes()[0].name),
-            selected: themes()[0].name,
+            focused: Some(opening),
+            selected: opening,
         }
     }
 }
@@ -70,20 +63,41 @@ impl State {
         }
     }
 
+    /// The theme the picker is showing, as of this frame.
     pub fn theme(&self) -> Theme {
-        themes()
-            .iter()
-            .find(|theme| theme.name == self.selected)
-            .copied()
-            .expect("selected theme is always declared")
+        selected_theme(self.selected, demo_shared::theme())
     }
+}
+
+/// Which theme the row named `selected` stands for, given what the terminal
+/// currently resolves to.
+///
+/// The resolved row is read live, so a terminal that re-themes carries the app
+/// with it — but only while that row is the selection. A preset the user picked
+/// by hand is their choice, and a flip of the terminal does not take it back;
+/// it changes what the resolved row would give them if they went back to it.
+fn selected_theme(selected: &str, resolved: Theme) -> Theme {
+    if selected == resolved.name {
+        return resolved;
+    }
+    Theme::presets()
+        .iter()
+        .find(|preset| preset.name == selected)
+        .copied()
+        .unwrap_or(resolved)
 }
 
 pub fn declare(ctx: &mut DeclareCtx<'_, AppState, AppMsg>) {
     let area = ctx.area();
     let controls_disabled = ctx.state().controls_disabled;
+    // Built per frame, never cached: on a terminal that reports its own theme
+    // changes the resolved entry is a different color after every flip, and a
+    // list settled at startup would keep showing the colors it was born with.
+    // Its *name* does not move — a solved theme is always `Adaptive` — so a
+    // selection made against an earlier list still matches.
+    let themes = ordered(demo_shared::theme());
     let picker = List::new(
-        themes()
+        themes
             .iter()
             .map(|theme| ListItem::new(theme.name, theme.name)),
     )
@@ -101,7 +115,7 @@ pub fn declare(ctx: &mut DeclareCtx<'_, AppState, AppMsg>) {
     let [header_area, intro_area, list_area] = Layout::vertical([
         Constraint::Length(1),
         Constraint::Length(3),
-        Constraint::Length(themes().len() as u16),
+        Constraint::Length(themes.len() as u16),
     ])
     .spacing(1)
     .areas(inner);
@@ -116,8 +130,8 @@ pub fn declare(ctx: &mut DeclareCtx<'_, AppState, AppMsg>) {
     );
     ctx.paint_widget(
         Paragraph::new(
-            "Ratcn includes seven preset themes, supports custom themes, and solves \
-             one from your terminal's colors.",
+            "Seven preset themes, custom themes, and one solved from your \
+             terminal's colors when it answers.",
         )
         .style(Style::default().fg(theme.muted_foreground))
         .wrap(Wrap { trim: true }),
@@ -128,7 +142,7 @@ pub fn declare(ctx: &mut DeclareCtx<'_, AppState, AppMsg>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{State, ordered, themes};
+    use super::{State, ordered, selected_theme};
     use ratatui::style::Color;
     use ratcn::Theme;
 
@@ -142,10 +156,84 @@ mod tests {
 
     /// A theme no preset can be: solved from a terminal's own colors, so it is
     /// named `Adaptive` and shares its name with nothing in `presets()`. This
-    /// is the case the tests cannot reach through [`themes`], because without a
-    /// terminal to ask the resolved theme *is* a preset.
+    /// is the case the tests cannot reach through [`demo_shared::theme`],
+    /// because without a terminal to ask the resolved theme *is* a preset.
     fn solved() -> Theme {
         Theme::adaptive(Color::Rgb(253, 246, 227), Color::Rgb(101, 123, 131), None)
+    }
+
+    /// The same terminal after the user flips it the other way.
+    fn solved_dark() -> Theme {
+        Theme::adaptive(Color::Rgb(26, 27, 38), Color::Rgb(192, 202, 245), None)
+    }
+
+    #[test]
+    fn the_resolved_row_follows_the_terminal_wherever_it_goes() {
+        // Its name never moves — a solved theme is always `Adaptive` — so the
+        // selection made against the light one still names the dark one.
+        let light = solved();
+        let dark = solved_dark();
+        assert_eq!(light.name, dark.name);
+
+        assert_eq!(selected_theme(light.name, light), light);
+        assert_eq!(
+            selected_theme(light.name, dark),
+            dark,
+            "the row is read live: the app wears whatever the terminal is now"
+        );
+    }
+
+    #[test]
+    fn a_preset_the_user_picked_is_not_taken_back_by_the_terminal() {
+        let nord = Theme::nord();
+
+        assert_eq!(
+            selected_theme(nord.name, solved()),
+            nord,
+            "their choice stands while the terminal is light"
+        );
+        assert_eq!(
+            selected_theme(nord.name, solved_dark()),
+            nord,
+            "and still stands after it flips: the flip changed what `Adaptive` \
+             offers, not what they chose"
+        );
+    }
+
+    #[test]
+    fn the_resolved_row_outranks_a_preset_that_shares_its_name() {
+        // The row is the terminal's, whatever it is called. Today a solved
+        // theme is always `Adaptive` and no preset can collide with it, so
+        // without this the lookup would happen to give the same answer by
+        // falling through to the resolved theme anyway — and would stop doing
+        // so the moment a resolved theme took a preset's name.
+        let mut impostor = solved();
+        impostor.name = Theme::nord().name;
+
+        assert_eq!(
+            selected_theme(impostor.name, impostor),
+            impostor,
+            "the selection named the resolved row, so it gets the resolved row"
+        );
+        assert_ne!(selected_theme(impostor.name, impostor), Theme::nord());
+    }
+
+    #[test]
+    fn a_selection_that_names_nothing_falls_back_to_the_resolved_theme() {
+        // Unreachable through the picker, which only ever selects a row it
+        // listed — but the answer has to be a theme either way.
+        assert_eq!(selected_theme("no such theme", solved()), solved());
+    }
+
+    #[test]
+    fn going_back_to_the_resolved_row_returns_the_terminals_own_theme() {
+        // Driven through `selected_theme` with a resolved theme no preset can
+        // be: in-process the resolved theme *is* a preset, so a round trip
+        // through `State` would prove nothing about the branch it takes.
+        let resolved = solved();
+
+        assert_eq!(selected_theme(Theme::nord().name, resolved), Theme::nord());
+        assert_eq!(selected_theme(resolved.name, resolved), resolved);
     }
 
     #[test]
@@ -196,7 +284,9 @@ mod tests {
         // A wiring pin only: with no terminal to ask, the resolved theme is
         // itself a preset, so this cannot tell `ordered` apart from `presets()`
         // by construction. What `ordered` actually does is pinned above.
-        assert_eq!(State::default().selected, themes()[0].name);
-        assert_eq!(themes(), ordered(*demo_shared::theme()));
+        assert_eq!(
+            State::default().selected,
+            ordered(demo_shared::theme())[0].name
+        );
     }
 }

--- a/demos/list-multi/src/main.rs
+++ b/demos/list-multi/src/main.rs
@@ -114,7 +114,7 @@ impl demo_shared::Demo for App {
             .set_style(area, Style::default().bg(theme.background));
 
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, state, &theme, |ctx| {
             let muted = ctx.theme.muted_foreground;
             let list = List::new(TOPICS.map(|label| ListItem::new(label, label)))
                 .item_focus(|s: &AppState| s.focused_topic, Msg::TopicFocusChanged)

--- a/demos/list/src/main.rs
+++ b/demos/list/src/main.rs
@@ -119,7 +119,7 @@ impl demo_shared::Demo for App {
             .buffer_mut()
             .set_style(area, Style::default().bg(theme.background));
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, state, &theme, |ctx| {
             let muted = ctx.theme.muted_foreground;
             let list = List::new(FOLDERS.map(|label| ListItem::new(label, label)))
                 .item_focus(

--- a/demos/shared/src/lib.rs
+++ b/demos/shared/src/lib.rs
@@ -11,7 +11,9 @@
 //! resize. Nothing else. An idle demo costs one blocked read natively, and
 //! nothing at all in the browser.
 
-use std::{io, sync::OnceLock, time::Duration};
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+use std::{io, sync::RwLock, time::Duration};
 
 use ratatui::{Frame, Terminal, backend::Backend, style::Color};
 #[cfg(not(target_arch = "wasm32"))]
@@ -22,6 +24,8 @@ use ratatui_termina::{
         escape::csi::{Csi, DecPrivateMode, DecPrivateModeCode, Mode},
     },
 };
+#[cfg(not(target_arch = "wasm32"))]
+use ratcn::terminal_query::ThemeWatch;
 use ratcn::{Theme, runtime::Event};
 
 /// The theme every demo paints with.
@@ -30,18 +34,34 @@ use ratcn::{Theme, runtime::Event};
 /// so the demos sit in the user's own palette rather than next to it. In the
 /// browser, and on a terminal that could not be asked, it is a preset.
 ///
-/// It is resolved once, natively, before the demo is built. A demo built by
-/// `main` and handed to [`run`] has therefore already been built by then, so it
-/// must read this per frame rather than at construction; a demo that has to
-/// read it while being built is built by [`run_lazy`] instead, after the
-/// terminal has answered.
+/// It is resolved before the demo is built, and on a terminal that reports its
+/// own theme changes it is resolved *again* whenever the user flips theirs — so
+/// read it per frame and paint from what it says. A demo that copies it into
+/// its own state stops following the terminal at that moment. A demo that has
+/// to read it while being built is built by [`run_lazy`], after the first
+/// answer is in.
 #[must_use]
-pub fn theme() -> &'static Theme {
-    THEME.get_or_init(fallback_theme)
+pub fn theme() -> Theme {
+    *THEME
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
-/// Resolved by the native [`run_lazy`]; never set in the browser.
-static THEME: OnceLock<Theme> = OnceLock::new();
+/// Publish a newly resolved theme, and report whether it is a change — which is
+/// what the next frame depends on being told.
+#[cfg(not(target_arch = "wasm32"))]
+fn publish_theme(theme: Theme) -> bool {
+    let mut published = THEME
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let changed = *published != theme;
+    *published = theme;
+    changed
+}
+
+/// Resolved by the native [`run_lazy`] and re-resolved by its event loop; in
+/// the browser it keeps the value it was born with.
+static THEME: RwLock<Theme> = RwLock::new(fallback_theme());
 
 /// The theme to paint with when the terminal's own colors are unknown.
 ///
@@ -51,7 +71,7 @@ static THEME: OnceLock<Theme> = OnceLock::new();
 /// which on a light terminal is near-black text on a near-black fill. A theme
 /// that names its colors is at least legible on every terminal, whichever way
 /// round that terminal is.
-fn fallback_theme() -> Theme {
+const fn fallback_theme() -> Theme {
     Theme::default_dark()
 }
 
@@ -113,9 +133,11 @@ pub trait Demo {
 /// Run `demo` until it quits (natively) or forever (in the browser).
 ///
 /// The demo already exists, so it was built before the terminal was asked about
-/// its colors. That is fine for a demo whose theme is a constant, and wrong for
-/// one that reads [`theme`] while being built — which panics here rather than
-/// silently painting the fallback. Those demos use [`run_lazy`].
+/// its colors. That is fine for a demo whose theme is a constant. A demo that
+/// reads [`theme`] must read it *per frame* — a copy taken while the demo was
+/// being built is not only the pre-query theme, it also stops following the
+/// terminal from then on. A demo that has to read the theme while being built
+/// uses [`run_lazy`], which builds it after the query.
 ///
 /// # Errors
 ///
@@ -142,27 +164,29 @@ pub fn run_lazy<D: Demo + 'static>(build: impl FnOnce() -> D) -> io::Result<()> 
     // Raw mode first: nothing below reads a reply that the line discipline
     // would otherwise hold back until Enter.
     output.enter_raw_mode()?;
+    // The one window the query has: raw mode is on and no event reader has
+    // taken a byte yet, so the terminal's answers are the only thing in the
+    // stream that is not the user typing. It happens before the alternate
+    // screen so a slow terminal is answered against the shell the user can
+    // still see, rather than behind a blank screen.
+    //
+    // The panic hook has to know the mode list, and whether the subscription
+    // joins it is the query's answer — so the query goes first and the hook is
+    // installed against the list it produced.
+    let (theme, subscribe) = queried(&mut output);
+    publish_theme(theme);
+
+    let modes = modes(D::INPUT, D::PASTE, subscribe);
     // Termina restores raw mode after this hook runs, so the hook owes only the
     // modes this host turns on below. It writes through a handle of its own,
-    // which is why it can run while the session is being unwound.
-    let modes = modes(D::INPUT, D::PASTE);
+    // which is why it can run while the session is being unwound. Nothing is on
+    // yet, so the query above had nothing for a hook to put back.
     output.set_panic_hook({
         let modes = modes.clone();
         move |handle| {
             let _ = restore_modes(handle, &modes);
         }
     });
-
-    // The one window the query has: raw mode is on and no event reader has
-    // taken a byte yet, so the terminal's answers are the only thing in the
-    // stream that is not the user typing. It happens before the alternate
-    // screen so a slow terminal is answered against the shell the user can
-    // still see, rather than behind a blank screen.
-    assert!(
-        THEME.set(queried_theme(&mut output)).is_ok(),
-        "the theme must be resolved before any demo code reads it: a demo that \
-         reads `theme()` while being built belongs in `run_lazy`, not `run`"
-    );
 
     let events = output.event_reader();
     // `Terminal::new` measures the grid and can fail. It runs while the modes
@@ -213,30 +237,48 @@ impl Drop for Session {
     }
 }
 
-/// Solve a theme from the colors the terminal reports about itself.
+/// Solve a theme from the colors the terminal reports about itself, and say
+/// whether to subscribe to changes in them.
+///
+/// Any terminal that answered is subscribed to. There is no way to ask mode
+/// 2031 whether it is supported, and switching it on where it is not costs
+/// nothing — the notification that never comes is the same silence as not
+/// asking. The light/dark verdict is deliberately *not* the signal: it is a
+/// separate capability with wider support than the mode, and a verdict that
+/// merely arrived after the startup fence would write off a terminal that
+/// supports everything.
 ///
 /// A terminal that cannot be asked, will not answer, or answers only in part
-/// gets the [`fallback_theme`]. So does one whose reply could not be read: the
-/// same terminal is about to be drawn on, and if it is broken enough to fail
-/// here the frame will say so.
+/// gets the [`fallback_theme`] and no subscription. So does one whose reply
+/// could not be read: the same terminal is about to be drawn on, and if it is
+/// broken enough to fail here the frame will say so.
+///
+/// Neither branch is reachable without a terminal, so both are covered by the
+/// pty scenarios rather than by a test here: an answering terminal is sent
+/// `?2031h` and follows a flip, a silent one is sent neither.
 #[cfg(not(target_arch = "wasm32"))]
-fn queried_theme(terminal: &mut PlatformTerminal) -> Theme {
+fn queried(terminal: &mut PlatformTerminal) -> (Theme, bool) {
     match ratcn::terminal_query::query(terminal) {
-        Ok(Some(colors)) => Theme::adaptive(
-            colors.background,
-            colors.foreground,
-            colors.palette16.as_ref(),
+        Ok(Some(colors)) => (
+            Theme::adaptive(
+                colors.background,
+                colors.foreground,
+                colors.palette16.as_ref(),
+            ),
+            true,
         ),
-        Ok(None) | Err(_) => fallback_theme(),
+        Ok(None) | Err(_) => (fallback_theme(), false),
     }
 }
 
 /// The terminal modes the host switches on, in the order it switches them on.
 ///
 /// Termina deliberately manages none of these: they are protocol, and the
-/// application decides. Restoring walks the list back off in reverse.
+/// application decides. Restoring walks the list back off in reverse, which is
+/// why the theme subscription goes on last — it comes off first, and no change
+/// gets reported into a terminal that has started being put back.
 #[cfg(not(target_arch = "wasm32"))]
-fn modes(input: bool, paste: bool) -> Vec<DecPrivateModeCode> {
+fn modes(input: bool, paste: bool, subscribe: bool) -> Vec<DecPrivateModeCode> {
     use DecPrivateModeCode as M;
 
     let mut modes = vec![M::ClearAndEnableAlternateScreen];
@@ -253,6 +295,9 @@ fn modes(input: bool, paste: bool) -> Vec<DecPrivateModeCode> {
     }
     if paste {
         modes.push(M::BracketedPaste);
+    }
+    if subscribe {
+        modes.push(M::Theme);
     }
     modes
 }
@@ -316,9 +361,16 @@ impl Events for TerminalEvents {
 fn drive<D, B, E>(demo: &mut D, terminal: &mut Terminal<B>, events: &mut E) -> io::Result<()>
 where
     D: Demo,
-    B: Backend<Error = io::Error>,
+    B: Backend<Error = io::Error> + io::Write,
     E: Events,
 {
+    // Idle unless the terminal was subscribed to, and free either way: a
+    // terminal that never reports a change never moves it out of `Idle`.
+    //
+    // A process that can be suspended would re-query on SIGCONT as well — the
+    // terminal may have been re-themed while it was stopped. These demos do not
+    // handle suspension, so there is no handler for it to hang off.
+    let mut watch = ThemeWatch::new();
     let mut stale = true;
     loop {
         if stale {
@@ -335,10 +387,29 @@ where
         // deadline's work happens whether the wake-up or an event caused the
         // frame. The browser host has no such asymmetry: its timer is
         // independent of input.
-        let timeout = demo.wake().map(|delay| delay.max(ANIMATION_FRAME));
-        let Some(event) = events.next(timeout)? else {
-            // The wait ran out: the deadline the demo named has arrived, and no
-            // event needs inventing for it.
+        let wanted = demo.wake().map(|delay| delay.max(ANIMATION_FRAME));
+        let timeout = soonest(wanted, watch.wake(Instant::now()));
+        let event = events.next(timeout)?;
+
+        // The watch sees the event before the demo does, and takes nothing away
+        // from it: a reply is not an app event, and a keystroke that arrived
+        // mid-exchange is not a reply.
+        let now = Instant::now();
+        if let Some(event) = &event {
+            watch.absorb(event, now);
+        }
+        if let Some(colors) = watch.step(terminal.backend_mut(), now)? {
+            stale |= publish_theme(Theme::adaptive(
+                colors.background,
+                colors.foreground,
+                colors.palette16.as_ref(),
+            ));
+        }
+
+        let Some(event) = event else {
+            // The wait ran out. Either the demo's deadline arrived or the
+            // watch's did; a frame answers both, and the watch's costs one
+            // frame per theme change.
             stale = true;
             continue;
         };
@@ -352,6 +423,15 @@ where
         if let Ok(event) = Event::try_from(event) {
             stale |= demo.handle_event(event);
         }
+    }
+}
+
+/// The nearer of two waits, where [`None`] is "no deadline of my own".
+#[cfg(not(target_arch = "wasm32"))]
+fn soonest(one: Option<Duration>, other: Option<Duration>) -> Option<Duration> {
+    match (one, other) {
+        (Some(one), Some(other)) => Some(one.min(other)),
+        (only, None) | (None, only) => only,
     }
 }
 
@@ -742,6 +822,9 @@ mod tests {
         inner: TestBackend,
         /// Adopted during the next flush, once.
         resize_on_flush: Option<Size>,
+        /// Bytes the host wrote straight through, rather than as cells: the
+        /// theme watch's re-query is the only thing that does.
+        written: Vec<u8>,
     }
 
     impl HostBackend {
@@ -749,6 +832,7 @@ mod tests {
             Self {
                 inner: TestBackend::new(width, height),
                 resize_on_flush: None,
+                written: Vec::new(),
             }
         }
 
@@ -756,6 +840,20 @@ mod tests {
         fn resizing(mut self, width: u16, height: u16) -> Self {
             self.resize_on_flush = Some(Size::new(width, height));
             self
+        }
+    }
+
+    /// The re-query the theme watch writes goes through the backend, which the
+    /// real one is: `TerminaBackend` is the terminal's own writer. Discarding
+    /// it here would let the watch write into a hole and no test would notice.
+    impl io::Write for HostBackend {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.written.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
         }
     }
 
@@ -857,6 +955,11 @@ mod tests {
         steps: VecDeque<Option<TerminalEvent>>,
         /// The timeout the host asked for, per wait, in order.
         waits: Vec<Option<Duration>>,
+        /// Whether a wait that runs out really takes that long. Off by default,
+        /// because a scripted deadline is usually seconds the test has no
+        /// reason to spend; on where the watch's own deadlines are what is
+        /// being driven, and those are wall-clock.
+        sleeps: bool,
     }
 
     impl Script {
@@ -864,7 +967,13 @@ mod tests {
             Self {
                 steps: steps.into_iter().collect(),
                 waits: Vec::new(),
+                sleeps: false,
             }
+        }
+
+        fn sleeping(mut self) -> Self {
+            self.sleeps = true;
+            self
         }
     }
 
@@ -872,7 +981,14 @@ mod tests {
         fn next(&mut self, timeout: Option<Duration>) -> io::Result<Option<TerminalEvent>> {
             self.waits.push(timeout);
             // A spent script quits, so the loop returns instead of running on.
-            Ok(self.steps.pop_front().unwrap_or_else(|| Some(quit())))
+            let step = self.steps.pop_front().unwrap_or_else(|| Some(quit()));
+            if self.sleeps
+                && step.is_none()
+                && let Some(timeout) = timeout
+            {
+                std::thread::sleep(timeout);
+            }
+            Ok(step)
         }
     }
 
@@ -896,6 +1012,31 @@ mod tests {
         })
     }
 
+    /// The terminal reporting that its theme changed.
+    fn re_themed() -> TerminalEvent {
+        use ratatui_termina::termina::escape::csi::{Csi, Mode, ThemeMode};
+
+        TerminalEvent::Csi(Csi::Mode(Mode::ReportTheme(ThemeMode::Light)))
+    }
+
+    /// The terminal answering one half of a colour re-query.
+    fn color_reply(background: bool, red: u8, green: u8, blue: u8) -> TerminalEvent {
+        use ratatui_termina::termina::{
+            escape::osc::{ColorOrQuery, DynamicColorNumber, Osc},
+            style::RgbColor,
+        };
+
+        let slot = if background {
+            DynamicColorNumber::TextBackgroundColor
+        } else {
+            DynamicColorNumber::TextForegroundColor
+        };
+        TerminalEvent::Osc(Osc::ChangeDynamicColors(
+            slot,
+            vec![ColorOrQuery::Color(RgbColor::new(red, green, blue))],
+        ))
+    }
+
     /// Run the host over `script` and hand back the terminal it drew on.
     fn run_scripted(
         probe: &mut Probe,
@@ -915,10 +1056,10 @@ mod tests {
         // its concrete dark wells is near-black on near-black once the screen
         // turns out to be light.
         //
-        // Read through `theme()`, not `fallback_theme()`, so this also pins
-        // what an unasked terminal gets: no query has run in a test process.
-        let theme = super::theme();
-        assert_eq!(*theme, super::fallback_theme());
+        // What an unasked terminal actually gets is pinned by
+        // `the_published_theme_is_what_the_next_frame_reads`, which owns the
+        // published theme — this one must not touch it.
+        let theme = super::fallback_theme();
 
         for (role, color) in [
             ("foreground", theme.foreground),
@@ -928,6 +1069,123 @@ mod tests {
         ] {
             assert_ne!(color, Color::Reset, "{role} is named, not inherited");
         }
+    }
+
+    /// The published theme is one value for the whole process. Tests that move
+    /// it take this in turn rather than racing over it, and put the fallback
+    /// back when they are done.
+    fn published_theme() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+        LOCK.lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    #[test]
+    fn a_solved_theme_differs_from_another_by_more_than_its_name() {
+        // Every change this feature produces is `Adaptive` following `Adaptive`,
+        // so a comparison that stopped at the name would report no change ever
+        // and quietly switch live re-theming off.
+        let _guard = published_theme();
+
+        let light =
+            ratcn::Theme::adaptive(Color::Rgb(253, 246, 227), Color::Rgb(101, 123, 131), None);
+        let dark = ratcn::Theme::adaptive(Color::Rgb(26, 27, 38), Color::Rgb(192, 202, 245), None);
+        assert_eq!(
+            light.name, dark.name,
+            "both are solved, so both are Adaptive"
+        );
+
+        assert!(super::publish_theme(light), "the first is a change");
+        assert!(
+            super::publish_theme(dark),
+            "and so is the second, name for name identical though it is"
+        );
+
+        super::publish_theme(super::fallback_theme());
+    }
+
+    #[test]
+    fn the_published_theme_is_what_the_next_frame_reads() {
+        let _guard = published_theme();
+        // No query has run here, so this is what an unasked terminal gets.
+        assert_eq!(super::theme(), super::fallback_theme());
+
+        let flipped = ratcn::Theme::catppuccin();
+        assert!(
+            super::publish_theme(flipped),
+            "a different theme is a change, and the frame that shows it is owed"
+        );
+        assert_eq!(super::theme(), flipped, "a demo reads it on the next frame");
+        assert!(
+            !super::publish_theme(flipped),
+            "re-publishing the same theme owes no frame: a terminal that \
+             reports a change to the colors it already had costs no repaint"
+        );
+
+        assert!(super::publish_theme(super::fallback_theme()));
+        assert_eq!(super::theme(), super::fallback_theme());
+    }
+
+    #[test]
+    fn the_subscription_goes_on_last_so_it_comes_off_first() {
+        use super::DecPrivateModeCode as M;
+
+        let quiet = super::modes(false, false, false);
+        let subscribed = super::modes(true, true, true);
+
+        assert!(
+            !quiet.contains(&M::Theme),
+            "a terminal that cannot report changes is not subscribed to"
+        );
+        assert_eq!(
+            subscribed.last(),
+            Some(&M::Theme),
+            "restoring walks the list backwards, so last on is first off"
+        );
+        assert_eq!(
+            subscribed.first(),
+            Some(&M::ClearAndEnableAlternateScreen),
+            "and the screen the user came from is the last thing given back"
+        );
+    }
+
+    #[test]
+    fn restoring_switches_the_subscription_off_before_anything_else() {
+        let modes = super::modes(true, true, true);
+        let mut written = Vec::new();
+
+        super::restore_modes(&mut written, &modes).expect("a vector accepts every write");
+
+        let written = String::from_utf8(written).expect("escape sequences are ASCII");
+        let subscription_off = written
+            .find("\x1b[?2031l")
+            .expect("the subscription is switched off");
+        let screen_back = written
+            .find("\x1b[?1049l")
+            .expect("the alternate screen is left");
+
+        assert!(
+            subscription_off < screen_back,
+            "no change may be reported into a terminal that has started being \
+             put back: {written:?}"
+        );
+        assert!(
+            written.ends_with("\x1b[?25h"),
+            "and the cursor is visible again at the end: {written:?}"
+        );
+    }
+
+    #[test]
+    fn the_nearer_of_two_waits_wins_and_no_wait_at_all_yields() {
+        let short = Duration::from_millis(10);
+        let long = Duration::from_millis(500);
+
+        assert_eq!(super::soonest(Some(long), Some(short)), Some(short));
+        assert_eq!(super::soonest(Some(short), Some(long)), Some(short));
+        assert_eq!(super::soonest(Some(short), None), Some(short));
+        assert_eq!(super::soonest(None, Some(long)), Some(long));
+        assert_eq!(super::soonest(None, None), None);
     }
 
     #[test]
@@ -1056,6 +1314,71 @@ mod tests {
             vec![Some(ANIMATION_FRAME)],
             "a zero wait would spin the CPU for nothing new to show"
         );
+    }
+
+    #[test]
+    fn a_reported_theme_change_shortens_the_wait_a_demo_asked_to_be_endless() {
+        // The demo names no deadline, so before the notification the host waits
+        // for input with no timeout at all. Afterwards it owes the watch a
+        // visit, and the wait it asks for has to be short enough to make it.
+        let mut probe = Probe::default();
+        let mut script = Script::new([Some(re_themed())]);
+
+        run_scripted(&mut probe, HostBackend::new(20, 5), &mut script);
+
+        assert!(
+            probe.routed.is_empty(),
+            "a terminal's report is not an app event: {:?}",
+            probe.routed
+        );
+        assert_eq!(script.waits.first(), Some(&None), "endless, until the news");
+        let after = script.waits.get(1).copied().flatten();
+        let waited = after.expect("the watch put a deadline on the next wait");
+        assert!(
+            waited <= Duration::from_millis(100),
+            "the re-query is due within the collapse window: {waited:?}"
+        );
+    }
+
+    #[test]
+    fn a_reported_change_is_re_queried_and_the_answer_reaches_the_next_frame() {
+        // The whole pipeline through the host: notification in, re-query out on
+        // the wire, replies in, new theme published, frame drawn. Costs the one
+        // debounce window in real time, which is what the sleeping script is
+        // for — the watch's deadlines are wall-clock.
+        let _guard = published_theme();
+        super::publish_theme(super::fallback_theme());
+
+        let mut probe = Probe::default();
+        let mut script = Script::new([
+            Some(re_themed()),
+            // The wait that lets the collapse window close.
+            None,
+            Some(color_reply(false, 101, 123, 131)),
+            Some(color_reply(true, 253, 246, 227)),
+        ])
+        .sleeping();
+
+        let terminal = run_scripted(&mut probe, HostBackend::new(20, 5), &mut script);
+
+        let written = String::from_utf8(terminal.backend().written.clone())
+            .expect("escape sequences are ASCII");
+        assert_eq!(
+            written, "\x1b]10;?\x07\x1b]11;?\x07",
+            "the re-query went out through the terminal's own writer, once"
+        );
+        assert_eq!(
+            super::theme(),
+            ratcn::Theme::adaptive(Color::Rgb(253, 246, 227), Color::Rgb(101, 123, 131), None),
+            "the colours the terminal answered with are what the app now wears"
+        );
+        assert_eq!(
+            probe.frames, 3,
+            "the first frame, the one the closing window asked for, and the one \
+             the new theme did"
+        );
+
+        super::publish_theme(super::fallback_theme());
     }
 
     #[test]


### PR DESCRIPTION
Phase C of the adaptive terminal theme — the last phase. An app on the termina host now follows a terminal theme flip live, without restarting.

`terminal_query::ThemeWatch` (feature `termina`): after a successful startup query the host subscribes to DEC mode 2031 (theme-change notifications; the subscribe is inert on terminals that lack it, so any terminal that answered the color query is subscribed). Each notification opens a ~100ms collapse window — a burst of five costs one requery — then the watch re-asks OSC 10/11, absorbs the replies streaming in the normal event loop (input stays responsive; a notification arriving mid-exchange discards the stale half rather than completing a theme from two different terminals), re-derives `Theme::adaptive`, and the next frame wears it. A terminal that stops answering costs one bounded wait and keeps the colors it had. `?2031l` is first out on every exit path, panic included.

The demo theme seam graduates from set-once to refreshable (read per frame; a changed theme marks the frame stale so the repaint is prompt), and the landing picker's Adaptive entry follows live while a manually picked preset is never overridden.

Verified end-to-end under live ptys: dark→Solarized Light mid-session flips the next frame; five-notification bursts collapse to one requery; the late-996 terminal (ghostty pre-2026) still subscribes and pays only one self-correcting requery; a terminal without 2031 takes the subscribe silently and nothing else happens. Two adversarial review rounds plus mutation confirm (the sharpest catch: the only change this feature ever produces is `Adaptive`→`Adaptive`, so whole-theme comparison is now pinned where a name-only compare would have silently disabled the feature). Suite at 539 lib tests; the end-to-end host test survived 60 runs under 2× CPU oversubscription.