### PR TITLE
Adaptive theme: ask again until the answer settles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   alternate screen, the input modes you ask for — and restores every one on any
   exit, panic included. `Session::next` is the event source.
 - `SessionOptions::adaptive()` has the session ask the terminal what colors it
-  uses and follow them as they change. `session.theme()` and
-  `theme_with_fallback(preset)` answer per frame; paint from one of them and the
-  app follows a re-theme.
+  uses and follow them: it asks again when the window regains focus, shortly
+  after every change signal, and when input resumes after a pause.
+  `session.theme()` and `theme_with_fallback(preset)` answer per frame.
 - A `termina` feature, converting [termina](https://docs.rs/termina) events into
   `runtime::Event` the way `crossterm` does. Both features can be on at once,
   and neither is on by default.

--- a/crates/ratcn/src/terminal/mod.rs
+++ b/crates/ratcn/src/terminal/mod.rs
@@ -27,7 +27,9 @@
 //! ```
 //!
 //! Or paint with the terminal's own colors. [`SessionOptions::adaptive`] asks
-//! the terminal what it looks like and follows it as the user changes it; read
+//! the terminal what it looks like and follows it as the user changes it: it
+//! asks again when the window regains focus, shortly after every change signal,
+//! and when input resumes after a pause. Read
 //! [`theme_with_fallback`](Session::theme_with_fallback) each frame and paint
 //! from what it says.
 //!
@@ -82,8 +84,8 @@ use watch::Watch;
 
 pub use query::{TerminalColors, query};
 /// The terminal library this module is built on, re-exported so an integrator
-/// can name the types inside [`SessionEvent::Input`] without depending on it
-/// separately and keeping the versions in step.
+/// names the types inside [`SessionEvent::Input`] through ratcn, at the version
+/// ratcn builds against.
 pub use termina;
 
 /// The backend a [`Session`] draws through.
@@ -157,9 +159,10 @@ impl SessionOptions {
 
     /// Paint with the terminal's own colors, and follow them as they change.
     ///
-    /// The session asks the terminal what it looks like while opening, and
-    /// subscribes to changes it reports. [`Session::theme`] answers with what
-    /// it said.
+    /// The session asks the terminal what it looks like while opening,
+    /// subscribes to changes it reports, and asks again when the window regains
+    /// focus, shortly after every change signal, and when input resumes after a
+    /// pause. [`Session::theme`] answers with what it said.
     pub const fn adaptive(mut self) -> Self {
         self.adaptive = true;
         self
@@ -170,8 +173,10 @@ impl Session {
     /// Open the terminal and switch on the modes `options` asked for.
     ///
     /// Under [`SessionOptions::adaptive`] the terminal is asked what colors it
-    /// uses while the session opens, and subscribed to for changes it reports;
-    /// [`theme`](Self::theme) answers with what it said.
+    /// uses while the session opens, subscribed to for changes it reports, and
+    /// asked again when the window regains focus, shortly after every change
+    /// signal, and when input resumes after a pause; [`theme`](Self::theme)
+    /// answers with what it said.
     ///
     /// # Errors
     ///
@@ -197,7 +202,7 @@ impl Session {
         } else {
             None
         };
-        let (theme, watch) = opening(answer);
+        let (theme, watch) = opening(answer, Instant::now());
 
         let modes = modes(options, watch.is_some());
         // Termina restores raw mode after this hook runs, so the hook owes only
@@ -286,9 +291,9 @@ impl Drop for Session {
 /// The terminal modes a session switches on, in the order it switches them on.
 ///
 /// Termina deliberately manages none of these: they are protocol, and the
-/// application decides. Restoring walks the list back off in reverse, which is
-/// why the theme subscription goes on last — it comes off first, and no change
-/// gets reported into a terminal that has started being put back.
+/// application decides. Restoring walks the list back off in reverse, so the
+/// theme subscription goes on last and comes off first — a terminal being put
+/// back reports no change into a session that is closing.
 fn modes(options: SessionOptions, subscribe: bool) -> Vec<DecPrivateModeCode> {
     use DecPrivateModeCode as M;
 
@@ -308,7 +313,10 @@ fn modes(options: SessionOptions, subscribe: bool) -> Vec<DecPrivateModeCode> {
         modes.push(M::BracketedPaste);
     }
     if subscribe {
-        modes.push(M::Theme);
+        // Focus tracking is the second trigger for a re-query: a terminal
+        // recoloured from outside its own theme selector reports nothing, and
+        // some terminals have no mode 2031 to report through.
+        modes.extend([M::FocusTracking, M::Theme]);
     }
     modes
 }
@@ -416,9 +424,12 @@ const fn stored_or(stored: Option<Theme>, fallback: Theme) -> Theme {
 /// A terminal that answered is followed; one that would not say — or was never
 /// asked — leaves both empty, so the watch exists exactly where mode 2031 is
 /// switched on.
-fn opening(answer: Option<TerminalColors>) -> (Option<Theme>, Option<Watch>) {
+///
+/// `now` is when the session opened, which is the quiet the first event is
+/// measured against.
+fn opening(answer: Option<TerminalColors>, now: Instant) -> (Option<Theme>, Option<Watch>) {
     match answer {
-        Some(colors) => (Some(colors.theme()), Some(Watch::new(Some(colors)))),
+        Some(colors) => (Some(colors.theme()), Some(Watch::new(Some(colors), now))),
         None => (None, None),
     }
 }
@@ -456,8 +467,9 @@ fn restore_modes(out: &mut impl io::Write, modes: &[DecPrivateModeCode]) -> io::
 #[cfg(test)]
 mod tests {
     use super::{
-        DecPrivateModeCode as M, Duration, SessionEvent, SessionOptions, Source, TerminalColors,
-        Watch, io, modes, opening, pump, pump_and_remember, remember, restore_modes, stored_or,
+        DecPrivateModeCode as M, Duration, Instant, SessionEvent, SessionOptions, Source,
+        TerminalColors, Watch, io, modes, opening, pump, pump_and_remember, remember,
+        restore_modes, stored_or,
     };
     use crate::Theme;
     use ratatui::style::Color;
@@ -466,13 +478,22 @@ mod tests {
     use termina::Parser;
 
     /// An event source the test writes the script for: each step is either an
-    /// event to hand over or a wait to really sit out. Running dry is an error
-    /// rather than an empty poll, so a loop that would spin says so.
+    /// event to hand over or a wait to really sit out. A spent script is a
+    /// terminal with nothing more to say, and [`POLLS`] is what keeps a loop
+    /// that would never leave it from running forever.
     struct Scripted {
         steps: RefCell<VecDeque<Option<termina::Event>>>,
         /// The timeout each poll was given, in order.
         polls: RefCell<Vec<Option<Duration>>>,
     }
+
+    /// How many times one `pump` call may ask the source before the loop it is
+    /// in counts as a spin.
+    ///
+    /// Every script here is a handful of steps, and every pass through the loop
+    /// spends one: a pump still asking after this many has stopped making
+    /// progress through anything.
+    const POLLS: usize = 64;
 
     impl Scripted {
         /// `script` parses to the events; `waits` marks, by index, the points
@@ -515,14 +536,24 @@ mod tests {
     impl Source for Scripted {
         fn poll(&self, timeout: Option<Duration>) -> io::Result<bool> {
             self.polls.borrow_mut().push(timeout);
+            let asked = self.polls.borrow().len();
+            if asked > POLLS {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    format!("the source was asked {asked} times: the loop is spinning"),
+                ));
+            }
             match self.steps.borrow().front() {
                 Some(Some(_)) => return Ok(true),
                 Some(None) => {}
+                // A spent script is a terminal with nothing more to say: it
+                // sits out whatever wait it was given, and answers an unbounded
+                // one the way a silent terminal does, by staying silent.
                 None => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::WouldBlock,
-                        "the script ran dry: the loop would spin here",
-                    ));
+                    if let Some(timeout) = timeout {
+                        std::thread::sleep(timeout);
+                    }
+                    return Ok(false);
                 }
             }
             self.steps.borrow_mut().pop_front();
@@ -542,6 +573,13 @@ mod tests {
     }
 
     const NOTIFIED: &str = "\x1b[?997;2n";
+
+    /// Long enough for a collapse window to close and its answer to arrive.
+    const PATIENT: Duration = Duration::from_millis(500);
+
+    /// Long enough for a collapse window to close, which is what a re-query on
+    /// its way out would need.
+    const PAST_THE_WINDOW: Duration = Duration::from_millis(200);
     const LIGHT: &str = "\x1b]10;rgb:6565/7b7b/8383\x07\x1b]11;rgb:fdfd/f6f6/e3e3\x07";
 
     fn typed(code: char) -> termina::Event {
@@ -550,11 +588,21 @@ mod tests {
         ))
     }
 
+    /// A watch on a session nobody has touched since it opened, which is how
+    /// the quiet the input trigger answers to is arranged without sitting one
+    /// out.
+    fn quiet_watch() -> Watch {
+        let opened = Instant::now()
+            .checked_sub(super::watch::IDLE + Duration::from_secs(1))
+            .expect("the process clock has six seconds behind it");
+        Watch::new(None, opened)
+    }
+
     #[test]
     fn typing_reaches_the_app_whether_or_not_the_terminal_is_watched() {
         for watched in [false, true] {
             let source = Scripted::new("q", &[]);
-            let mut watch = Watch::new(None);
+            let mut watch = Watch::new(None, Instant::now());
             let mut out = Vec::new();
 
             let event = pump(
@@ -574,12 +622,67 @@ mod tests {
     }
 
     #[test]
+    fn focus_reaches_the_app_whether_or_not_the_terminal_is_watched() {
+        for watched in [false, true] {
+            let source = Scripted::new("\x1b[I", &[]);
+            let mut watch = Watch::new(None, Instant::now());
+            let mut out = Vec::new();
+
+            let event = pump(
+                &source,
+                &mut out,
+                watched.then_some(&mut watch),
+                Some(PATIENT),
+            )
+            .expect("a scripted source cannot fail");
+
+            assert_eq!(
+                event,
+                Some(SessionEvent::Input(termina::Event::FocusIn)),
+                "the watch observes focus without taking it (watched: {watched})"
+            );
+            assert!(
+                out.is_empty(),
+                "focus opens a window; the re-query it triggers goes out when \
+                 that window closes (watched: {watched})"
+            );
+        }
+    }
+
+    #[test]
+    fn a_session_that_follows_nothing_writes_nothing_when_focus_returns() {
+        // A session with no re-query to trigger has nothing for focus to do,
+        // and the wait in the middle carries it long past any collapse window.
+        let source = Scripted::new("\x1b[Iq", &[1]);
+        let mut out = Vec::new();
+
+        let focus =
+            pump(&source, &mut out, None, Some(PATIENT)).expect("a scripted source cannot fail");
+        let quiet = pump(&source, &mut out, None, Some(PAST_THE_WINDOW))
+            .expect("a scripted source cannot fail");
+        let after =
+            pump(&source, &mut out, None, Some(PATIENT)).expect("a scripted source cannot fail");
+
+        assert_eq!(focus, Some(SessionEvent::Input(termina::Event::FocusIn)));
+        assert_eq!(
+            quiet, None,
+            "the wait ran out, and nothing came due while it did"
+        );
+        assert_eq!(
+            after,
+            Some(SessionEvent::Input(typed('q'))),
+            "and the session goes on routing what the user does"
+        );
+        assert!(out.is_empty(), "not one byte went out");
+    }
+
+    #[test]
     fn a_terminals_own_answer_is_never_input() {
         // Unsolicited or left over, an escape report is not something the app
         // can read. The contract is the same with a watch and without one.
         for watched in [false, true] {
             let source = Scripted::new("\x1b[?62;1;6cq", &[]);
-            let mut watch = Watch::new(None);
+            let mut watch = Watch::new(None, Instant::now());
             let mut out = Vec::new();
 
             let event = pump(
@@ -616,17 +719,21 @@ mod tests {
     fn a_pending_watch_shortens_a_wait_the_caller_made_long() {
         // The caller names five seconds; the watch owes a re-query in a
         // hundred milliseconds, and the poll has to come back in time for it.
-        let source = Scripted::new(NOTIFIED, &[1]);
-        let mut watch = Watch::new(None);
+        // A keystroke after the window closes, so the pump has something to
+        // return once the re-query has gone out.
+        let source = Scripted::new(&format!("{NOTIFIED}q"), &[1]);
+        let mut watch = Watch::new(None, Instant::now());
         let mut out = Vec::new();
 
-        let _ = pump(
+        let event = pump(
             &source,
             &mut out,
             Some(&mut watch),
             Some(Duration::from_secs(5)),
-        );
+        )
+        .expect("a scripted source cannot fail");
 
+        assert_eq!(event, Some(SessionEvent::Input(typed('q'))));
         let shortened = source.poll_at(1).expect("a second wait happened");
         assert!(
             shortened <= Duration::from_millis(100),
@@ -637,7 +744,7 @@ mod tests {
     #[test]
     fn the_colours_a_re_query_brings_back_are_the_theme_that_comes_out() {
         let source = Scripted::new(&format!("{NOTIFIED}{LIGHT}"), &[1]);
-        let mut watch = Watch::new(None);
+        let mut watch = Watch::new(None, Instant::now());
         let mut out = Vec::new();
 
         let event =
@@ -669,8 +776,129 @@ mod tests {
     }
 
     #[test]
+    fn focus_returning_re_queries_and_reports_a_real_change() {
+        // The reproducer, at the seam: a terminal that reports no change of its
+        // own, recoloured while the app was in the background.
+        let source = Scripted::new(&format!("\x1b[I{LIGHT}"), &[1]);
+        let mut watch = Watch::new(None, Instant::now());
+        let mut out = Vec::new();
+
+        let focus = pump(&source, &mut out, Some(&mut watch), Some(PATIENT))
+            .expect("a scripted source cannot fail");
+        let event = pump(&source, &mut out, Some(&mut watch), Some(PATIENT))
+            .expect("a scripted source cannot fail");
+
+        assert_eq!(
+            focus,
+            Some(SessionEvent::Input(termina::Event::FocusIn)),
+            "focus reaches the app: the watch observes it without taking it"
+        );
+        assert_eq!(
+            event,
+            Some(SessionEvent::ThemeChanged(answered().theme())),
+            "the colors the re-query brought back are the new theme"
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&out),
+            "\x1b]10;?\x07\x1b]11;?\x07",
+            "and the re-query went out"
+        );
+    }
+
+    #[test]
+    fn focus_returning_to_an_unchanged_terminal_owes_the_app_nothing() {
+        // Alt-tabbing costs a round trip and no frame.
+        let known = TerminalColors {
+            background: Color::Rgb(26, 27, 38),
+            foreground: Color::Rgb(192, 202, 245),
+        };
+        let unchanged = "\x1b]10;rgb:c0c0/caca/f5f5\x07\x1b]11;rgb:1a1a/1b1b/2626\x07";
+        let source = Scripted::new(&format!("\x1b[I{unchanged}q"), &[1]);
+        let mut watch = Watch::new(Some(known), Instant::now());
+        let mut out = Vec::new();
+
+        let focus = pump(&source, &mut out, Some(&mut watch), Some(PATIENT))
+            .expect("a scripted source cannot fail");
+        let event = pump(&source, &mut out, Some(&mut watch), Some(PATIENT))
+            .expect("a scripted source cannot fail");
+
+        assert_eq!(focus, Some(SessionEvent::Input(termina::Event::FocusIn)));
+        assert_eq!(
+            event,
+            Some(SessionEvent::Input(typed('q'))),
+            "the re-query answered with what was already on screen, so the next \
+             thing the app hears is the keystroke"
+        );
+    }
+
+    #[test]
+    fn input_after_a_long_quiet_re_queries_and_reports_a_real_change() {
+        // The other reproducer: a compositor that gives the window no focus
+        // event at all, so the user coming back to it is the whole signal.
+        let source = Scripted::new(&format!("q{LIGHT}"), &[1]);
+        let mut watch = quiet_watch();
+        let mut out = Vec::new();
+
+        let typing = pump(&source, &mut out, Some(&mut watch), Some(PATIENT))
+            .expect("a scripted source cannot fail");
+        let event = pump(&source, &mut out, Some(&mut watch), Some(PATIENT))
+            .expect("a scripted source cannot fail");
+
+        assert_eq!(
+            typing,
+            Some(SessionEvent::Input(typed('q'))),
+            "the keystroke is the app's, trigger or not"
+        );
+        assert_eq!(
+            event,
+            Some(SessionEvent::ThemeChanged(answered().theme())),
+            "the colors the re-query brought back are the new theme"
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&out),
+            "\x1b]10;?\x07\x1b]11;?\x07",
+            "and the re-query went out through the terminal's own writer"
+        );
+    }
+
+    #[test]
+    fn input_inside_a_session_already_in_use_asks_the_terminal_nothing() {
+        // Typing is what a session is for. Only the first keystroke after a
+        // spell of nothing at all says the user was somewhere else.
+        let source = Scripted::new("q", &[1]);
+        let mut watch = Watch::new(None, Instant::now());
+        let mut out = Vec::new();
+
+        let typing = pump(&source, &mut out, Some(&mut watch), Some(PATIENT))
+            .expect("a scripted source cannot fail");
+        let quiet = pump(&source, &mut out, Some(&mut watch), Some(PAST_THE_WINDOW))
+            .expect("a scripted source cannot fail");
+
+        assert_eq!(typing, Some(SessionEvent::Input(typed('q'))));
+        assert_eq!(quiet, None, "the wait ran out with nothing to report");
+        assert!(out.is_empty(), "and no window ever opened");
+    }
+
+    #[test]
+    fn a_session_that_follows_nothing_writes_nothing_when_input_resumes() {
+        // A session with no re-query to trigger has no quiet to answer to
+        // either, however long it was left alone.
+        let source = Scripted::new("q", &[1]);
+        let mut out = Vec::new();
+
+        let typing =
+            pump(&source, &mut out, None, Some(PATIENT)).expect("a scripted source cannot fail");
+        let quiet = pump(&source, &mut out, None, Some(PAST_THE_WINDOW))
+            .expect("a scripted source cannot fail");
+
+        assert_eq!(typing, Some(SessionEvent::Input(typed('q'))));
+        assert_eq!(quiet, None);
+        assert!(out.is_empty(), "not one byte went out");
+    }
+
+    #[test]
     fn a_terminal_that_answered_is_worn_and_followed() {
-        let (theme, watch) = opening(Some(answered()));
+        let (theme, watch) = opening(Some(answered()), Instant::now());
 
         assert_eq!(theme, Some(answered().theme()), "the answer is worn");
         assert!(watch.is_some(), "and the terminal is followed");
@@ -678,7 +906,7 @@ mod tests {
 
     #[test]
     fn a_terminal_that_said_nothing_is_neither_worn_nor_followed() {
-        let (theme, watch) = opening(None);
+        let (theme, watch) = opening(None, Instant::now());
 
         assert_eq!(theme, None, "there is nothing to wear but a fallback");
         assert!(
@@ -694,7 +922,7 @@ mod tests {
         // A caller that reads the theme after the event must see the theme the
         // event carried.
         let source = Scripted::new(&format!("{NOTIFIED}{LIGHT}"), &[1]);
-        let mut watch = Watch::new(None);
+        let mut watch = Watch::new(None, Instant::now());
         let mut out = Vec::new();
         let mut stored = None;
 
@@ -782,6 +1010,21 @@ mod tests {
             subscribed.first(),
             Some(&M::ClearAndEnableAlternateScreen),
             "and the screen the user came from is the last thing given back"
+        );
+    }
+
+    #[test]
+    fn following_the_terminal_turns_on_focus_reporting_too() {
+        let unanswered = modes(SessionOptions::new().mouse(), false);
+        let subscribed = modes(SessionOptions::new().mouse(), true);
+
+        assert!(
+            !unanswered.contains(&M::FocusTracking),
+            "a session with no re-query has nothing for focus to trigger"
+        );
+        assert!(
+            subscribed.contains(&M::FocusTracking),
+            "focus is the second trigger for a re-query"
         );
     }
 

--- a/crates/ratcn/src/terminal/watch.rs
+++ b/crates/ratcn/src/terminal/watch.rs
@@ -2,8 +2,9 @@
 //!
 //! [`Watch`] is what a [`Session`](super::Session) runs behind its event
 //! source: it notices a change notification, waits for the burst to settle,
-//! asks the terminal for its colors again, and hands back the answer. The app
-//! sees none of that — only the
+//! asks the terminal for its colors again, and hands back the answer. It asks
+//! again over the seconds that follow, so a recolour still in progress is
+//! reached at the value it arrives at. The app sees none of that — only the
 //! [`ThemeChanged`](super::SessionEvent::ThemeChanged) that comes out the end.
 
 use std::{
@@ -33,16 +34,47 @@ const REQUERY: &str = "\x1b]10;?\x07\x1b]11;?\x07";
 /// and a repaint.
 const DEBOUNCE: Duration = Duration::from_millis(100);
 
+/// The re-asks a trigger schedules after its own, measured from the trigger.
+///
+/// A recolour that starts at the moment the trigger fires answers the first
+/// round trip with the colors it is in the middle of replacing. Asking again a
+/// second later, and once more two seconds after that, is what reaches the
+/// answer a desktop script arrives at in its own time.
+pub(super) const SETTLE: [Duration; 2] = [Duration::from_secs(1), Duration::from_secs(3)];
+
+/// How long a session goes without events before the next one counts as the
+/// user coming back to it.
+///
+/// Longer than the pauses inside continuous use — reading a screen, moving
+/// between fields, waiting out a command — so a gap this wide places the user
+/// somewhere else, which is where a terminal gets recoloured on the compositors
+/// that report no focus at all.
+pub(super) const IDLE: Duration = Duration::from_secs(5);
+
 #[derive(Debug)]
 pub(super) struct Watch {
     state: Watching,
     /// What the terminal last said its colors were. A re-query that lands back
     /// on these is not a change and is not reported.
     last: Option<TerminalColors>,
+    /// The settle sequence the current trigger opened, while it still owes a
+    /// re-ask.
+    settle: Option<Settle>,
+    /// When the terminal last produced an event of any kind, starting at the
+    /// instant the session opened.
+    seen: Instant,
+}
+
+/// The re-asks one trigger still owes: where they are measured from, and how
+/// many of [`SETTLE`] have gone out.
+#[derive(Debug, Clone, Copy)]
+struct Settle {
+    from: Instant,
+    spent: usize,
 }
 
 /// Where the watch is in the notification-to-new-colors round trip.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 enum Watching {
     /// Nothing has happened, and nothing is owed.
     Idle,
@@ -52,26 +84,33 @@ enum Watching {
     /// The colors have been asked for again, and the answer is owed by
     /// `deadline`.
     Awaiting { deadline: Instant, replies: Replies },
+    /// The exchange is over and the trigger still owes a re-ask, due at `due`.
+    Settling { due: Instant },
 }
 
 impl Watch {
-    /// A watch with nothing pending.
+    /// A watch with nothing pending, opened at `opened`.
     /// `known` is what the startup query answered, so a re-query that repeats
     /// it reports nothing.
-    pub(super) const fn new(known: Option<TerminalColors>) -> Self {
+    pub(super) const fn new(known: Option<TerminalColors>, opened: Instant) -> Self {
         Self {
             state: Watching::Idle,
             last: known,
+            settle: None,
+            seen: opened,
         }
     }
 
     /// Note one event read from the terminal.
     ///
-    /// Events that are neither a change notification nor a reply this watch is
-    /// waiting for are ignored, so a host can hand it everything it reads
-    /// without sorting first — and hand the same event on to the app, which is
-    /// what keeps a keystroke that arrived mid-exchange a keystroke.
+    /// The watch takes what it needs of each event — a trigger, a reply it is
+    /// waiting for, or the instant it arrived — and leaves the event itself
+    /// alone, so a host hands it everything it reads without sorting first and
+    /// hands the same event on to the app, which is what keeps a keystroke that
+    /// arrived mid-exchange a keystroke.
     pub(super) fn absorb(&mut self, event: &Event, now: Instant) {
+        let quiet = now.saturating_duration_since(self.seen);
+        self.seen = now;
         match event {
             // The notification carries a light/dark value of its own, and it is
             // deliberately not read: terminals disagree over whether it
@@ -82,26 +121,88 @@ impl Watch {
             // A stray `CSI ? 997 ; N n` — a startup verdict that arrived after
             // the fence — is indistinguishable from a notification. It costs
             // one re-query, and the answer reports no change.
-            Event::Csi(Csi::Mode(csi::Mode::ReportTheme(_))) => {
-                // A window already open is not pushed back. Extending it on
-                // every notification would let a terminal that keeps sending
-                // hold the re-query off indefinitely; collapsing into a fixed
-                // window instead guarantees the round trip happens, and a
-                // change that lands after it opens a window of its own.
-                if !matches!(self.state, Watching::Collapsing { .. }) {
-                    self.state = Watching::Collapsing {
-                        due: deadline(now, DEBOUNCE),
-                    };
-                }
+            //
+            // Focus returning to the window is the other trigger. A terminal
+            // recoloured by something other than its own theme selector — a
+            // desktop that injects OSC 10/11 into every pty — reports no
+            // change, and mode 2031 does not exist at all on some terminals.
+            // Asking again when the user comes back covers both: the colors
+            // answer for themselves, and an unchanged palette ends the round
+            // trip without an event.
+            Event::Csi(Csi::Mode(csi::Mode::ReportTheme(_))) | Event::FocusIn => {
+                self.trigger(now);
             }
-            // Anything collected before this notification described the theme
-            // the terminal has just left, so it is dropped with the state.
+            // Anything collected before a trigger described the theme the
+            // terminal has just left, so it is dropped with the state.
             event => {
                 if let Watching::Awaiting { replies, .. } = &mut self.state {
                     let _fence = replies.absorb(event);
                 }
+                // Input resuming after a long quiet is the third trigger, and
+                // the one that needs nothing of the terminal: the user was
+                // away, and the compositors that recolour a window without
+                // giving it a focus event are covered by the same round trip.
+                // The comparison happens on an event that arrived, so a session
+                // nobody is using costs no wake-up at all.
+                //
+                // Only from rest: a sequence already running asks again on its
+                // own schedule, and a settle runs shorter than a quiet spell.
+                else if matches!(self.state, Watching::Idle)
+                    && quiet >= IDLE
+                    && !event.is_escape()
+                {
+                    self.trigger(now);
+                }
             }
         }
+    }
+
+    /// Open a collapse window, and the settle sequence that follows it.
+    ///
+    /// A window already open is not pushed back, and keeps the sequence it
+    /// started. Extending it on every trigger would let a terminal that keeps
+    /// sending hold the re-query off indefinitely; collapsing into a fixed
+    /// window instead guarantees the round trip happens, and a trigger that
+    /// lands after it opens a window — and a sequence — of its own.
+    fn trigger(&mut self, now: Instant) {
+        if matches!(self.state, Watching::Collapsing { .. }) {
+            return;
+        }
+        self.state = Watching::Collapsing {
+            due: deadline(now, DEBOUNCE),
+        };
+        self.settle = Some(Settle {
+            from: now,
+            spent: 0,
+        });
+    }
+
+    /// When the current trigger's next re-ask comes due, while it owes one.
+    fn settle_due(&self) -> Option<Instant> {
+        let settle = self.settle?;
+        Some(deadline(settle.from, *SETTLE.get(settle.spent)?))
+    }
+
+    /// Where the watch goes when an exchange ends: on to the re-ask the trigger
+    /// still owes, or to rest.
+    fn rest(&mut self) {
+        if let Some(due) = self.settle_due() {
+            self.state = Watching::Settling { due };
+            return;
+        }
+        self.settle = None;
+        self.state = Watching::Idle;
+    }
+
+    /// Write the re-query, and start waiting out its answer.
+    fn ask<W: io::Write>(&mut self, out: &mut W, now: Instant) -> io::Result<()> {
+        out.write_all(REQUERY.as_bytes())?;
+        out.flush()?;
+        self.state = Watching::Awaiting {
+            deadline: deadline(now, BACKSTOP),
+            replies: Replies::default(),
+        };
+        Ok(())
     }
 
     /// How long the host may wait before calling [`step`](Self::step) again, or
@@ -109,9 +210,9 @@ impl Watch {
     pub(super) fn wake(&self, now: Instant) -> Option<Duration> {
         match self.state {
             Watching::Idle => None,
-            Watching::Collapsing { due: at } | Watching::Awaiting { deadline: at, .. } => {
-                Some(at.saturating_duration_since(now))
-            }
+            Watching::Collapsing { due: at }
+            | Watching::Settling { due: at }
+            | Watching::Awaiting { deadline: at, .. } => Some(at.saturating_duration_since(now)),
         }
     }
 
@@ -130,27 +231,30 @@ impl Watch {
         out: &mut W,
         now: Instant,
     ) -> io::Result<Option<TerminalColors>> {
-        match &mut self.state {
+        match self.state {
             Watching::Idle => Ok(None),
             Watching::Collapsing { due } => {
-                if now < *due {
-                    return Ok(None);
+                if now >= due {
+                    self.ask(out, now)?;
                 }
-                out.write_all(REQUERY.as_bytes())?;
-                out.flush()?;
-                self.state = Watching::Awaiting {
-                    deadline: deadline(now, BACKSTOP),
-                    replies: Replies::default(),
-                };
+                Ok(None)
+            }
+            Watching::Settling { due } => {
+                if now >= due {
+                    if let Some(settle) = &mut self.settle {
+                        settle.spent += 1;
+                    }
+                    self.ask(out, now)?;
+                }
                 Ok(None)
             }
             Watching::Awaiting { deadline, replies } => {
                 if let Some(colors) = replies.resolve() {
-                    self.state = Watching::Idle;
+                    self.rest();
                     return Ok((self.last.replace(colors) != Some(colors)).then_some(colors));
                 }
-                if now >= *deadline {
-                    self.state = Watching::Idle;
+                if now >= deadline {
+                    self.rest();
                 }
                 Ok(None)
             }
@@ -167,7 +271,7 @@ pub(super) fn deadline(now: Instant, span: Duration) -> Instant {
 /// The watch, driven at instants the test names rather than at the clock's.
 #[cfg(test)]
 mod tests {
-    use super::{Duration, Instant, REQUERY, TerminalColors, Watch};
+    use super::{DEBOUNCE, Duration, IDLE, Instant, REQUERY, SETTLE, TerminalColors, Watch};
     use ratatui::style::Color;
     use termina::{
         Event, Parser,
@@ -196,15 +300,16 @@ mod tests {
                 let _fence = replies.absorb(&event);
             }
             let mut watched = Self::new();
-            watched.watch = Watch::new(replies.resolve());
+            watched.watch = Watch::new(replies.resolve(), watched.t0);
             watched
         }
 
         fn new() -> Self {
+            let t0 = Instant::now();
             Self {
-                watch: Watch::new(None),
+                watch: Watch::new(None, t0),
                 written: Vec::new(),
-                t0: Instant::now(),
+                t0,
             }
         }
 
@@ -243,8 +348,16 @@ mod tests {
     /// The reply to a re-query: the two colors, no verdict and no fence.
     const RETHEMED: &str = "\x1b]10;rgb:6565/7b7b/8383\x07\x1b]11;rgb:fdfd/f6f6/e3e3\x07";
 
+    /// The same shape of reply, carrying the dark colors a light re-theme
+    /// replaces.
+    const DARK: &str = "\x1b]10;rgb:c0c0/caca/f5f5\x07\x1b]11;rgb:1a1a/1b1b/2626\x07";
+
     /// A change notification. The value it carries is never read.
     const NOTIFIED: &str = "\x1b[?997;2n";
+
+    /// The window regaining focus, and losing it.
+    const FOCUSED: &str = "\x1b[I";
+    const UNFOCUSED: &str = "\x1b[O";
 
     #[test]
     fn a_watch_with_nothing_pending_asks_for_no_wait_and_writes_nothing() {
@@ -355,6 +468,75 @@ mod tests {
     }
 
     #[test]
+    fn focus_returning_to_the_window_asks_the_terminal_again() {
+        // The terminals that matter here report no change of their own: a
+        // desktop recoloured them from outside, or they have no mode 2031.
+        let mut watched = Watched::new();
+
+        watched.feed(0, FOCUSED);
+        assert_eq!(
+            watched.wake(0),
+            Some(Duration::from_millis(100)),
+            "the window opens, as it does for a notification"
+        );
+        watched.step(100);
+        assert_eq!(watched.requeries(), 1);
+
+        watched.feed(110, RETHEMED);
+        assert!(watched.step(110).is_some(), "and the answer is a theme");
+    }
+
+    #[test]
+    fn losing_focus_asks_the_terminal_nothing() {
+        let mut watched = Watched::new();
+
+        watched.feed(0, UNFOCUSED);
+
+        assert_eq!(watched.wake(0), None, "nothing is owed");
+        watched.step(100);
+        assert_eq!(watched.requeries(), 0);
+    }
+
+    #[test]
+    fn alt_tabbing_costs_one_re_query() {
+        // Focus arrives once per switch, and a user switching windows produces
+        // a burst of them.
+        let mut watched = Watched::new();
+
+        for arrival in [0, 5, 40, 80, 99] {
+            watched.feed(arrival, FOCUSED);
+        }
+        watched.step(100);
+
+        assert_eq!(watched.requeries(), 1, "the window collapsed all five");
+    }
+
+    #[test]
+    fn a_notification_and_a_focus_in_the_same_window_cost_one_re_query() {
+        let mut watched = Watched::new();
+
+        watched.feed(0, NOTIFIED);
+        watched.feed(20, FOCUSED);
+        watched.feed(60, NOTIFIED);
+        watched.step(100);
+
+        assert_eq!(watched.requeries(), 1);
+    }
+
+    #[test]
+    fn focus_on_a_terminal_that_did_not_change_costs_nothing_but_the_round_trip() {
+        // Alt-tabbing back and forth is free: the colors answer for themselves.
+        let mut watched = Watched::started_from(RETHEMED);
+
+        watched.feed(0, FOCUSED);
+        watched.step(100);
+        watched.feed(110, RETHEMED);
+
+        assert_eq!(watched.step(110), None, "nothing moved, so nothing is news");
+        assert_eq!(watched.requeries(), 1);
+    }
+
+    #[test]
     fn a_burst_of_notifications_costs_exactly_one_re_query() {
         // Terminals send one per palette slot, or one per transition step.
         let mut watched = Watched::new();
@@ -402,7 +584,11 @@ mod tests {
             }),
             "a re-query asks for colors alone, so it brings back no verdict"
         );
-        assert_eq!(watched.wake(120), None, "and the watch is idle again");
+        assert_eq!(
+            watched.wake(120),
+            Some(Duration::from_millis(880)),
+            "and what is still owed is the re-ask a second after the trigger"
+        );
     }
 
     #[test]
@@ -424,9 +610,20 @@ mod tests {
             "the terminal stopped answering, and the colors on screen stand"
         );
         assert_eq!(
-            watched.wake(1_200),
+            watched.requeries(),
+            1,
+            "the exchange was let go rather than retried inside its own wait"
+        );
+
+        // The re-ask the trigger owed goes out on its own schedule, and starts
+        // from nothing.
+        watched.step(1_200);
+        assert_eq!(watched.requeries(), 2);
+        watched.feed(1_210, "\x1b]10;rgb:6565/7b7b/8383\x07");
+        assert_eq!(
+            watched.step(1_210),
             None,
-            "the watch let it go rather than waiting on it forever"
+            "the half collected before the wait ran out went with it"
         );
     }
 
@@ -440,8 +637,25 @@ mod tests {
         assert_eq!(watched.step(1_099), None, "still inside the wait");
         assert!(watched.wake(1_099).is_some());
         assert_eq!(watched.step(1_100), None);
-        assert_eq!(watched.wake(1_100), None, "one second after the re-query");
-        assert_eq!(watched.requeries(), 1, "and it was not retried");
+        assert_eq!(
+            watched.requeries(),
+            1,
+            "one second after the re-query it is let go, never retried inside \
+             its own wait"
+        );
+
+        // The sequence the trigger opened runs its course against the silence,
+        // and each re-ask costs the same one bounded wait.
+        for at in [1_100, 2_100, 3_000, 4_000] {
+            watched.step(at);
+        }
+
+        assert_eq!(watched.requeries(), 3, "the trigger's, and its two re-asks");
+        assert_eq!(
+            watched.wake(4_000),
+            None,
+            "and then a terminal that says nothing is left alone"
+        );
     }
 
     #[test]
@@ -483,6 +697,295 @@ mod tests {
             watched.step(230),
             None,
             "the pre-flip half was dropped with the state it described"
+        );
+    }
+
+    #[test]
+    fn a_focus_mid_exchange_starts_over_rather_than_mixing_answers() {
+        // Focus and a notification share one arm, so what a second notification
+        // does to a half-collected answer, focus does too.
+        let mut watched = Watched::new();
+
+        watched.feed(0, NOTIFIED);
+        watched.step(100);
+        // Half the answer to the first re-query, and then the window comes back.
+        watched.feed(110, "\x1b]11;rgb:1a1a/1b1b/2626\x07");
+        watched.feed(120, FOCUSED);
+
+        assert_eq!(watched.step(120), None, "the window is open again");
+        assert_eq!(watched.step(220), None, "and a second re-query goes out");
+        assert_eq!(watched.requeries(), 2);
+
+        // Only one color arrives this time. If the discarded half had been kept
+        // it would complete a theme out of two different terminals.
+        watched.feed(230, "\x1b]10;rgb:6565/7b7b/8383\x07");
+        assert_eq!(
+            watched.step(230),
+            None,
+            "the pre-focus half was dropped with the state it described"
+        );
+    }
+
+    #[test]
+    fn a_trigger_asks_again_a_second_later_and_three_seconds_later() {
+        let mut watched = Watched::started_from(DARK);
+
+        watched.feed(0, NOTIFIED);
+        watched.step(100);
+        watched.feed(110, DARK);
+        watched.step(110);
+        assert_eq!(watched.requeries(), 1, "the trigger's own round trip");
+
+        assert_eq!(
+            watched.wake(110),
+            Some(Duration::from_millis(890)),
+            "the host is asked back for the first re-ask, a second after the \
+             trigger"
+        );
+        watched.step(999);
+        assert_eq!(watched.requeries(), 1, "still inside the first second");
+        watched.step(1_000);
+        assert_eq!(watched.requeries(), 2);
+
+        watched.feed(1_010, DARK);
+        watched.step(1_010);
+        watched.step(2_999);
+        assert_eq!(watched.requeries(), 2, "still inside the third second");
+        watched.step(3_000);
+        assert_eq!(watched.requeries(), 3, "and the last re-ask goes out");
+    }
+
+    #[test]
+    fn the_watch_rests_once_the_settle_sequence_is_spent() {
+        let mut watched = Watched::started_from(DARK);
+
+        watched.feed(0, NOTIFIED);
+        for (asked, answered) in [(100, 110), (1_000, 1_010), (3_000, 3_010)] {
+            watched.step(asked);
+            watched.feed(answered, DARK);
+            watched.step(answered);
+        }
+
+        assert_eq!(watched.requeries(), 3, "the trigger's, and its two re-asks");
+        assert_eq!(
+            watched.wake(3_010),
+            None,
+            "the sequence is spent, and the wait is the app's again"
+        );
+        watched.step(60_000);
+        assert_eq!(watched.requeries(), 3, "nothing goes out after it rests");
+    }
+
+    #[test]
+    fn a_settle_re_ask_that_lands_on_the_colours_already_showing_says_nothing() {
+        // Alt-tabbing back to a terminal nobody touched costs three round trips
+        // and no frame.
+        let mut watched = Watched::started_from(DARK);
+
+        watched.feed(0, FOCUSED);
+        for (asked, answered) in [(100, 110), (1_000, 1_010), (3_000, 3_010)] {
+            watched.step(asked);
+            watched.feed(answered, DARK);
+            assert_eq!(
+                watched.step(answered),
+                None,
+                "nothing moved at {answered} ms, so nothing is news"
+            );
+        }
+
+        assert_eq!(
+            watched.requeries(),
+            3,
+            "and each of the three round trips happened: silence here is the \
+             answer being the same, not the asking being skipped"
+        );
+    }
+
+    #[test]
+    fn a_recolour_that_starts_as_the_trigger_fires_is_caught_by_the_settle() {
+        // The selector overlay closes, focus comes back, and the desktop's
+        // re-theme script starts at that same instant: the first round trip
+        // reads the colors it is in the middle of replacing.
+        let mut watched = Watched::started_from(DARK);
+
+        watched.feed(0, FOCUSED);
+        watched.step(100);
+        watched.feed(110, DARK);
+        assert_eq!(
+            watched.step(110),
+            None,
+            "the terminal has not repainted yet, so its answer is the old one"
+        );
+
+        // The recolour lands eight hundred milliseconds later, unannounced.
+        watched.step(1_000);
+        watched.feed(1_010, RETHEMED);
+
+        assert!(
+            watched.step(1_010).is_some(),
+            "the re-ask a second after the trigger is what reaches it"
+        );
+        assert_eq!(watched.requeries(), 2);
+    }
+
+    #[test]
+    fn a_fresh_trigger_during_a_settle_sequence_starts_the_sequence_over() {
+        let mut watched = Watched::started_from(DARK);
+
+        watched.feed(0, NOTIFIED);
+        watched.step(100);
+        watched.feed(110, DARK);
+        watched.step(110);
+
+        // A second flip while the first sequence is waiting out its re-ask.
+        watched.feed(500, NOTIFIED);
+        watched.step(600);
+        watched.feed(610, DARK);
+        watched.step(610);
+        assert_eq!(watched.requeries(), 2, "the new trigger's own round trip");
+
+        watched.step(1_000);
+        assert_eq!(
+            watched.requeries(),
+            2,
+            "the first sequence went with the trigger it belonged to"
+        );
+        watched.step(1_500);
+        assert_eq!(
+            watched.requeries(),
+            3,
+            "and the re-asks are measured from the trigger that is current"
+        );
+        watched.feed(1_510, DARK);
+        watched.step(1_510);
+        watched.step(3_000);
+        assert_eq!(watched.requeries(), 3, "still the new sequence's schedule");
+        watched.step(3_500);
+        assert_eq!(watched.requeries(), 4);
+    }
+
+    #[test]
+    fn five_triggers_inside_one_window_cost_one_settle_sequence() {
+        // A user switching windows produces a burst of focus events, and the
+        // whole burst is one return to one terminal.
+        let mut watched = Watched::started_from(DARK);
+
+        for arrival in [0, 5, 40, 80, 99] {
+            watched.feed(arrival, FOCUSED);
+        }
+        for (asked, answered) in [(100, 110), (1_000, 1_010), (3_000, 3_010)] {
+            watched.step(asked);
+            watched.feed(answered, DARK);
+            watched.step(answered);
+        }
+
+        assert_eq!(
+            watched.requeries(),
+            3,
+            "one round trip and one pair of re-asks, not five of each"
+        );
+        assert_eq!(watched.wake(3_010), None, "and then it rests");
+    }
+
+    #[test]
+    fn typing_after_a_long_quiet_asks_the_terminal_again() {
+        // The compositors that recolour a window without giving it a focus
+        // event leave the user's return as the only signal there is.
+        let mut brief = Watched::new();
+        brief.feed(4_900, "q");
+
+        assert_eq!(
+            brief.wake(4_900),
+            None,
+            "four and nine tenths of a second is a pause inside one sitting"
+        );
+
+        let mut long = Watched::new();
+        long.feed(5_100, "q");
+
+        assert_eq!(
+            long.wake(5_100),
+            Some(DEBOUNCE),
+            "five and a tenth places the user somewhere else, and coming back \
+             opens the same window a notification does"
+        );
+        long.step(5_200);
+        assert_eq!(long.requeries(), 1);
+        long.feed(5_210, RETHEMED);
+        assert!(
+            long.step(5_210).is_some(),
+            "and the colors it brings back are a theme like any other"
+        );
+    }
+
+    #[test]
+    fn typing_through_a_session_asks_the_terminal_nothing() {
+        let mut watched = Watched::new();
+
+        for arrival in [0, 3_000, 6_000, 9_000, 12_000] {
+            watched.feed(arrival, "q");
+        }
+
+        assert_eq!(
+            watched.wake(12_000),
+            None,
+            "no gap in twelve seconds of use was a quiet one"
+        );
+        watched.step(12_100);
+        assert_eq!(watched.requeries(), 0);
+    }
+
+    #[test]
+    fn a_session_nobody_is_using_costs_no_wake_up_at_all() {
+        // The quiet is measured on an event that arrived, so an idle session
+        // asks the host for no deadline and the host blocks.
+        let watched = Watched::new();
+
+        assert_eq!(watched.wake(60_000), None, "a minute in, nothing is owed");
+    }
+
+    #[test]
+    fn a_terminals_own_answer_after_a_long_quiet_is_the_terminal_talking() {
+        // A stray report is not the user coming back to the window.
+        let mut watched = Watched::new();
+
+        watched.feed(9_000, "\x1b[?62;1;6c");
+
+        assert_eq!(watched.wake(9_000), None, "nothing is owed");
+        watched.step(9_100);
+        assert_eq!(watched.requeries(), 0);
+    }
+
+    #[test]
+    fn a_quiet_spell_during_a_settle_sequence_opens_no_window_of_its_own() {
+        // Every re-ask lands inside the gap it would take to open a quiet
+        // spell, so the state below is reached by naming it: what it pins is
+        // that the input trigger answers to the resting state alone.
+        assert!(
+            SETTLE.iter().all(|span| *span < IDLE),
+            "a settle sequence runs shorter than a quiet spell: {SETTLE:?}"
+        );
+
+        let mut watched = Watched::started_from(DARK);
+        watched.feed(0, NOTIFIED);
+        watched.step(100);
+        watched.feed(110, DARK);
+        watched.step(110);
+
+        watched.watch.seen = watched.at(0);
+        watched.feed(6_000, "q");
+
+        assert_eq!(
+            watched.wake(6_000),
+            Some(Duration::ZERO),
+            "the re-ask the trigger still owes is the only deadline, and it is \
+             already due"
+        );
+        watched.step(6_000);
+        assert_eq!(
+            watched.requeries(),
+            2,
+            "the sequence asked once, on its own schedule"
         );
     }
 

--- a/docs/docs/concepts/host-integration.md
+++ b/docs/docs/concepts/host-integration.md
@@ -59,7 +59,10 @@ drawing you already write.
 ### Opening adaptively
 
 `.adaptive()` makes a session follow the terminal. It asks the terminal what
-colors it uses while opening and subscribes to changes if it answered.
+colors it uses while opening, subscribes to changes it reports, and asks again
+when the window regains focus, shortly after every change signal, and when input
+resumes after a pause — which is how a change reaches an app whose terminal was
+recoloured from outside, or has no change notification to send.
 `session.theme()` is what that answer becomes, falling back to
 `Theme::default_dark()` where the terminal keeps quiet;
 `session.theme_with_fallback(fallback)` uses a preset of the app's own as that


### PR DESCRIPTION
Fixes live re-theming in the real world. The mode-2031 notification an adaptive session subscribes to is the precise signal — but foot only sends it for its own dark/light config switch, omarchy re-themes running terminals by injecting OSC sets into ptys (silent by spec), and alacritty has no 2031 at all. So the session now asks the terminal again on three occasions, all feeding the one existing debounce/requery/change-detection machinery:

1. **When the window regains focus** (focus reporting joins the adaptive session's modes).
2. **Shortly after every change signal** — a settle sequence re-asks at +1s and +3s, which catches the common race where focus returns just as the desktop's re-theme script starts, so the first requery reads the colors being replaced.
3. **When input resumes after a pause** — the first input event after 5 quiet seconds counts as the user coming back, covering overlays that produce no terminal focus events, SSH sessions, and terminals with no notification to send. Pure timestamp comparison: an idle session still never wakes.

An unchanged answer stays silent (no event, no frame), repeated triggers coalesce (twelve alt-tabs cost four bounded round trips and zero repaints), and a static session gains none of this — no focus tracking, no queries, nothing.

Verified end-to-end under pty with a decisive A/B: the theme-selector reproducer (focus returns → old colors answered → recolor lands 800ms later → the settle requery catches it, exactly one theme change) and the no-focus-events variant both fail before this change and pass after, while the full regression matrix is identical on both sides. Suite at 580 lib tests.