### PR TITLE
ScrollArea: controlled vertical scrolling with focus-safe viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `ScrollArea`, with `ScrollAreaChange` and `ScrollAreaStyle`: a vertical
+  viewport for arbitrary interactive descendants. Paint and pointer input are
+  clipped to the visible rows while descendants keep their full logical
+  allocations, and focus landing on a clipped descendant scrolls it into view.
+- `DeclareCtx::viewport`, the runtime mechanism behind `ScrollArea`, and
+  `Component::reveal_in_viewport`, which the runtime calls on the component
+  that declared a viewport when focus lands on a descendant it clips.
+- `DeclareCtx::pointer_within_area`, `pointer_within` narrowed to the
+  declaration's own rectangle.
 - `terminal::Session` (feature `termina`) opens the terminal — raw mode, the
   alternate screen, the input modes you ask for — and restores every one on any
   exit, panic included. `Session::next` is the event source.
@@ -138,6 +147,9 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Breaking:** `MouseEvent` coordinates and `DragPhase` positions are in the
+  coordinate space the receiving component was declared with, matching
+  `EventCtx::area`. Outside a viewport that is the screen.
 - **Breaking:** the direction-named shift constant pairs collapse into
   `color::FOCUS_SHIFT`, `HOVER_SHIFT`, `FIELD_FOCUS_SHIFT`, and
   `FIELD_HOVER_SHIFT` — the direction now comes from the theme.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,6 +1425,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll-area"
+version = "0.0.1"
+dependencies = [
+ "ratatui",
+ "ratcn",
+ "ratzilla",
+ "shared",
+]
+
+[[package]]
 name = "select"
 version = "0.0.1"
 dependencies = [

--- a/README.md
+++ b/README.md
@@ -16,12 +16,10 @@ it:
 - **There is no install command.** The shadcn resemblance is in how the code is
   structured, not yet in tooling. Copying a component into your project is a
   manual file copy today. A CLI is intended, but it does not exist.
-- **The component set is small and growing.** Eight components ship today:
-  `Button`, `List`, `Select`, `Tabs`, `Dialog`, `Toast`, `BarChart`, and
-  `Tooltip`. Notably missing and planned next are **text input**, **multi-line
-  text area**, and a **scroll area** for content taller than its viewport.
-  Input and TextArea existed in an earlier preview and were withdrawn pending
-  upstream fixes in the text-editing crate they wrap.
+- **The component set is small and growing.** Nine components ship today:
+  `Button`, `List`, `Select`, `Tabs`, `Dialog`, `Toast`, `BarChart`, `Tooltip`,
+  and `ScrollArea`. Notably missing and planned next are **text input** and a
+  **multi-line text area**.
 
 If you want specific components, patterns, or features, please
 [open an issue](https://github.com/kristoferlund/ratcn/issues).

--- a/crates/copy-fixture/src/bin/scroll_area.rs
+++ b/crates/copy-fixture/src/bin/scroll_area.rs
@@ -1,0 +1,4 @@
+// One component module, copied at build time and compiled alone. See build.rs.
+include!(concat!(env!("OUT_DIR"), "/", env!("CARGO_BIN_NAME"), ".rs"));
+
+fn main() {}

--- a/crates/ratcn/src/components/mod.rs
+++ b/crates/ratcn/src/components/mod.rs
@@ -7,7 +7,8 @@
 //!
 //! Interactive components (focusable, event-handling): [`Button`](crate::Button),
 //! [`List`](crate::List), [`Select`](crate::Select), [`Tabs`](crate::Tabs),
-//! [`Dialog`](crate::Dialog). Event-handling but never focusable:
+//! [`Dialog`](crate::Dialog), and [`ScrollArea`](crate::ScrollArea).
+//! Event-handling but never focusable:
 //! [`Tooltip`](crate::Tooltip), which explains the trigger it wraps rather than
 //! acting itself. Paint-only, with no interactive half:
 //! [`ToasterWidget`](crate::ToasterWidget), and
@@ -119,6 +120,7 @@ pub(crate) mod barchart;
 pub(crate) mod button;
 pub(crate) mod dialog;
 pub(crate) mod list;
+pub(crate) mod scroll_area;
 pub(crate) mod select;
 pub(crate) mod tabs;
 pub(crate) mod toast;

--- a/crates/ratcn/src/components/scroll_area.rs
+++ b/crates/ratcn/src/components/scroll_area.rs
@@ -1,0 +1,1858 @@
+//! A vertical viewport for arbitrary interactive ratcn descendants.
+//!
+//! Descendants are declared against their full logical content allocations.
+//! The runtime translates and clips ordinary paint and pointer input without
+//! changing those allocations, while keeping offscreen descendants in focus
+//! traversal. Popup, hint, modal, and deferred paint escape the ordinary clip.
+
+use ratatui::{
+    layout::Rect,
+    style::{Color, Style},
+    widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState},
+};
+
+use crate::Theme;
+use crate::runtime::{
+    Component, DeclareCtx, Event, EventCtx, EventResult, KeyCode, MouseKind, ScopeOptions,
+    ScrollDirection,
+};
+use crate::theme::resolve_style;
+
+const WHEEL_ROWS: u16 = 3;
+
+/// Every color a [`ScrollArea`] scrollbar paints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScrollAreaStyle {
+    /// Scrollbar thumb color.
+    pub thumb: Color,
+    /// Scrollbar track color.
+    pub track: Color,
+}
+
+impl ScrollAreaStyle {
+    /// A neutral style using plain ANSI colors.
+    #[must_use]
+    pub const fn fallback() -> Self {
+        Self {
+            thumb: Color::White,
+            track: Color::DarkGray,
+        }
+    }
+
+    /// Derive the thumb and track from `theme`.
+    #[must_use]
+    pub const fn from_theme(theme: &Theme) -> Self {
+        Self {
+            thumb: theme.primary,
+            track: theme.border,
+        }
+    }
+}
+
+/// A scroll position [`ScrollArea`] asks a bound app to store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollAreaChange {
+    /// The requested first visible content row.
+    ScrollTo(u16),
+}
+
+/// Where the wheel, a key, or a reveal left the view.
+///
+/// Event handling writes it and the next declaration reads it, which is what
+/// lets an unbound area scroll at all and what carries a reveal into the frame
+/// that follows a focus change.
+///
+/// `base` is the bound offset the hold was taken against, and `held` is what
+/// makes releasing permanent: the declaration drops the hold for good the
+/// moment a bound offset moves away from `base`, so an app that scrolls its own
+/// area keeps it, and returning to the offset the hold was taken at cannot
+/// revive it.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct ScrollPark {
+    offset: u16,
+    held: bool,
+    base: Option<u16>,
+}
+
+type ReadOffsetFn<S> = Box<dyn Fn(&S) -> u16>;
+type OnChangeFn<M> = Box<dyn Fn(ScrollAreaChange) -> M>;
+type ContentFn<S, M> = Box<dyn FnOnce(&mut DeclareCtx<'_, S, M>)>;
+type StyleFn = Box<dyn Fn(&Theme) -> ScrollAreaStyle>;
+
+/// A vertical viewport that hosts arbitrary interactive ratcn descendants.
+///
+/// One column is reserved at the right for the scrollbar. The
+/// [`content`](Self::content) closure receives the remaining width and exactly
+/// `content_height` logical rows, however many of them are visible. The
+/// scrollbar is an indicator of where the view sits.
+///
+/// The offset is the area's own until [`offset`](Self::offset) binds it. Wheel,
+/// Page Up, Page Down, Home, and End reach descendants first; what none of them
+/// handles scrolls the area. An event that leaves the offset where it is — every
+/// one of these keys at an edge, and a horizontal wheel — bubbles on to the app,
+/// which keeps app hotkeys on those keys alive. The area is a fallback focus
+/// stop while it holds no focusable descendant, so keyboard scrolling works for
+/// paint-only content.
+///
+/// Focus moving to a descendant the viewport clips scrolls that descendant
+/// into view.
+///
+/// # Panics
+///
+/// A `ScrollArea` inside another `ScrollArea` panics, as does content larger
+/// than 262,144 cells.
+///
+/// ```
+/// # use ratatui::layout::Rect;
+/// # use ratcn::runtime::DeclareCtx;
+/// # use ratcn::{Button, ScrollArea};
+/// # struct State;
+/// # enum Msg { Saved }
+/// # fn declare(ctx: &mut DeclareCtx<'_, State, Msg>) {
+/// ctx.component(
+///     "settings",
+///     ScrollArea::new(40).content(|ctx| {
+///         ctx.component(
+///             "save",
+///             Button::new("Save").on_press(|| Msg::Saved),
+///             Rect::new(0, 0, 10, 3),
+///         );
+///     }),
+///     Rect::new(0, 0, 30, 10),
+/// );
+/// # }
+/// ```
+pub struct ScrollArea<S, M> {
+    content_height: u16,
+    read_offset: Option<ReadOffsetFn<S>>,
+    on_change: Option<OnChangeFn<M>>,
+    content: Option<ContentFn<S, M>>,
+    style: Option<StyleFn>,
+    hover_focus: bool,
+}
+
+impl<S, M> std::fmt::Debug for ScrollArea<S, M> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScrollArea")
+            .field("content_height", &self.content_height)
+            .field("content", &self.content.is_some())
+            .field("hover_focus", &self.hover_focus)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S, M> ScrollArea<S, M> {
+    /// A viewport over `content_height` logical rows.
+    #[must_use]
+    pub fn new(content_height: u16) -> Self {
+        Self {
+            content_height,
+            read_offset: None,
+            on_change: None,
+            content: None,
+            style: None,
+            hover_focus: false,
+        }
+    }
+
+    /// Bind the first visible content row to app state.
+    ///
+    /// `read` is consulted for every event, so repeated wheel or page events
+    /// compose before a redraw, and `on_change` carries each new offset to the
+    /// app's update. Left unbound, the area keeps the offset itself and emits
+    /// nothing.
+    ///
+    /// A reveal moves the view on its own, without a message; the next offset
+    /// the area emits starts from where the reveal left it.
+    #[must_use]
+    pub fn offset(
+        mut self,
+        read: impl Fn(&S) -> u16 + 'static,
+        on_change: impl Fn(ScrollAreaChange) -> M + 'static,
+    ) -> Self {
+        self.read_offset = Some(Box::new(read));
+        self.on_change = Some(Box::new(on_change));
+        self
+    }
+
+    /// Declare the viewport's descendants in their full logical content area.
+    #[must_use]
+    pub fn content(mut self, content: impl FnOnce(&mut DeclareCtx<'_, S, M>) + 'static) -> Self {
+        self.content = Some(Box::new(content));
+        self
+    }
+
+    /// Replace the theme-derived scrollbar style.
+    #[must_use]
+    pub fn style(mut self, style: impl Fn(&Theme) -> ScrollAreaStyle + 'static) -> Self {
+        self.style = Some(Box::new(style));
+        self
+    }
+
+    /// Make pointer motion choose between the content's direct child scopes.
+    ///
+    /// This is opt-in so ordinary scrollable forms leave keyboard focus alone
+    /// when the pointer drifts. It suits a scrollable pane or tile grid whose
+    /// direct children are the regions focus should follow.
+    #[must_use]
+    pub const fn hover_focus(mut self) -> Self {
+        self.hover_focus = true;
+        self
+    }
+
+    /// The visible content rectangle inside `area`: everything but the
+    /// scrollbar gutter.
+    fn viewport(area: Rect) -> Rect {
+        Rect::new(area.x, area.y, area.width.saturating_sub(1), area.height)
+    }
+
+    fn max_offset(&self, area: Rect) -> u16 {
+        self.content_height
+            .saturating_sub(Self::viewport(area).height)
+    }
+
+    fn bound_offset(&self, state: &S) -> Option<u16> {
+        self.read_offset.as_ref().map(|read| read(state))
+    }
+
+    /// The offset in force: a standing hold, or the bound value.
+    fn resolve(&self, area: Rect, bound: Option<u16>, park: ScrollPark) -> u16 {
+        let offset = if park.held && park.base == bound {
+            park.offset
+        } else {
+            bound.unwrap_or(0)
+        };
+        offset.min(self.max_offset(area))
+    }
+
+    /// Release a hold the app has scrolled out from under, and answer with the
+    /// offset this declaration lays out from.
+    ///
+    /// Releasing happens here, once per frame, because the declaration is
+    /// where a bound offset is read; and it is permanent, so an app that
+    /// returns to the offset a hold was taken at does not revive it.
+    fn settle(&self, ctx: &mut DeclareCtx<'_, S, M>, area: Rect, bound: Option<u16>) -> u16 {
+        let mut unheld = ScrollPark::default();
+        let park = ctx.transient_mut::<ScrollPark>().unwrap_or(&mut unheld);
+        if park.held && park.base != bound {
+            *park = ScrollPark::default();
+        }
+        self.resolve(area, bound, *park)
+    }
+
+    /// The offset in force at event time.
+    fn current(&self, state: &S, ctx: &mut EventCtx<'_>) -> u16 {
+        let park = *ctx.transient::<ScrollPark>();
+        self.resolve(ctx.area(), self.bound_offset(state), park)
+    }
+
+    /// Hold the view at `offset` for the coming declaration, and report the
+    /// offset taken. `None` when the view is already there.
+    fn park(&self, offset: u16, state: &S, ctx: &mut EventCtx<'_>) -> Option<u16> {
+        let area = ctx.area();
+        let bound = self.bound_offset(state);
+        let current = self.current(state, ctx);
+        let offset = offset.min(self.max_offset(area));
+        if offset == current {
+            return None;
+        }
+        *ctx.transient::<ScrollPark>() = ScrollPark {
+            offset,
+            held: true,
+            base: bound,
+        };
+        Some(offset)
+    }
+
+    /// Scroll to `offset`.
+    ///
+    /// [`EventResult::Ignored`] when the view is already there, which leaves an
+    /// app hotkey on Home, End, or a page key working while focus rests in an
+    /// area with nothing to scroll.
+    fn scroll_to(&self, offset: u16, state: &S, ctx: &mut EventCtx<'_>) -> EventResult<M> {
+        let Some(offset) = self.park(offset, state, ctx) else {
+            return EventResult::Ignored;
+        };
+        match &self.on_change {
+            Some(on_change) => EventResult::Emit(on_change(ScrollAreaChange::ScrollTo(offset))),
+            None => EventResult::Consumed,
+        }
+    }
+
+    /// The smallest offset change that puts `target` on screen.
+    fn reveal_offset(&self, target: Rect, area: Rect, current: u16) -> u16 {
+        let viewport = Self::viewport(area);
+        let visible_top = viewport.y.saturating_add(current);
+        let visible_bottom = visible_top.saturating_add(viewport.height);
+        let requested = if target.height > viewport.height || target.y < visible_top {
+            target.y.saturating_sub(viewport.y)
+        } else if target.bottom() > visible_bottom {
+            target
+                .bottom()
+                .saturating_sub(viewport.height)
+                .saturating_sub(viewport.y)
+        } else {
+            current
+        };
+        requested.min(self.max_offset(area))
+    }
+}
+
+impl<S: 'static, M: 'static> Component<S, M> for ScrollArea<S, M> {
+    fn declare(&mut self, ctx: &mut DeclareCtx<'_, S, M>) {
+        let area = ctx.area();
+        let viewport = Self::viewport(area);
+        let bound = self.bound_offset(ctx.state());
+        let offset = self.settle(ctx, area, bound);
+        let content = self.content.take();
+        ctx.viewport(viewport, self.content_height, offset, |ctx| {
+            if let Some(content) = content {
+                content(ctx);
+            }
+        });
+
+        if self.content_height <= viewport.height || area.width == 0 || area.height == 0 {
+            return;
+        }
+        let gutter = Rect::new(area.right().saturating_sub(1), area.y, 1, area.height);
+        let style = resolve_style(
+            self.style.as_deref(),
+            ctx.theme,
+            ScrollAreaStyle::from_theme,
+        );
+        let viewport_height = viewport.height;
+        // Ratatui 0.3.2 defines `content_length - 1` as the maximum
+        // scrollbar position. ScrollArea positions are row offsets, so the
+        // count is the inclusive offset range, not the total row count.
+        let position_count = self
+            .content_height
+            .saturating_sub(viewport_height)
+            .saturating_add(1);
+        ctx.paint(move |ctx| {
+            let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(None)
+                .end_symbol(None)
+                .thumb_style(Style::new().fg(style.thumb))
+                .track_style(Style::new().fg(style.track));
+            let mut state = ScrollbarState::new(usize::from(position_count))
+                .position(usize::from(offset))
+                .viewport_content_length(usize::from(viewport_height));
+            ctx.stateful_widget(scrollbar, gutter, &mut state);
+        });
+    }
+
+    fn handle_event(&mut self, event: &Event, state: &S, ctx: &mut EventCtx<'_>) -> EventResult<M> {
+        let area = ctx.area();
+        let current = self.current(state, ctx);
+        let page = Self::viewport(area).height;
+        let target = match event {
+            Event::Mouse(mouse) => match mouse.kind {
+                MouseKind::Scroll(ScrollDirection::Up) => current.saturating_sub(WHEEL_ROWS),
+                MouseKind::Scroll(ScrollDirection::Down) => current.saturating_add(WHEEL_ROWS),
+                _ => return EventResult::Ignored,
+            },
+            Event::Key(key) if !key.modifiers.any() => match key.code {
+                KeyCode::PageUp => current.saturating_sub(page),
+                KeyCode::PageDown => current.saturating_add(page),
+                KeyCode::Home => 0,
+                KeyCode::End => self.max_offset(area),
+                _ => return EventResult::Ignored,
+            },
+            _ => return EventResult::Ignored,
+        };
+        self.scroll_to(target, state, ctx)
+    }
+
+    fn reveal_in_viewport(&mut self, target: Rect, state: &S, ctx: &mut EventCtx<'_>) {
+        let area = ctx.area();
+        let current = self.current(state, ctx);
+        self.park(self.reveal_offset(target, area, current), state, ctx);
+    }
+
+    fn scope_options(&self) -> ScopeOptions {
+        let options = ScopeOptions::default().focusable();
+        if self.hover_focus {
+            options.hover_focus()
+        } else {
+            options
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        cell::Cell,
+        panic::{AssertUnwindSafe, catch_unwind},
+        rc::Rc,
+    };
+
+    use ratatui::{
+        Terminal,
+        backend::TestBackend,
+        text::Text,
+        widgets::{Block, Paragraph},
+    };
+
+    use super::*;
+    use crate::runtime::{
+        ChildId, FocusState, KeyChord, KeyEvent, Modifiers, MouseButton, MouseEvent, PopupOptions,
+        Ratcn,
+    };
+    use crate::{Button, ListItem, Select, Tooltip};
+
+    #[derive(Default)]
+    struct State {
+        focus: FocusState,
+        offset: u16,
+        select_open: bool,
+        select_cursor: Option<&'static str>,
+        selected: Option<&'static str>,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    enum Msg {
+        Area(ScrollAreaChange),
+        Focus(FocusState),
+        Pressed(&'static str),
+        ChildHandled,
+        SelectOpen(bool),
+        SelectFocused(&'static str),
+        Selected(&'static str),
+        Escape,
+        ModalClosed,
+    }
+
+    struct Driver {
+        terminal: Terminal<TestBackend>,
+        ratcn: Ratcn<State, Msg>,
+    }
+
+    impl Driver {
+        fn new(width: u16, height: u16) -> Self {
+            Self {
+                terminal: Terminal::new(TestBackend::new(width, height)).expect("terminal"),
+                ratcn: Ratcn::new().focus(|state: &State| &state.focus, Msg::Focus),
+            }
+        }
+
+        fn render(&mut self, state: &State, declare: impl FnOnce(&mut DeclareCtx<'_, State, Msg>)) {
+            let theme = Theme::default_dark();
+            self.terminal
+                .draw(|frame| self.ratcn.render(frame, state, &theme, declare))
+                .expect("draw");
+        }
+
+        fn event(&mut self, event: Event, state: &State) -> EventResult<Msg> {
+            self.ratcn.handle_event(event, state)
+        }
+
+        fn row(&self, row: u16) -> String {
+            let buffer = self.terminal.backend().buffer();
+            (0..buffer.area.width)
+                .map(|column| buffer.cell((column, row)).expect("cell").symbol())
+                .collect()
+        }
+    }
+
+    fn scroll_area(
+        content_height: u16,
+        content: impl FnOnce(&mut DeclareCtx<'_, State, Msg>) + 'static,
+    ) -> ScrollArea<State, Msg> {
+        ScrollArea::new(content_height)
+            .offset(|state: &State| state.offset, Msg::Area)
+            .content(content)
+    }
+
+    fn key(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code))
+    }
+
+    fn mouse(kind: MouseKind, column: u16, row: u16) -> Event {
+        Event::Mouse(MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: Modifiers::NONE,
+        })
+    }
+
+    #[derive(Debug)]
+    struct Probe {
+        name: &'static str,
+        focusable: bool,
+        handle_page_down: bool,
+    }
+
+    impl Probe {
+        const fn focusable(name: &'static str) -> Self {
+            Self {
+                name,
+                focusable: true,
+                handle_page_down: false,
+            }
+        }
+
+        const fn page_sink(name: &'static str) -> Self {
+            Self {
+                name,
+                focusable: true,
+                handle_page_down: true,
+            }
+        }
+    }
+
+    impl Component<State, Msg> for Probe {
+        fn declare(&mut self, _ctx: &mut DeclareCtx<'_, State, Msg>) {}
+
+        fn paint(&mut self, ctx: &mut crate::runtime::PaintCtx<'_, '_, State>) {
+            ctx.widget(Paragraph::new(self.name), ctx.area());
+        }
+
+        fn handle_event(
+            &mut self,
+            event: &Event,
+            _state: &State,
+            _ctx: &mut EventCtx<'_>,
+        ) -> EventResult<Msg> {
+            match event {
+                Event::Key(key)
+                    if self.handle_page_down
+                        && key.code == KeyCode::PageDown
+                        && !key.modifiers.any() =>
+                {
+                    EventResult::Emit(Msg::ChildHandled)
+                }
+                Event::Mouse(mouse) if mouse.kind == MouseKind::Click(MouseButton::Left) => {
+                    EventResult::Emit(Msg::Pressed(self.name))
+                }
+                _ => EventResult::Ignored,
+            }
+        }
+
+        fn is_focusable(&self, _state: &State) -> bool {
+            self.focusable
+        }
+    }
+
+    #[test]
+    fn ordinary_paint_uses_full_logical_allocation_then_translates_and_clips() {
+        let mut driver = Driver::new(8, 5);
+        let state = State {
+            offset: 2,
+            ..State::default()
+        };
+        driver.render(&state, |ctx| {
+            ctx.component(
+                "scroll",
+                scroll_area(6, |ctx| {
+                    let area = ctx.area();
+                    ctx.paint_widget(
+                        Paragraph::new(Text::from("00000\n11111\n22222\n33333\n44444\n55555")),
+                        area,
+                    );
+                }),
+                Rect::new(1, 1, 6, 3),
+            );
+        });
+
+        assert_eq!(&driver.row(1)[1..6], "22222");
+        assert_eq!(&driver.row(2)[1..6], "33333");
+        assert_eq!(&driver.row(3)[1..6], "44444");
+        for (column, row) in [(0, 1), (7, 1), (1, 0), (1, 4)] {
+            assert_eq!(
+                driver
+                    .terminal
+                    .backend()
+                    .buffer()
+                    .cell((column, row))
+                    .expect("outside cell")
+                    .symbol(),
+                " ",
+                "viewport paint escaped at ({column}, {row})"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_and_sparse_viewports_preserve_earlier_frame_cells() {
+        for sparse in [false, true] {
+            let mut driver = Driver::new(6, 2);
+            let state = State::default();
+            driver.render(&state, move |ctx| {
+                ctx.paint_widget(
+                    Paragraph::new("ABCDE\nFGHIJ").style(Style::new().bg(Color::Red)),
+                    Rect::new(0, 0, 5, 2),
+                );
+                ctx.component(
+                    "scroll",
+                    scroll_area(2, move |ctx| {
+                        if sparse {
+                            ctx.paint_widget(Paragraph::new("X"), Rect::new(2, 0, 1, 1));
+                        }
+                    }),
+                    Rect::new(0, 0, 6, 2),
+                );
+            });
+
+            assert_eq!(&driver.row(0)[..5], if sparse { "ABXDE" } else { "ABCDE" });
+            assert_eq!(&driver.row(1)[..5], "FGHIJ");
+            let buffer = driver.terminal.backend().buffer();
+            for position in [(0, 0), (4, 0), (0, 1), (4, 1)] {
+                assert_eq!(
+                    buffer.cell(position).expect("preserved cell").bg,
+                    Color::Red,
+                    "untouched styles survive viewport composition"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn partially_visible_fixed_height_control_keeps_its_real_allocation() {
+        let mut driver = Driver::new(8, 4);
+        let state = State {
+            offset: 2,
+            ..State::default()
+        };
+        driver.render(&state, |ctx| {
+            ctx.component(
+                "scroll",
+                scroll_area(6, |ctx| {
+                    let area = ctx.area();
+                    ctx.component(
+                        "button",
+                        Button::new("OK")
+                            .outline()
+                            .size(crate::ButtonSize::Large)
+                            .on_press(|| Msg::Pressed("button")),
+                        Rect::new(area.x, area.y + 1, area.width, 3),
+                    );
+                }),
+                Rect::new(1, 0, 6, 3),
+            );
+        });
+
+        assert!(driver.row(0).contains("OK"), "{}", driver.row(0));
+        assert!(driver.row(1).contains('└'), "{}", driver.row(1));
+        assert_eq!(&driver.row(2)[1..6], "     ");
+        assert_eq!(
+            driver.event(mouse(MouseKind::Click(MouseButton::Left), 2, 0), &state),
+            EventResult::Emit(Msg::Pressed("button")),
+            "the visible middle row remains interactive"
+        );
+    }
+
+    #[test]
+    fn pointer_routing_inverse_translates_visible_hits_and_clips_offscreen_hits() {
+        let mut driver = Driver::new(8, 5);
+        let state = State {
+            offset: 2,
+            ..State::default()
+        };
+        driver.render(&state, |ctx| {
+            ctx.component(
+                "scroll",
+                scroll_area(8, |ctx| {
+                    let area = ctx.area();
+                    ctx.component(
+                        "visible",
+                        Probe::focusable("visible"),
+                        Rect::new(area.x, area.y + 3, area.width, 1),
+                    );
+                    ctx.component(
+                        "offscreen",
+                        Probe::focusable("offscreen"),
+                        Rect::new(area.x, area.y + 7, area.width, 1),
+                    );
+                }),
+                Rect::new(1, 1, 6, 3),
+            );
+        });
+
+        assert_eq!(
+            driver.event(mouse(MouseKind::Click(MouseButton::Left), 2, 2), &state),
+            EventResult::Emit(Msg::Pressed("visible"))
+        );
+        assert_eq!(
+            driver.event(mouse(MouseKind::Click(MouseButton::Left), 2, 8), &state),
+            EventResult::Ignored,
+            "an offscreen logical allocation is not a screen hit target"
+        );
+    }
+
+    /// A focus change inside a `ScrollArea` reaches the app through the same
+    /// `Ratcn::focus` binding every other focus change uses, and the reveal
+    /// arrives with it.
+    #[test]
+    fn tab_into_an_offscreen_descendant_emits_the_focus_message_and_reveals_it() {
+        let mut driver = Driver::new(8, 3);
+        let mut state = State {
+            focus: FocusState::intent(["scroll", "first"]),
+            ..State::default()
+        };
+        let render = |driver: &mut Driver, state: &State| {
+            driver.render(state, |ctx| {
+                ctx.component(
+                    "scroll",
+                    scroll_area(9, |ctx| {
+                        assert_eq!(ctx.area().height, 9, "children see full content height");
+                        ctx.component("first", Probe::focusable("first"), Rect::new(0, 0, 7, 1));
+                        ctx.component("last", Probe::focusable("last"), Rect::new(0, 6, 7, 1));
+                    }),
+                    Rect::new(0, 0, 8, 3),
+                );
+            });
+        };
+        render(&mut driver, &state);
+
+        assert_eq!(
+            driver.event(key(KeyCode::Tab), &state),
+            EventResult::Emit(Msg::Focus(FocusState::intent(["scroll", "last"]))),
+            "the app's focus binding fires for a focus change inside a ScrollArea"
+        );
+        state.focus = FocusState::intent(["scroll", "last"]);
+        render(&mut driver, &state);
+        assert_eq!(
+            &driver.row(2)[..4],
+            "last",
+            "the reveal reached the same frame the focus change did"
+        );
+    }
+
+    /// A reveal holds the view until the app scrolls its own bound offset, and
+    /// releasing it is permanent: coming back to the offset the hold was taken
+    /// at must not scroll the reveal back in.
+    #[test]
+    fn a_bound_offset_takes_the_area_back_for_good() {
+        let mut driver = Driver::new(8, 3);
+        let mut state = State {
+            focus: FocusState::intent(["scroll", "first"]),
+            ..State::default()
+        };
+        let render = |driver: &mut Driver, state: &State| {
+            driver.render(state, |ctx| {
+                ctx.component(
+                    "scroll",
+                    scroll_area(9, |ctx| {
+                        ctx.component("first", Probe::focusable("first"), Rect::new(0, 0, 7, 1));
+                        ctx.component("last", Probe::focusable("last"), Rect::new(0, 6, 7, 1));
+                    }),
+                    Rect::new(0, 0, 8, 3),
+                );
+            });
+        };
+        render(&mut driver, &state);
+
+        assert_eq!(
+            driver.event(key(KeyCode::Tab), &state),
+            EventResult::Emit(Msg::Focus(FocusState::intent(["scroll", "last"])))
+        );
+        state.focus = FocusState::intent(["scroll", "last"]);
+        render(&mut driver, &state);
+        assert_eq!(&driver.row(2)[..4], "last", "the reveal held the view");
+
+        state.offset = 2;
+        render(&mut driver, &state);
+        assert_eq!(
+            &driver.row(0)[..5],
+            "     ",
+            "the app scrolled its own offset, so the hold is released"
+        );
+
+        state.offset = 0;
+        render(&mut driver, &state);
+        assert_eq!(
+            &driver.row(0)[..5],
+            "first",
+            "returning to the offset the hold was taken at must not revive it"
+        );
+    }
+
+    /// An unbound area owns the reveal outright: the app stores focus and
+    /// nothing else.
+    #[test]
+    fn an_unbound_area_reveals_without_asking_the_app_for_an_offset() {
+        let mut driver = Driver::new(8, 3);
+        let mut state = State {
+            focus: FocusState::intent(["scroll", "first"]),
+            ..State::default()
+        };
+        let render = |driver: &mut Driver, state: &State| {
+            driver.render(state, |ctx| {
+                ctx.component(
+                    "scroll",
+                    ScrollArea::new(9).content(|ctx| {
+                        ctx.component("first", Probe::focusable("first"), Rect::new(0, 0, 7, 1));
+                        ctx.component("last", Probe::focusable("last"), Rect::new(0, 6, 7, 1));
+                    }),
+                    Rect::new(0, 0, 8, 3),
+                );
+            });
+        };
+        render(&mut driver, &state);
+
+        assert_eq!(
+            driver.event(key(KeyCode::Tab), &state),
+            EventResult::Emit(Msg::Focus(FocusState::intent(["scroll", "last"])))
+        );
+        state.focus = FocusState::intent(["scroll", "last"]);
+        render(&mut driver, &state);
+        assert_eq!(&driver.row(2)[..4], "last");
+    }
+
+    #[test]
+    fn backtab_and_focus_keys_minimally_reveal_their_destination() {
+        let mut driver = Driver::new(8, 3);
+        driver.ratcn = std::mem::take(&mut driver.ratcn)
+            .focus_key(KeyChord::from('l').alt(), ["scroll", "last"]);
+        let mut state = State {
+            focus: FocusState::intent(["scroll", "last"]),
+            offset: 4,
+            ..State::default()
+        };
+        let render = |driver: &mut Driver, state: &State| {
+            driver.render(state, |ctx| {
+                ctx.component(
+                    "scroll",
+                    scroll_area(9, |ctx| {
+                        ctx.component("first", Probe::focusable("first"), Rect::new(0, 0, 7, 1));
+                        ctx.component("last", Probe::focusable("last"), Rect::new(0, 6, 7, 1));
+                    }),
+                    Rect::new(0, 0, 8, 3),
+                );
+            });
+        };
+        render(&mut driver, &state);
+
+        assert_eq!(
+            driver.event(key(KeyCode::BackTab), &state),
+            EventResult::Emit(Msg::Focus(FocusState::intent(["scroll", "first"])))
+        );
+        state.focus = FocusState::intent(["scroll", "first"]);
+        render(&mut driver, &state);
+        assert_eq!(
+            &driver.row(0)[..5],
+            "first",
+            "the top edge is the minimal reveal for a target above the view"
+        );
+
+        let jump = Event::Key(KeyEvent {
+            code: KeyCode::Char('l'),
+            modifiers: Modifiers {
+                alt: true,
+                ..Modifiers::NONE
+            },
+        });
+        assert_eq!(
+            driver.event(jump, &state),
+            EventResult::Emit(Msg::Focus(FocusState::intent(["scroll", "last"])))
+        );
+        state.focus = FocusState::intent(["scroll", "last"]);
+        render(&mut driver, &state);
+        assert_eq!(
+            &driver.row(2)[..4],
+            "last",
+            "the bottom edge is the minimal reveal for a target below the view"
+        );
+    }
+
+    #[test]
+    fn focus_key_reveals_an_already_focused_offscreen_descendant() {
+        let mut driver = Driver::new(8, 3);
+        driver.ratcn = std::mem::take(&mut driver.ratcn)
+            .focus_key(KeyChord::from('l').alt(), ["scroll", "last"]);
+        let state = State {
+            focus: FocusState::intent(["scroll", "last"]),
+            ..State::default()
+        };
+        let render = |driver: &mut Driver, state: &State| {
+            driver.render(state, |ctx| {
+                ctx.component(
+                    "scroll",
+                    scroll_area(9, |ctx| {
+                        ctx.component("last", Probe::focusable("last"), Rect::new(0, 6, 7, 1));
+                    }),
+                    Rect::new(0, 0, 8, 3),
+                );
+            });
+        };
+        render(&mut driver, &state);
+
+        assert_eq!(
+            driver.event(
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char('l'),
+                    modifiers: Modifiers {
+                        alt: true,
+                        ..Modifiers::NONE
+                    },
+                }),
+                &state,
+            ),
+            EventResult::Consumed,
+            "focus did not change, so there is no focus message to send"
+        );
+        render(&mut driver, &state);
+        assert_eq!(&driver.row(2)[..4], "last");
+    }
+
+    #[test]
+    fn wrapped_traversal_reveals_its_same_offscreen_target() {
+        let mut driver = Driver::new(8, 3);
+        let state = State {
+            focus: FocusState::intent(["scroll", "wrap", "only"]),
+            ..State::default()
+        };
+        let render = |driver: &mut Driver, state: &State| {
+            driver.render(state, |ctx| {
+                ctx.component(
+                    "scroll",
+                    scroll_area(9, |ctx| {
+                        ctx.scope(
+                            "wrap",
+                            ctx.area(),
+                            ScopeOptions::default().tab_wrap(crate::runtime::TabWrap::Wrap),
+                            |ctx| {
+                                ctx.component(
+                                    "only",
+                                    Probe::focusable("only"),
+                                    Rect::new(0, 6, 7, 1),
+                                );
+                            },
+                        );
+                    }),
+                    Rect::new(0, 0, 8, 3),
+                );
+            });
+        };
+        render(&mut driver, &state);
+
+        assert_eq!(
+            driver.event(key(KeyCode::Tab), &state),
+            EventResult::Consumed,
+            "the wrap landed back where it started, so focus did not change"
+        );
+        render(&mut driver, &state);
+        assert_eq!(&driver.row(2)[..4], "only");
+    }
+
+    #[test]
+    fn repeated_controlled_events_read_current_app_offset_before_redraw() {
+        let mut driver = Driver::new(8, 3);
+        let mut state = State::default();
+        driver.render(&state, |ctx| {
+            ctx.component("scroll", scroll_area(12, |_| {}), Rect::new(0, 0, 8, 3));
+        });
+
+        assert_eq!(
+            driver.event(
+                mouse(MouseKind::Scroll(ScrollDirection::Down), 1, 1),
+                &state
+            ),
+            EventResult::Emit(Msg::Area(ScrollAreaChange::ScrollTo(3)))
+        );
+        state.offset = 3;
+        assert_eq!(
+            driver.event(
+                mouse(MouseKind::Scroll(ScrollDirection::Down), 1, 1),
+                &state
+            ),
+            EventResult::Emit(Msg::Area(ScrollAreaChange::ScrollTo(6)))
+        );
+        state.offset = 6;
+        assert_eq!(
+            driver.event(key(KeyCode::PageDown), &state),
+            EventResult::Emit(Msg::Area(ScrollAreaChange::ScrollTo(9)))
+        );
+    }
+
+    /// An unbound area owns its offset the same way an unbound `List` owns
+    /// its scroll: the wheel moves the view and the offset survives the
+    /// redraw, with nothing emitted.
+    #[test]
+    fn an_unbound_area_scrolls_itself_on_the_wheel() {
+        let mut driver = Driver::new(8, 3);
+        let state = State::default();
+        let render = |driver: &mut Driver, state: &State| {
+            driver.render(state, |ctx| {
+                ctx.component(
+                    "scroll",
+                    ScrollArea::new(9).content(|ctx| {
+                        let area = ctx.area();
+                        ctx.paint_widget(
+                            Paragraph::new(Text::from("a\nb\nc\nd\ne\nf\ng\nh\ni")),
+                            area,
+                        );
+                    }),
+                    Rect::new(0, 0, 8, 3),
+                );
+            });
+        };
+        render(&mut driver, &state);
+        assert_eq!(&driver.row(0)[..1], "a");
+
+        assert_eq!(
+            driver.event(
+                mouse(MouseKind::Scroll(ScrollDirection::Down), 1, 1),
+                &state
+            ),
+            EventResult::Consumed,
+            "there is no offset binding, so nothing is emitted"
+        );
+        render(&mut driver, &state);
+        assert_eq!(
+            &driver.row(0)[..1],
+            "d",
+            "the wheel moved the view by itself"
+        );
+    }
+
+    /// A key the view cannot act on has to reach the app, or an app hotkey on
+    /// Home, End, or a page key dies whenever focus rests in a scroll area.
+    #[test]
+    fn scroll_keys_and_wheel_clamp_and_bubble_at_the_edges() {
+        let mut driver = Driver::new(8, 3);
+        let mut state = State {
+            offset: 5,
+            ..State::default()
+        };
+        driver.render(&state, |ctx| {
+            ctx.component("scroll", scroll_area(8, |_| {}), Rect::new(0, 0, 8, 3));
+        });
+
+        assert_eq!(
+            driver.event(key(KeyCode::End), &state),
+            EventResult::Ignored
+        );
+        assert_eq!(
+            driver.event(
+                mouse(MouseKind::Scroll(ScrollDirection::Down), 1, 1),
+                &state
+            ),
+            EventResult::Ignored
+        );
+        assert_eq!(
+            driver.event(key(KeyCode::Home), &state),
+            EventResult::Emit(Msg::Area(ScrollAreaChange::ScrollTo(0)))
+        );
+        state.offset = 0;
+        assert_eq!(
+            driver.event(key(KeyCode::PageUp), &state),
+            EventResult::Ignored
+        );
+        assert_eq!(
+            driver.event(
+                mouse(MouseKind::Scroll(ScrollDirection::Left), 1, 1),
+                &state
+            ),
+            EventResult::Ignored
+        );
+        assert_eq!(
+            driver.event(
+                Event::Key(KeyEvent {
+                    code: KeyCode::End,
+                    modifiers: Modifiers {
+                        ctrl: true,
+                        ..Modifiers::NONE
+                    },
+                }),
+                &state
+            ),
+            EventResult::Ignored
+        );
+    }
+
+    /// The same keys in an area that has nothing to scroll.
+    #[test]
+    fn an_area_that_cannot_scroll_leaves_its_keys_to_the_app() {
+        let mut driver = Driver::new(8, 5);
+        let state = State::default();
+        driver.render(&state, |ctx| {
+            ctx.component("scroll", scroll_area(2, |_| {}), Rect::new(0, 0, 8, 5));
+        });
+
+        for code in [
+            KeyCode::Home,
+            KeyCode::End,
+            KeyCode::PageUp,
+            KeyCode::PageDown,
+        ] {
+            assert_eq!(
+                driver.event(key(code), &state),
+                EventResult::Ignored,
+                "{code:?} has nothing to scroll and belongs to the app"
+            );
+        }
+        assert_eq!(
+            driver.event(
+                mouse(MouseKind::Scroll(ScrollDirection::Down), 1, 1),
+                &state
+            ),
+            EventResult::Ignored
+        );
+    }
+
+    #[test]
+    fn focused_descendant_gets_scroll_keys_before_the_area() {
+        let mut driver = Driver::new(8, 3);
+        let state = State {
+            focus: FocusState::intent(["scroll", "sink"]),
+            ..State::default()
+        };
+        driver.render(&state, |ctx| {
+            ctx.component(
+                "scroll",
+                scroll_area(8, |ctx| {
+                    ctx.component("sink", Probe::page_sink("sink"), Rect::new(0, 0, 7, 1));
+                }),
+                Rect::new(0, 0, 8, 3),
+            );
+        });
+
+        assert_eq!(
+            driver.event(key(KeyCode::PageDown), &state),
+            EventResult::Emit(Msg::ChildHandled)
+        );
+    }
+
+    #[test]
+    fn reserved_gutter_uses_the_configured_ratatui_scrollbar_style() {
+        let mut driver = Driver::new(6, 4);
+        let state = State::default();
+        driver.render(&state, |ctx| {
+            ctx.component(
+                "scroll",
+                scroll_area(12, |ctx| {
+                    ctx.paint_widget(Block::new().style(Style::new().bg(Color::Red)), ctx.area());
+                })
+                .style(|_| ScrollAreaStyle {
+                    thumb: Color::Yellow,
+                    track: Color::Blue,
+                }),
+                Rect::new(0, 0, 6, 4),
+            );
+        });
+
+        let buffer = driver.terminal.backend().buffer();
+        assert_eq!(buffer.cell((4, 0)).expect("content cell").bg, Color::Red);
+        let gutter = (0..4)
+            .map(|row| buffer.cell((5, row)).expect("gutter cell"))
+            .collect::<Vec<_>>();
+        assert!(gutter.iter().any(|cell| cell.fg == Color::Yellow));
+        assert!(gutter.iter().any(|cell| cell.fg == Color::Blue));
+        assert!(gutter.iter().all(|cell| cell.bg != Color::Red));
+    }
+
+    #[test]
+    fn scrollbar_thumb_reaches_both_offset_endpoints() {
+        let mut driver = Driver::new(6, 4);
+        let mut state = State::default();
+        let render = |driver: &mut Driver, state: &State| {
+            driver.render(state, |ctx| {
+                ctx.component(
+                    "scroll",
+                    scroll_area(12, |_| {}).style(|_| ScrollAreaStyle {
+                        thumb: Color::Yellow,
+                        track: Color::Blue,
+                    }),
+                    Rect::new(0, 0, 6, 4),
+                );
+            });
+        };
+        let thumb_rows = |driver: &Driver| {
+            (0..4)
+                .filter(|&row| {
+                    driver
+                        .terminal
+                        .backend()
+                        .buffer()
+                        .cell((5, row))
+                        .is_some_and(|cell| cell.fg == Color::Yellow)
+                })
+                .collect::<Vec<_>>()
+        };
+
+        render(&mut driver, &state);
+        assert_eq!(thumb_rows(&driver).first(), Some(&0));
+
+        state.offset = 8;
+        render(&mut driver, &state);
+        assert_eq!(thumb_rows(&driver).last(), Some(&3));
+    }
+
+    /// One row of overflow is two offsets, not one, so the thumb has to reach
+    /// both ends of the gutter.
+    #[test]
+    fn a_single_row_of_overflow_still_reaches_both_scrollbar_endpoints() {
+        let mut driver = Driver::new(6, 4);
+        let mut state = State::default();
+        let render = |driver: &mut Driver, state: &State| {
+            driver.render(state, |ctx| {
+                ctx.component(
+                    "scroll",
+                    scroll_area(5, |_| {}).style(|_| ScrollAreaStyle {
+                        thumb: Color::Yellow,
+                        track: Color::Blue,
+                    }),
+                    Rect::new(0, 0, 6, 4),
+                );
+            });
+        };
+        let thumb_rows = |driver: &Driver| {
+            (0..4)
+                .filter(|&row| {
+                    driver
+                        .terminal
+                        .backend()
+                        .buffer()
+                        .cell((5, row))
+                        .is_some_and(|cell| cell.fg == Color::Yellow)
+                })
+                .collect::<Vec<_>>()
+        };
+
+        render(&mut driver, &state);
+        let top = thumb_rows(&driver);
+        assert_eq!(top.first(), Some(&0));
+        assert_ne!(top.last(), Some(&3), "one row is still below the view");
+
+        state.offset = 1;
+        render(&mut driver, &state);
+        let bottom = thumb_rows(&driver);
+        assert_eq!(bottom.last(), Some(&3));
+        assert_ne!(bottom.first(), Some(&0), "one row is now above the view");
+    }
+
+    #[test]
+    fn zero_sized_viewports_are_inert_without_dropping_declarations() {
+        for area in [Rect::new(0, 0, 0, 3), Rect::new(0, 0, 4, 0)] {
+            let mut driver = Driver::new(4, 3);
+            let state = State::default();
+            driver.render(&state, move |ctx| {
+                ctx.component(
+                    "scroll",
+                    scroll_area(5, |ctx| {
+                        ctx.component("child", Probe::focusable("child"), ctx.area());
+                    }),
+                    area,
+                );
+            });
+
+            assert!(
+                driver
+                    .ratcn
+                    .focus_path(&[ChildId::from("scroll"), ChildId::from("child")])
+                    .is_none()
+            );
+            assert_eq!(
+                driver.event(key(KeyCode::Tab), &state),
+                EventResult::Ignored
+            );
+        }
+    }
+
+    #[derive(Debug)]
+    struct LayerHost {
+        layer: LayerExample,
+    }
+
+    #[derive(Debug)]
+    struct HoverPopupHost;
+
+    impl Component<State, Msg> for HoverPopupHost {
+        fn declare(&mut self, ctx: &mut DeclareCtx<'_, State, Msg>) {
+            let anchor = ctx.area();
+            ctx.paint_widget(Paragraph::new("OWNER"), anchor);
+            if ctx.pointer_within() {
+                let popup = Rect::new(anchor.x, anchor.y + 2, 5, 1);
+                ctx.popup("popup", PopupOptions::default(), popup, move |ctx| {
+                    ctx.paint_widget(Paragraph::new("POPUP"), popup);
+                    ctx.component("item", Probe::focusable("popup-item"), popup);
+                });
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum LayerExample {
+        Hint,
+        Popup,
+        Modal,
+        Deferred,
+    }
+
+    impl Component<State, Msg> for LayerHost {
+        fn declare(&mut self, ctx: &mut DeclareCtx<'_, State, Msg>) {
+            let anchor = ctx.area();
+            let escaped = Rect::new(anchor.x, anchor.y + 2, 5, 1);
+            match self.layer {
+                LayerExample::Hint => {
+                    ctx.hint("layer", ScopeOptions::default(), escaped, move |ctx| {
+                        ctx.paint_widget(Paragraph::new("HINT"), escaped);
+                    });
+                }
+                LayerExample::Popup => {
+                    ctx.popup("layer", PopupOptions::default(), escaped, move |ctx| {
+                        ctx.paint_widget(Paragraph::new("POPUP"), escaped);
+                        ctx.component("item", Probe::focusable("item"), escaped);
+                    });
+                }
+                LayerExample::Modal => {
+                    ctx.modal("layer", ModalProbe, escaped);
+                }
+                LayerExample::Deferred => {
+                    ctx.defer_paint(move |painter, _| {
+                        painter.with_buffer(|buffer| {
+                            buffer.set_string(escaped.x, escaped.y, "DEFER", Style::default());
+                        });
+                    });
+                }
+            }
+        }
+
+        fn handle_event(
+            &mut self,
+            event: &Event,
+            _state: &State,
+            _ctx: &mut EventCtx<'_>,
+        ) -> EventResult<Msg> {
+            match event {
+                Event::Key(key) if key.code == KeyCode::Esc && !key.modifiers.any() => {
+                    EventResult::Emit(Msg::Escape)
+                }
+                _ => EventResult::Ignored,
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct ModalProbe;
+
+    impl Component<State, Msg> for ModalProbe {
+        fn declare(&mut self, _ctx: &mut DeclareCtx<'_, State, Msg>) {}
+
+        fn paint(&mut self, ctx: &mut crate::runtime::PaintCtx<'_, '_, State>) {
+            ctx.widget(Paragraph::new("MODAL"), ctx.area());
+        }
+
+        fn handle_event(
+            &mut self,
+            event: &Event,
+            _state: &State,
+            _ctx: &mut EventCtx<'_>,
+        ) -> EventResult<Msg> {
+            match event {
+                Event::Key(key) if key.code == KeyCode::Esc && !key.modifiers.any() => {
+                    EventResult::Emit(Msg::ModalClosed)
+                }
+                _ => EventResult::Ignored,
+            }
+        }
+
+        fn is_focusable(&self, _state: &State) -> bool {
+            true
+        }
+    }
+
+    fn render_layer_example(driver: &mut Driver, state: &State, layer: LayerExample) {
+        driver.render(state, move |ctx| {
+            ctx.component(
+                "scroll",
+                scroll_area(8, move |ctx| {
+                    let area = ctx.area();
+                    ctx.component(
+                        "host",
+                        LayerHost { layer },
+                        Rect::new(area.x, area.y + 3, 5, 1),
+                    );
+                }),
+                Rect::new(0, 0, 6, 3),
+            );
+            ctx.paint_widget(Paragraph::new("XXXXX"), Rect::new(0, 3, 5, 1));
+        });
+    }
+
+    fn declare_scroll_in_outer_layer(ctx: &mut DeclareCtx<'_, State, Msg>) {
+        ctx.paint_widget(Paragraph::new("KEEP"), Rect::new(1, 4, 4, 1));
+        ctx.component(
+            "scroll",
+            scroll_area(6, |ctx| {
+                let area = ctx.area();
+                ctx.paint_widget(Paragraph::new("zero\none\ntwo\nthree\nfour\nfive"), area);
+                ctx.component(
+                    "child",
+                    Probe::focusable("layer-child"),
+                    Rect::new(area.x, area.y + 2, area.width, 1),
+                );
+            }),
+            Rect::new(1, 1, 7, 3),
+        );
+    }
+
+    #[test]
+    fn viewport_inside_popup_and_modal_uses_true_nesting_for_paint_clip_and_hits() {
+        let state = State {
+            offset: 2,
+            ..State::default()
+        };
+        for modal in [false, true] {
+            let mut driver = Driver::new(10, 6);
+            driver.render(&state, move |ctx| {
+                if modal {
+                    ctx.modal_scope(
+                        "outer",
+                        Rect::new(0, 0, 10, 6),
+                        ScopeOptions::default(),
+                        declare_scroll_in_outer_layer,
+                    );
+                } else {
+                    ctx.popup(
+                        "outer",
+                        PopupOptions::default(),
+                        Rect::new(0, 0, 10, 6),
+                        declare_scroll_in_outer_layer,
+                    );
+                }
+            });
+
+            assert!(driver.row(1).contains("layer"), "{}", driver.row(1));
+            assert!(
+                driver.row(4).contains("KEEP"),
+                "viewport paint escaped its clip in the outer layer: {}",
+                driver.row(4)
+            );
+            assert_eq!(
+                driver.event(mouse(MouseKind::Click(MouseButton::Left), 2, 1), &state),
+                EventResult::Emit(Msg::Pressed("layer-child")),
+                "the visible logical child is hit inside the outer layer"
+            );
+        }
+    }
+
+    #[test]
+    fn viewport_priming_preserves_earlier_enclosing_layer_cells() {
+        for sparse in [false, true] {
+            let mut driver = Driver::new(6, 4);
+            let state = State::default();
+            driver.render(&state, move |ctx| {
+                ctx.popup(
+                    "outer",
+                    PopupOptions::default(),
+                    Rect::new(0, 0, 6, 4),
+                    move |ctx| {
+                        ctx.paint_widget(
+                            Paragraph::new("ABCDE\nFGHIJ").style(Style::new().bg(Color::Magenta)),
+                            Rect::new(0, 1, 5, 2),
+                        );
+                        ctx.component(
+                            "scroll",
+                            scroll_area(2, move |ctx| {
+                                if sparse {
+                                    ctx.paint_widget(Paragraph::new("X"), Rect::new(2, 1, 1, 1));
+                                }
+                            }),
+                            Rect::new(0, 1, 6, 2),
+                        );
+                    },
+                );
+            });
+
+            assert_eq!(&driver.row(1)[..5], if sparse { "ABXDE" } else { "ABCDE" });
+            assert_eq!(&driver.row(2)[..5], "FGHIJ");
+            assert_eq!(
+                driver
+                    .terminal
+                    .backend()
+                    .buffer()
+                    .cell((4, 2))
+                    .expect("preserved layer cell")
+                    .bg,
+                Color::Magenta
+            );
+        }
+    }
+
+    #[test]
+    fn sparse_viewport_in_a_layer_does_not_cover_lower_layer_cells() {
+        for sparse in [false, true] {
+            let mut driver = Driver::new(6, 4);
+            let state = State::default();
+            driver.render(&state, move |ctx| {
+                ctx.paint_widget(
+                    Paragraph::new("ABCDE\nFGHIJ").style(Style::new().bg(Color::Blue)),
+                    Rect::new(0, 1, 5, 2),
+                );
+                ctx.popup(
+                    "outer",
+                    PopupOptions::default(),
+                    Rect::new(0, 0, 6, 4),
+                    move |ctx| {
+                        ctx.component(
+                            "scroll",
+                            scroll_area(2, move |ctx| {
+                                if sparse {
+                                    ctx.paint_widget(Paragraph::new("X"), Rect::new(2, 1, 1, 1));
+                                }
+                            }),
+                            Rect::new(0, 1, 6, 2),
+                        );
+                    },
+                );
+            });
+
+            assert_eq!(&driver.row(1)[..5], if sparse { "ABXDE" } else { "ABCDE" });
+            assert_eq!(&driver.row(2)[..5], "FGHIJ");
+            assert_eq!(
+                driver
+                    .terminal
+                    .backend()
+                    .buffer()
+                    .cell((4, 2))
+                    .expect("preserved base cell")
+                    .bg,
+                Color::Blue
+            );
+        }
+    }
+
+    #[test]
+    fn hints_popups_modals_and_deferred_paint_escape_and_project_once() {
+        let state = State {
+            offset: 2,
+            ..State::default()
+        };
+        for (layer, expected) in [
+            (LayerExample::Hint, "HINT"),
+            (LayerExample::Popup, "item"),
+            (LayerExample::Modal, "MODAL"),
+            (LayerExample::Deferred, "DEFER"),
+        ] {
+            let mut driver = Driver::new(8, 6);
+            render_layer_example(&mut driver, &state, layer);
+            assert!(
+                driver.row(3).contains(expected),
+                "{layer:?} was clipped or translated more than once: {}",
+                driver.row(3)
+            );
+        }
+    }
+
+    #[test]
+    fn popup_and_modal_keep_existing_escape_routing() {
+        let mut popup = Driver::new(8, 6);
+        let popup_state = State {
+            focus: FocusState::intent(["scroll", "host"]),
+            offset: 2,
+            ..State::default()
+        };
+        render_layer_example(&mut popup, &popup_state, LayerExample::Popup);
+        assert_eq!(
+            popup.event(key(KeyCode::Esc), &popup_state),
+            EventResult::Emit(Msg::Escape),
+            "Esc crosses a popup root to its declaring component"
+        );
+
+        let mut modal = Driver::new(8, 6);
+        let modal_state = State {
+            offset: 2,
+            ..State::default()
+        };
+        render_layer_example(&mut modal, &modal_state, LayerExample::Modal);
+        assert_eq!(
+            modal.event(key(KeyCode::Esc), &modal_state),
+            EventResult::Emit(Msg::ModalClosed),
+            "the modal remains the key-routing floor"
+        );
+    }
+
+    #[test]
+    fn pointer_within_keeps_an_owner_open_while_the_pointer_is_in_its_escaped_popup() {
+        let mut driver = Driver::new(10, 8);
+        let state = State::default();
+        let render = |driver: &mut Driver| {
+            driver.render(&state, |ctx| {
+                ctx.component(
+                    "scroll",
+                    scroll_area(8, |ctx| {
+                        ctx.component("owner", HoverPopupHost, Rect::new(0, 3, 5, 1));
+                    }),
+                    Rect::new(0, 0, 7, 5),
+                );
+            });
+        };
+
+        render(&mut driver);
+        driver.event(mouse(MouseKind::Moved, 1, 3), &state);
+        render(&mut driver);
+        assert!(driver.row(5).contains("popup"), "{}", driver.row(5));
+
+        driver.event(mouse(MouseKind::Moved, 1, 5), &state);
+        render(&mut driver);
+        assert!(
+            driver.row(5).contains("popup"),
+            "the escaped popup remains in its owner's hovered subtree: {}",
+            driver.row(5)
+        );
+        assert_eq!(
+            driver.event(mouse(MouseKind::Click(MouseButton::Left), 1, 5), &state),
+            EventResult::Emit(Msg::Pressed("popup-item"))
+        );
+    }
+
+    #[test]
+    fn select_popup_inside_scrolled_content_inverse_projects_option_events() {
+        let mut driver = Driver::new(16, 8);
+        let state = State {
+            offset: 3,
+            select_open: true,
+            select_cursor: Some("one"),
+            ..State::default()
+        };
+        driver.render(&state, |ctx| {
+            ctx.component(
+                "scroll",
+                scroll_area(8, |ctx| {
+                    let area = ctx.area();
+                    ctx.component(
+                        "select",
+                        Select::new([ListItem::new("one", "One"), ListItem::new("two", "Two")])
+                            .open(|state: &State| state.select_open, Msg::SelectOpen)
+                            .item_focus(|state: &State| state.select_cursor, Msg::SelectFocused)
+                            .selection(|state: &State| state.selected, Msg::Selected),
+                        Rect::new(area.x, area.y + 3, area.width, 1),
+                    );
+                }),
+                Rect::new(2, 2, 11, 3),
+            );
+        });
+
+        assert!(
+            driver.row(3).contains("Two"),
+            "the escaped panel paints in screen space: {}",
+            driver.row(3)
+        );
+        assert_eq!(
+            driver.event(mouse(MouseKind::Moved, 4, 3), &state),
+            EventResult::Emit(Msg::SelectFocused("two")),
+            "option hover uses the popup's declaration-space row"
+        );
+        assert_eq!(
+            driver.event(mouse(MouseKind::Click(MouseButton::Left), 4, 3), &state),
+            EventResult::Emit(Msg::Selected("two")),
+            "option click uses the same inverse projection"
+        );
+    }
+
+    /// A popup or hint whose anchor has scrolled out of sight is dropped even
+    /// though its own rows would land on visible screen rows.
+    #[test]
+    fn popup_and_hint_anchors_are_dropped_when_the_anchor_is_offscreen() {
+        let state = State::default();
+        for layer in [LayerExample::Hint, LayerExample::Popup] {
+            let escaped = Rect::new(0, 1, 5, 1);
+            let mut visible = Driver::new(8, 6);
+            visible.render(&state, move |ctx| {
+                ctx.component(
+                    "scroll",
+                    scroll_area(8, move |ctx| {
+                        ctx.component(
+                            "host",
+                            FixedLayerHost { layer, escaped },
+                            Rect::new(0, 0, 5, 1),
+                        );
+                    }),
+                    Rect::new(0, 0, 6, 3),
+                );
+            });
+            assert!(
+                (0..6).any(|row| visible.row(row).contains("LAYER")),
+                "a visible {layer:?} anchor must keep its layer"
+            );
+
+            let mut offscreen = Driver::new(8, 6);
+            offscreen.render(&state, move |ctx| {
+                ctx.component(
+                    "scroll",
+                    scroll_area(8, move |ctx| {
+                        ctx.component(
+                            "host",
+                            FixedLayerHost { layer, escaped },
+                            Rect::new(0, 6, 5, 1),
+                        );
+                    }),
+                    Rect::new(0, 0, 6, 3),
+                );
+            });
+            assert!(
+                (0..6).all(|row| !offscreen.row(row).contains("LAYER")),
+                "offscreen {layer:?} anchor left an active layer on visible rows"
+            );
+        }
+    }
+
+    /// A layer host whose escaped rectangle does not follow its anchor, so the
+    /// anchor can be offscreen while the layer would not be.
+    #[derive(Debug)]
+    struct FixedLayerHost {
+        layer: LayerExample,
+        escaped: Rect,
+    }
+
+    impl Component<State, Msg> for FixedLayerHost {
+        fn declare(&mut self, ctx: &mut DeclareCtx<'_, State, Msg>) {
+            let escaped = self.escaped;
+            match self.layer {
+                LayerExample::Hint => {
+                    ctx.hint("layer", ScopeOptions::default(), escaped, move |ctx| {
+                        ctx.paint_widget(Paragraph::new("LAYER"), escaped);
+                    });
+                }
+                LayerExample::Popup => {
+                    ctx.popup("layer", PopupOptions::default(), escaped, move |ctx| {
+                        ctx.paint_widget(Paragraph::new("LAYER"), escaped);
+                    });
+                }
+                LayerExample::Modal | LayerExample::Deferred => {}
+            }
+        }
+    }
+
+    #[test]
+    fn nested_scroll_areas_are_rejected() {
+        let mut driver = Driver::new(8, 4);
+        let state = State::default();
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            driver.render(&state, |ctx| {
+                ctx.component(
+                    "outer",
+                    scroll_area(6, |ctx| {
+                        ctx.component("inner", scroll_area(5, |_| {}), Rect::new(0, 0, 6, 3));
+                    }),
+                    Rect::new(0, 0, 8, 4),
+                );
+            });
+        }));
+
+        let panic = result.expect_err("nested ScrollAreas must panic");
+        let message = panic
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| panic.downcast_ref::<&str>().copied())
+            .unwrap_or_default();
+        assert!(
+            message.contains("cannot be declared inside another viewport"),
+            "{message}"
+        );
+    }
+
+    #[derive(Debug)]
+    struct HoverCaptureProbe {
+        hovered: Rc<Cell<bool>>,
+    }
+
+    impl Component<State, Msg> for HoverCaptureProbe {
+        fn declare(&mut self, _ctx: &mut DeclareCtx<'_, State, Msg>) {}
+
+        fn paint(&mut self, ctx: &mut crate::runtime::PaintCtx<'_, '_, State>) {
+            self.hovered.set(ctx.hovered);
+        }
+
+        fn handle_event(
+            &mut self,
+            event: &Event,
+            _state: &State,
+            ctx: &mut EventCtx<'_>,
+        ) -> EventResult<Msg> {
+            match event {
+                Event::Mouse(mouse) if mouse.kind == MouseKind::Down(MouseButton::Left) => {
+                    ctx.capture_pointer(MouseButton::Left);
+                    EventResult::Consumed
+                }
+                _ => EventResult::Ignored,
+            }
+        }
+    }
+
+    #[test]
+    fn scrolling_a_captured_descendant_offscreen_clears_its_hover() {
+        let mut driver = Driver::new(8, 4);
+        let mut state = State::default();
+        let hovered = Rc::new(Cell::new(false));
+        let render = |driver: &mut Driver, state: &State, hovered: &Rc<Cell<bool>>| {
+            let hovered = Rc::clone(hovered);
+            driver.render(state, move |ctx| {
+                ctx.component(
+                    "scroll",
+                    scroll_area(8, move |ctx| {
+                        ctx.component(
+                            "capture",
+                            HoverCaptureProbe { hovered },
+                            Rect::new(0, 1, 7, 1),
+                        );
+                    }),
+                    Rect::new(0, 0, 8, 3),
+                );
+            });
+        };
+
+        render(&mut driver, &state, &hovered);
+        driver.event(mouse(MouseKind::Moved, 1, 1), &state);
+        render(&mut driver, &state, &hovered);
+        assert!(hovered.get());
+        driver.event(mouse(MouseKind::Down(MouseButton::Left), 1, 1), &state);
+
+        state.offset = 4;
+        render(&mut driver, &state, &hovered);
+        assert!(
+            !hovered.get(),
+            "capture preserves routing, but not hover for an offscreen node"
+        );
+    }
+
+    #[test]
+    fn wheel_scrolling_a_tooltip_trigger_away_closes_it_on_the_resulting_redraw() {
+        let mut driver = Driver::new(12, 8);
+        let mut state = State::default();
+        let render = |driver: &mut Driver, state: &State| {
+            driver.render(state, |ctx| {
+                ctx.component(
+                    "scroll",
+                    scroll_area(9, |ctx| {
+                        ctx.component(
+                            "tip",
+                            Tooltip::new("TIP").trigger(|ctx| {
+                                ctx.paint_widget(Paragraph::new("TRIG"), ctx.area());
+                            }),
+                            Rect::new(0, 3, 5, 1),
+                        );
+                    }),
+                    Rect::new(0, 0, 8, 5),
+                );
+            });
+        };
+
+        render(&mut driver, &state);
+        driver.event(mouse(MouseKind::Moved, 1, 3), &state);
+        render(&mut driver, &state);
+        assert!((0..8).any(|row| driver.row(row).contains("TIP")));
+
+        let EventResult::Emit(Msg::Area(ScrollAreaChange::ScrollTo(offset))) = driver.event(
+            mouse(MouseKind::Scroll(ScrollDirection::Down), 1, 3),
+            &state,
+        ) else {
+            panic!("the wheel must bubble through the Tooltip to ScrollArea");
+        };
+        assert_eq!(offset, 3);
+        state.offset = offset;
+        render(&mut driver, &state);
+        assert!(
+            (0..8).all(|row| !driver.row(row).contains("TIP")),
+            "the wheel redraw must use the trigger's current projected geometry"
+        );
+        assert!(
+            driver.row(0).contains("TRIG"),
+            "the trigger remains visible"
+        );
+    }
+}

--- a/crates/ratcn/src/components/tooltip.rs
+++ b/crates/ratcn/src/components/tooltip.rs
@@ -266,12 +266,12 @@ type TriggerFn<S, M> = Box<dyn FnOnce(&mut DeclareCtx<'_, S, M>)>;
 ///   keyboard focus, which the component cannot observe on its own: focus
 ///   changes are the runtime's messages, not this component's events.
 ///
-/// Whichever decides it, the answer is read while declaring, so it is the
-/// hover the *previous* frame resolved. Pointer motion hides that: it returns
-/// a non-`Ignored` result, the host redraws, and the redraw sees the new
-/// hover. A hover change with no motion behind it — a modal opening over the
-/// trigger — is one frame late: that frame paints the trigger unhovered and
-/// still declares the bubble, which the frame after drops.
+/// Whichever decides it, the answer starts with the hover the *previous* frame
+/// resolved. The Tooltip also checks the pointer against the trigger's current
+/// declaration geometry, so reflow or scrolling that moves the trigger away
+/// closes the bubble on that redraw. Other identity changes with no pointer
+/// motion — a modal opening over the trigger, for example — can still settle
+/// one frame later.
 ///
 /// [`open`](Self::open) is the same reader plus a message, for an app that
 /// keeps a flag the Tooltip should change. It asks for two:
@@ -484,9 +484,9 @@ impl<S, M> Tooltip<S, M> {
 
 impl<S: 'static, M: 'static> Component<S, M> for Tooltip<S, M> {
     fn declare(&mut self, ctx: &mut DeclareCtx<'_, S, M>) {
-        // Read before the trigger declares: `pointer_within` asks about the
-        // declaration that is open right now, which is this Tooltip's.
-        self.pointer_within = ctx.pointer_within();
+        // Read before the trigger declares: the question is about this
+        // Tooltip's subtree, which is what is open right now.
+        self.pointer_within = ctx.pointer_within_area();
         let open = self.is_open(ctx.state());
         if let Some(trigger) = self.trigger.take() {
             trigger(ctx);

--- a/crates/ratcn/src/lib.rs
+++ b/crates/ratcn/src/lib.rs
@@ -18,10 +18,10 @@
 //! - **There is no install command.** Each component module is self-contained
 //!   and meant to be copied into your own project, but copying is a manual file
 //!   copy today. A CLI is intended and does not exist.
-//! - **The component set is small and growing.** Eight ship today: [`Button`],
+//! - **The component set is small and growing.** Nine ship today: [`Button`],
 //!   [`List`], [`Select`], [`Tabs`], [`Dialog`], [`Toaster`](ToasterWidget),
-//!   [`BarChartWidget`], and [`Tooltip`]. Text input, a multi-line text area,
-//!   and a scroll area are planned next; there is no text entry component at
+//!   [`BarChartWidget`], [`Tooltip`], and [`ScrollArea`]. Text input and a
+//!   multi-line text area are planned next; there is no text entry component at
 //!   all right now.
 //!
 //! # Up to two halves, usable alone
@@ -142,6 +142,7 @@ pub use components::{
     button::{Button, ButtonRenderMode, ButtonSize, ButtonStyle, ButtonVariant, ButtonWidget},
     dialog::{Dialog, DialogStyle},
     list::{List, ListStyle, ListWidget},
+    scroll_area::{ScrollArea, ScrollAreaChange, ScrollAreaStyle},
     select::{Select, SelectStyle, SelectWidget},
     tabs::{Tab, TabLayout, Tabs, TabsActivation, TabsSize, TabsStyle, TabsWidget, tab_layout},
     toast::{ToastPosition, ToasterStyle, ToasterWidget},

--- a/crates/ratcn/src/runtime/component.rs
+++ b/crates/ratcn/src/runtime/component.rs
@@ -12,7 +12,7 @@ use ratatui::widgets::{StatefulWidget, Widget};
 use crate::Theme;
 
 use super::engine::{DeclarationEnv, LayerKind, RenderPass};
-use super::{ChildId, Event, KeyChord, MouseButton, TabWrap};
+use super::{ChildId, Event, KeyChord, MouseButton, MouseEvent, TabWrap};
 
 /// What a component did with an event, and what should happen next.
 ///
@@ -193,6 +193,8 @@ impl<'a, State, Msg> DeclareCtx<'a, State, Msg> {
     /// [`declare`](Component::declare) it means that component and its children,
     /// inside a [`scope`](Self::scope) it means the scope, and from the root
     /// closure it means "the pointer is on something declared at all".
+    /// Subtree identity is global across layers: an escaped popup belongs to
+    /// the component that declared it, wherever its geometry lands.
     ///
     /// # It answers with the last resolved hover
     ///
@@ -214,6 +216,22 @@ impl<'a, State, Msg> DeclareCtx<'a, State, Msg> {
     #[must_use]
     pub fn pointer_within(&self) -> bool {
         self.pass.pointer_within_current()
+    }
+
+    /// Whether the pointer rests inside this declaration *and* on the
+    /// rectangle it was given.
+    ///
+    /// [`pointer_within`](Self::pointer_within) follows subtree identity
+    /// across layers, so an escaped popup keeps its owner's answer true wherever
+    /// the popup sits. This adds the geometric half, for a component whose own
+    /// rectangle can move out from under a still pointer — through reflow, or
+    /// because a [`viewport`](Self::viewport) scrolled it away.
+    #[must_use]
+    pub fn pointer_within_area(&self) -> bool {
+        self.pointer_within()
+            && self
+                .hover_position
+                .is_some_and(|position| self.area.contains(position))
     }
 
     /// Read the transient stored at the current declaration's identity path,
@@ -306,6 +324,41 @@ impl<'a, State, Msg> DeclareCtx<'a, State, Msg> {
             state: self.state,
         };
         declare(&mut ctx);
+    }
+
+    /// Declare descendants in a vertically scrollable coordinate space.
+    ///
+    /// `screen` is the visible rectangle. Descendants are declared against
+    /// logical content that shares its origin and width and is
+    /// `content_height` rows tall, with `offset` naming the first content row
+    /// on screen; a larger offset is clamped to the last one that fills the
+    /// rectangle. Every widget paints with its full logical allocation, and
+    /// the result is translated and clipped afterwards. Pointer input arrives
+    /// in the same logical coordinates, and paint outside the logical content
+    /// is clipped away.
+    ///
+    /// A popup, hint, modal, or [`defer_paint`](Self::defer_paint) closure
+    /// declared inside escapes the clip and is projected into screen
+    /// coordinates once.
+    ///
+    /// This is the mechanism behind [`ScrollArea`](crate::ScrollArea), and
+    /// what a component of your own builds a viewport from. The offset such a
+    /// component chooses on the runtime's behalf comes from
+    /// [`Component::reveal_in_viewport`].
+    ///
+    /// # Panics
+    ///
+    /// Panics when a viewport is declared inside another, and when the logical
+    /// content exceeds 262,144 cells.
+    pub fn viewport(
+        &mut self,
+        screen: Rect,
+        content_height: u16,
+        offset: u16,
+        declare: impl FnOnce(&mut DeclareCtx<'_, State, Msg>),
+    ) {
+        let (pass, env) = self.declaring(screen);
+        pass.viewport(screen, content_height, offset, env, declare);
     }
 
     /// The pass and the declaration environment for a child covering `area`.
@@ -620,45 +673,121 @@ impl<Msg> PopupOptions<Msg> {
 /// [`PaintCtx`] are the two public faces over it, and they differ in what
 /// else they carry rather than in where they write.
 pub(crate) enum PaintTarget<'a, 'frame> {
-    Frame(&'a mut Frame<'frame>),
-    Canvas(&'a mut super::engine::LayerCanvas),
+    /// The frame itself.
+    Frame(&'a mut Frame<'frame>, Option<super::engine::Viewport>),
+    /// A layer's canvas.
+    Canvas(
+        &'a mut super::engine::LayerCanvas,
+        Option<super::engine::Viewport>,
+    ),
+    /// A viewport's own logical canvas.
+    Viewport(&'a mut super::engine::ViewportCanvas),
 }
 
 impl PaintTarget<'_, '_> {
-    fn widget(&mut self, widget: impl Widget, area: Rect) {
+    /// Paint `area` through this target: `paint` receives the buffer to write
+    /// and the rectangle to write it in.
+    ///
+    /// The three write forms differ only in what they hand that closure, so
+    /// routing — which buffer, which clip, which projection, what counts as
+    /// painted — is settled once, here.
+    fn paint_at<R>(&mut self, area: Rect, paint: impl FnOnce(Rect, &mut Buffer) -> R) -> R {
         match self {
-            Self::Frame(frame) => frame.render_widget(widget, area),
-            Self::Canvas(canvas) => {
-                widget.render(area.intersection(canvas.buffer.area), &mut canvas.buffer);
-                canvas.mark_painted(area);
+            Self::Frame(frame, projection) => match *projection {
+                None => paint(area, frame.buffer_mut()),
+                Some(viewport) => {
+                    with_projected_buffer(frame.buffer_mut(), viewport, area, |buffer| {
+                        paint(area, buffer)
+                    })
+                }
+            },
+            Self::Canvas(canvas, projection) => match *projection {
+                None => {
+                    let clipped = area.intersection(canvas.buffer.area);
+                    let result = canvas.with_buffer(|buffer| paint(clipped, buffer));
+                    canvas.mark_painted(area);
+                    result
+                }
+                Some(viewport) => {
+                    let painted = viewport.project_rect(area, canvas.buffer.area);
+                    let result = canvas.with_buffer(|buffer| {
+                        with_projected_buffer(buffer, viewport, area, |buffer| paint(area, buffer))
+                    });
+                    canvas.mark_painted(painted);
+                    result
+                }
+            },
+            Self::Viewport(canvas) => {
+                let clipped = canvas.clip(area);
+                let result = canvas.with_buffer(|buffer| paint(clipped, buffer));
+                canvas.mark_painted(clipped);
+                result
             }
         }
+    }
+
+    /// The whole of what this target writes, in the coordinates its paint
+    /// closure uses — the allocation a free-form [`Self::with_buffer`] covers.
+    fn whole_area(&mut self) -> Rect {
+        match self {
+            Self::Frame(frame, projection) => {
+                let area = frame.area();
+                (*projection).map_or(area, |viewport| viewport.logical_frame(area))
+            }
+            Self::Canvas(canvas, projection) => {
+                let area = canvas.buffer.area;
+                (*projection).map_or(area, |viewport| viewport.logical_frame(area))
+            }
+            Self::Viewport(canvas) => canvas.buffer.area,
+        }
+    }
+
+    fn widget(&mut self, widget: impl Widget, area: Rect) {
+        self.paint_at(area, |area, buffer| widget.render(area, buffer));
     }
 
     fn stateful_widget<W: StatefulWidget>(&mut self, widget: W, area: Rect, state: &mut W::State) {
-        match self {
-            Self::Frame(frame) => frame.render_stateful_widget(widget, area, state),
-            Self::Canvas(canvas) => {
-                widget.render(
-                    area.intersection(canvas.buffer.area),
-                    &mut canvas.buffer,
-                    state,
-                );
-                canvas.mark_painted(area);
-            }
-        }
+        self.paint_at(area, |area, buffer| widget.render(area, buffer, state));
     }
 
     fn with_buffer<R>(&mut self, paint: impl FnOnce(&mut Buffer) -> R) -> R {
-        match self {
-            Self::Frame(frame) => paint(frame.buffer_mut()),
-            Self::Canvas(canvas) => {
-                let area = canvas.buffer.area;
-                canvas.mark_painted(area);
-                paint(&mut canvas.buffer)
-            }
+        let area = self.whole_area();
+        self.paint_at(area, |_, buffer| paint(buffer))
+    }
+}
+
+/// Paint `logical` into `target` through `viewport`.
+///
+/// The closure sees a scratch buffer covering exactly the logical rectangle,
+/// so a widget lays out against its declared allocation; the rows that project
+/// onto the target are copied back afterwards.
+fn with_projected_buffer<R>(
+    target: &mut Buffer,
+    viewport: super::engine::Viewport,
+    logical: Rect,
+    paint: impl FnOnce(&mut Buffer) -> R,
+) -> R {
+    let mut scratch = Buffer::empty(logical);
+    for (logical_position, screen_position) in viewport.projected_positions(logical) {
+        if let (Some(source), Some(destination)) = (
+            target.cell(screen_position),
+            scratch.cell_mut(logical_position),
+        ) {
+            *destination = source.clone();
         }
     }
+
+    let result = paint(&mut scratch);
+
+    for (logical_position, screen_position) in viewport.projected_positions(logical) {
+        if let (Some(source), Some(destination)) = (
+            scratch.cell(logical_position),
+            target.cell_mut(screen_position),
+        ) {
+            *destination = source.clone();
+        }
+    }
+    result
 }
 
 /// Paint-only access to the active paint surface, handed to deferred paint
@@ -993,8 +1122,18 @@ pub struct EventCtx<'a> {
     /// [`transient`](Self::transient) without special-casing. Values live and
     /// die with this context, which is exactly what "no dispatch" means.
     detached_transients: Option<Box<TransientMap>>,
-    capture: Option<&'a mut Option<Vec<ChildId>>>,
-    capture_button: Option<MouseButton>,
+    pub(super) pointer: PointerInputs<'a>,
+}
+
+/// The pointer facts one dispatch carries into an [`EventCtx`].
+#[derive(Default)]
+pub(crate) struct PointerInputs<'a> {
+    /// Where a [`EventCtx::capture_pointer`] claim is recorded.
+    pub(crate) capture: Option<&'a mut Option<Vec<ChildId>>>,
+    /// The button holding the capture this event belongs to.
+    pub(crate) button: Option<MouseButton>,
+    /// The event as it arrived, before any declaration-space projection.
+    pub(crate) screen_mouse: Option<MouseEvent>,
 }
 
 impl fmt::Debug for EventCtx<'_> {
@@ -1002,7 +1141,8 @@ impl fmt::Debug for EventCtx<'_> {
         f.debug_struct("EventCtx")
             .field("path", &self.path)
             .field("transients_available", &self.transients.is_some())
-            .field("capture_button", &self.capture_button)
+            .field("capture_button", &self.pointer.button)
+            .field("screen_mouse", &self.pointer.screen_mouse)
             .finish()
     }
 }
@@ -1012,16 +1152,14 @@ impl<'a> EventCtx<'a> {
         path: &[ChildId],
         area: Rect,
         transients: &'a mut TransientMap,
-        capture: &'a mut Option<Vec<ChildId>>,
-        capture_button: Option<MouseButton>,
+        pointer: PointerInputs<'a>,
     ) -> Self {
         Self {
             path: path.to_vec(),
             area,
             transients: Some(transients),
             detached_transients: None,
-            capture: Some(capture),
-            capture_button,
+            pointer,
         }
     }
 
@@ -1061,6 +1199,11 @@ impl<'a> EventCtx<'a> {
 
     /// The area this component was declared with on the last successful
     /// render — the same rect the event was hit-tested against.
+    ///
+    /// Inside a [`viewport`](DeclareCtx::viewport) this is content geometry,
+    /// and the [`MouseEvent`] coordinates dispatched with it share that space.
+    /// So do [`DragPhase`](super::DragPhase) positions; see
+    /// [`drag`](Self::drag).
     ///
     /// Components that need event-time geometry (a dialog hit-testing its own
     /// border for a drag, say) read it from here instead of caching the area
@@ -1180,11 +1323,12 @@ impl<'a> EventCtx<'a> {
     /// gesture, not join one in progress.
     pub fn capture_pointer(&mut self, button: MouseButton) {
         assert_eq!(
-            self.capture_button,
+            self.pointer.button,
             Some(button),
             "EventCtx::capture_pointer({button:?}) requires the matching MouseKind::Down"
         );
         let capture = self
+            .pointer
             .capture
             .as_deref_mut()
             .expect("EventCtx::capture_pointer is unavailable outside Ratcn event dispatch");
@@ -1341,6 +1485,20 @@ pub trait Component<State, Msg> {
     ) -> EventResult<Msg> {
         EventResult::Ignored
     }
+
+    /// Bring `target` into view inside this component's
+    /// [`viewport`](DeclareCtx::viewport).
+    ///
+    /// The runtime calls this on the component that declared the viewport
+    /// whenever focus lands on a descendant the viewport is clipping, before
+    /// it emits the app's focus message. `target` is the descendant's logical
+    /// area, in the coordinates the viewport was declared with.
+    ///
+    /// The offset the component chooses belongs in an
+    /// [`EventCtx::transient`], which the next declaration reads. This adds to
+    /// a focus change: the app's focus message is emitted whatever happens
+    /// here.
+    fn reveal_in_viewport(&mut self, _target: Rect, _state: &State, _ctx: &mut EventCtx<'_>) {}
 
     /// Whether the component can hold focus, and so takes part in Tab
     /// traversal. Defaults to `false`; interactive leaves override it, often

--- a/crates/ratcn/src/runtime/drag.rs
+++ b/crates/ratcn/src/runtime/drag.rs
@@ -112,14 +112,15 @@ pub enum DragPhase {
         /// pointer has moved since the press. Unclamped — apply your own bound,
         /// such as [`clamp_offset`].
         offset: CellOffset,
-        /// Current pointer position, screen-absolute in cells.
+        /// Current pointer position, in the coordinate space the component was
+        /// declared with.
         position: Position,
     },
     /// The button was released and the gesture's internal state has been
     /// cleared.
     Ended {
-        /// Where the release happened, screen-absolute in cells — hit-test this
-        /// to find a drop target.
+        /// Where the release happened, in the coordinate space the component
+        /// was declared with — hit-test this to find a drop target.
         position: Position,
         /// False if the pointer never actually moved, which lets you treat the
         /// gesture as a click on the handle rather than as a drag.
@@ -165,6 +166,13 @@ impl EventCtx<'_> {
     /// is. Anything not part of that gesture comes back as
     /// [`DragPhase::Ignored`].
     ///
+    /// [`DragPhase`] positions are in the coordinate space the component was
+    /// declared with, matching [`EventCtx::area`](Self::area) and the
+    /// [`MouseEvent`] passed in. The anchor a gesture starts from is kept
+    /// internally in screen coordinates, so scrolling a
+    /// [`viewport`](super::DeclareCtx::viewport) mid-gesture leaves the offset
+    /// measuring pointer travel alone.
+    ///
     /// The gesture is tracked against the component's identity path, so it
     /// survives the component instance being rebuilt each frame. What it does
     /// not survive is the path itself disappearing: if a successful render no
@@ -181,12 +189,13 @@ impl EventCtx<'_> {
     /// keep an unrelated transient.
     pub fn drag(&mut self, mouse: &MouseEvent, options: DragOptions) -> DragPhase {
         let position = Position::new(mouse.column, mouse.row);
+        let screen = self.pointer.screen_mouse.unwrap_or(*mouse);
         match mouse.kind {
             MouseKind::Down(button) if button == options.button && options.can_start => {
                 self.capture_pointer(button);
                 *self.transient::<CapturedDrag>() = CapturedDrag(Some(ActiveDrag {
                     button,
-                    anchor: AnchorPoint::at(mouse.column, mouse.row, options.offset),
+                    anchor: AnchorPoint::at(screen.column, screen.row, options.offset),
                     moved: false,
                 }));
                 DragPhase::Down
@@ -201,7 +210,7 @@ impl EventCtx<'_> {
                 }
                 drag.moved = true;
                 DragPhase::Moved {
-                    offset: drag.anchor.offset_at(mouse.column, mouse.row),
+                    offset: drag.anchor.offset_at(screen.column, screen.row),
                     position,
                 }
             }
@@ -326,6 +335,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use crate::runtime::component::PointerInputs;
     use crate::runtime::{ChildId, Modifiers};
 
     fn mouse(kind: MouseKind, column: u16, row: u16) -> MouseEvent {
@@ -346,8 +356,11 @@ mod tests {
             &path,
             Rect::ZERO,
             &mut transients,
-            &mut capture,
-            Some(MouseButton::Left),
+            PointerInputs {
+                capture: Some(&mut capture),
+                button: Some(MouseButton::Left),
+                screen_mouse: None,
+            },
         );
 
         assert_eq!(
@@ -360,7 +373,16 @@ mod tests {
         assert_eq!(capture, Some(path.to_vec()));
 
         let mut no_capture = None;
-        let mut ctx = EventCtx::at(&path, Rect::ZERO, &mut transients, &mut no_capture, None);
+        let mut ctx = EventCtx::at(
+            &path,
+            Rect::ZERO,
+            &mut transients,
+            PointerInputs {
+                capture: Some(&mut no_capture),
+                button: None,
+                screen_mouse: None,
+            },
+        );
         assert_eq!(
             ctx.drag(
                 &mouse(MouseKind::Up(MouseButton::Left), 2, 3),
@@ -383,8 +405,11 @@ mod tests {
             &path,
             Rect::ZERO,
             &mut transients,
-            &mut capture,
-            Some(MouseButton::Left),
+            PointerInputs {
+                capture: Some(&mut capture),
+                button: Some(MouseButton::Left),
+                screen_mouse: None,
+            },
         )
         .drag(
             &mouse(MouseKind::Down(MouseButton::Left), 5, 5),
@@ -392,7 +417,17 @@ mod tests {
         );
 
         let mut no_capture = None;
-        let phase = EventCtx::at(&path, Rect::ZERO, &mut transients, &mut no_capture, None).drag(
+        let phase = EventCtx::at(
+            &path,
+            Rect::ZERO,
+            &mut transients,
+            PointerInputs {
+                capture: Some(&mut no_capture),
+                button: None,
+                screen_mouse: None,
+            },
+        )
+        .drag(
             &mouse(MouseKind::Drag(MouseButton::Left), 9, 2),
             DragOptions::new(CellOffset::default()).start_if(false),
         );
@@ -414,8 +449,11 @@ mod tests {
             &path,
             Rect::ZERO,
             &mut transients,
-            &mut capture,
-            Some(MouseButton::Right),
+            PointerInputs {
+                capture: Some(&mut capture),
+                button: Some(MouseButton::Right),
+                screen_mouse: None,
+            },
         );
 
         assert_eq!(
@@ -442,8 +480,11 @@ mod tests {
             &path,
             Rect::ZERO,
             &mut transients,
-            &mut capture,
-            Some(MouseButton::Left),
+            PointerInputs {
+                capture: Some(&mut capture),
+                button: Some(MouseButton::Left),
+                screen_mouse: None,
+            },
         )
         .drag(
             &mouse(MouseKind::Down(MouseButton::Left), 5, 5),
@@ -451,7 +492,16 @@ mod tests {
         );
 
         let mut no_capture = None;
-        let mut ctx = EventCtx::at(&path, Rect::ZERO, &mut transients, &mut no_capture, None);
+        let mut ctx = EventCtx::at(
+            &path,
+            Rect::ZERO,
+            &mut transients,
+            PointerInputs {
+                capture: Some(&mut no_capture),
+                button: None,
+                screen_mouse: None,
+            },
+        );
         assert_eq!(
             ctx.drag(
                 &mouse(MouseKind::Drag(MouseButton::Right), 9, 2),

--- a/crates/ratcn/src/runtime/engine.rs
+++ b/crates/ratcn/src/runtime/engine.rs
@@ -13,8 +13,11 @@ use super::{
     ChildId, Component, DeclareCtx, Event, EventCtx, EventResult, FocusState, KeyCode, KeyEvent,
     ModalState, MouseButton, MouseEvent, MouseKind, MouseTracker, PaintCtx, Painter, ScopeOptions,
     Step, TabWrap,
-    component::{InteractionFlags, PaintTarget, TransientMap},
+    component::{InteractionFlags, PaintTarget, PointerInputs, TransientMap},
 };
+
+// The per-viewport paint canvas holds one Ratatui cell per logical content cell.
+const MAX_VIEWPORT_CELLS: usize = 262_144;
 
 struct FocusBinding<State, Msg> {
     read: Box<dyn Fn(&State) -> &FocusState>,
@@ -23,6 +26,151 @@ struct FocusBinding<State, Msg> {
 
 struct ModalBinding<State> {
     read: Box<dyn Fn(&State) -> &ModalState>,
+}
+
+/// One vertical logical-content coordinate space projected into a screen rect.
+///
+/// The logical content shares the screen rectangle's origin and width and is
+/// `content_height` rows tall. `offset` is the first content row on screen, so
+/// the whole projection is a row shift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Viewport {
+    screen: Rect,
+    content_height: u16,
+    offset: u16,
+}
+
+/// How much of a node its viewport shows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ViewportVisibility {
+    /// No viewport clips this node, or every row of it is on screen.
+    Full,
+    /// Some rows are on screen.
+    Partial,
+    /// No row is on screen.
+    Hidden,
+}
+
+impl Viewport {
+    /// The full logical allocation descendants are declared against.
+    fn content(self) -> Rect {
+        Rect::new(
+            self.screen.x,
+            self.screen.y,
+            self.screen.width,
+            self.content_height,
+        )
+    }
+
+    /// The logical rows the screen rectangle shows at this offset.
+    fn visible_content(self) -> Rect {
+        Rect::new(
+            self.screen.x,
+            self.screen.y.saturating_add(self.offset),
+            self.screen.width,
+            self.screen.height,
+        )
+        .intersection(self.content())
+    }
+
+    fn visibility(self, area: Rect) -> ViewportVisibility {
+        let visible = area.intersection(self.visible_content());
+        if visible == area {
+            ViewportVisibility::Full
+        } else if visible.is_empty() {
+            ViewportVisibility::Hidden
+        } else {
+            ViewportVisibility::Partial
+        }
+    }
+
+    /// The one screen-to-logical translation: a row moves down by the offset
+    /// and a column stays put. `None` past the coordinate limit.
+    fn to_logical(self, point: Position) -> Option<Position> {
+        Some(Position::new(point.x, point.y.checked_add(self.offset)?))
+    }
+
+    /// [`Self::to_logical`], clamped to the last representable row for the
+    /// callers that owe an answer for every point.
+    fn to_logical_clamped(self, point: Position) -> Position {
+        self.to_logical(point)
+            .unwrap_or_else(|| Position::new(point.x, u16::MAX))
+    }
+
+    /// [`Self::to_logical`] for points inside the visible screen rectangle.
+    fn visible_to_logical(self, point: Position) -> Option<Position> {
+        self.screen
+            .contains(point)
+            .then(|| self.to_logical(point))
+            .flatten()
+    }
+
+    fn mouse_to_logical(self, mouse: MouseEvent) -> MouseEvent {
+        let point = self.to_logical_clamped(Position::new(mouse.column, mouse.row));
+        MouseEvent {
+            column: point.x,
+            row: point.y,
+            ..mouse
+        }
+    }
+
+    /// A logical rectangle in screen coordinates, clipped to `clip`. Rows that
+    /// project above the screen are dropped.
+    pub(crate) fn project_rect(self, area: Rect, clip: Rect) -> Rect {
+        let above = self.offset.saturating_sub(area.y);
+        if above >= area.height {
+            return Rect::ZERO;
+        }
+        // `max` then subtract: both operands are at least `offset`.
+        let projected = Rect::new(
+            area.x,
+            area.y.max(self.offset) - self.offset,
+            area.width,
+            area.height - above,
+        )
+        .intersection(clip);
+        if projected.is_empty() {
+            Rect::ZERO
+        } else {
+            projected
+        }
+    }
+
+    /// A logical row in screen coordinates, `None` when it sits above the
+    /// screen.
+    const fn to_screen_row(self, row: u16) -> Option<u16> {
+        row.checked_sub(self.offset)
+    }
+
+    /// Every cell of `logical` paired with the screen cell it projects onto.
+    pub(crate) fn projected_positions(
+        self,
+        logical: Rect,
+    ) -> impl Iterator<Item = (Position, Position)> {
+        (logical.y..logical.bottom()).flat_map(move |y| {
+            let screen_y = self.to_screen_row(y);
+            (logical.x..logical.right())
+                .filter_map(move |x| Some((Position::new(x, y), Position::new(x, screen_y?))))
+        })
+    }
+
+    /// The frame rectangle in this viewport's logical coordinates.
+    pub(crate) fn logical_frame(self, frame: Rect) -> Rect {
+        Rect {
+            y: frame.y.saturating_add(self.offset),
+            ..frame
+        }
+    }
+}
+
+/// One declared viewport, and where it sits in the tree being built.
+struct ViewportRecord {
+    viewport: Viewport,
+    /// The declaration that opened it, once one is open.
+    owner: Option<usize>,
+    /// The layer open at declaration. A descendant on another layer escaped
+    /// the clip.
+    layer: usize,
 }
 
 enum FocusAdvance {
@@ -136,6 +284,9 @@ pub(crate) struct Node<State, Msg> {
     parent: Option<usize>,
     children: Vec<usize>,
     area: Rect,
+    /// Index into [`Surface::viewports`] of the innermost viewport this node
+    /// was declared inside.
+    viewport: Option<usize>,
     options: ScopeOptions,
     is_scope: bool,
     self_focusable: bool,
@@ -156,6 +307,7 @@ impl<State, Msg> fmt::Debug for Node<State, Msg> {
             .field("parent", &self.parent)
             .field("children", &self.children)
             .field("area", &self.area)
+            .field("viewport", &self.viewport)
             .field("options", &self.options)
             .field("is_scope", &self.is_scope)
             .field("self_focusable", &self.self_focusable)
@@ -177,6 +329,8 @@ pub(crate) struct Surface<State, Msg> {
     /// The policy of each layer, indexed by the layer number nodes carry.
     /// Index 0 is the base layer.
     layer_policies: Vec<LayerPolicy>,
+    /// Every viewport declared this pass, in declaration order.
+    viewports: Vec<ViewportRecord>,
 }
 
 impl<State, Msg> Default for Surface<State, Msg> {
@@ -186,6 +340,7 @@ impl<State, Msg> Default for Surface<State, Msg> {
             roots: Vec::new(),
             layer_roots: Vec::new(),
             layer_policies: vec![LayerPolicy::base()],
+            viewports: Vec::new(),
         }
     }
 }
@@ -197,6 +352,7 @@ impl<State, Msg> fmt::Debug for Surface<State, Msg> {
             .field("roots", &self.roots.len())
             .field("layer_roots", &self.layer_roots.len())
             .field("layer_policies", &self.layer_policies.len())
+            .field("viewports", &self.viewports.len())
             .finish()
     }
 }
@@ -447,7 +603,10 @@ impl<State, Msg> Surface<State, Msg> {
         let matched = self.nodes_along_path(path);
         matched.len() == path.len()
             && matched.last().is_some_and(|&index| {
-                self.participates(index) && self.has_hit_geometry(index) && self.interactive(index)
+                self.participates(index)
+                    && self.has_hit_geometry(index)
+                    && self.interactive(index)
+                    && self.viewport_visibility(index) != ViewportVisibility::Hidden
             })
     }
 
@@ -470,7 +629,9 @@ impl<State, Msg> Surface<State, Msg> {
                 && self.interactive(index)
                 && self.participates(index)
                 && self.has_hit_geometry(index)
-                && node.area.contains(point)
+                && self
+                    .logical_point(index, point)
+                    .is_some_and(|point| node.area.contains(point))
             {
                 let key = (node.layer, index);
                 if best.is_none_or(|best| key > best) {
@@ -691,6 +852,36 @@ impl<State, Msg> Surface<State, Msg> {
             })
     }
 
+    /// The viewport that clips `index`, if one does. A node declared on a
+    /// layer opened inside a viewport escaped that clip and has none.
+    fn clipping_viewport(&self, index: usize) -> Option<&ViewportRecord> {
+        let node = &self.nodes[index];
+        let record = &self.viewports[node.viewport?];
+        (record.layer == node.layer).then_some(record)
+    }
+
+    /// How much of `index` its viewport shows. The one answer behind pointer
+    /// eligibility, anchor culling, and whether focus needs revealing.
+    fn viewport_visibility(&self, index: usize) -> ViewportVisibility {
+        self.clipping_viewport(index)
+            .map_or(ViewportVisibility::Full, |record| {
+                record.viewport.visibility(self.nodes[index].area)
+            })
+    }
+
+    /// `point` in the coordinate space `index` was declared with.
+    fn logical_point(&self, index: usize, point: Position) -> Option<Position> {
+        let node = &self.nodes[index];
+        let Some(record) = node.viewport.map(|index| &self.viewports[index]) else {
+            return Some(point);
+        };
+        if record.layer == node.layer {
+            record.viewport.visible_to_logical(point)
+        } else {
+            record.viewport.to_logical(point)
+        }
+    }
+
     fn next_focus(
         &self,
         focus: &FocusState,
@@ -721,7 +912,7 @@ impl<State, Msg> Surface<State, Msg> {
             let Some(current) = parent else {
                 return FocusAdvance::Ignored;
             };
-            return self.next_from_scope(current, focus, direction, root_options);
+            return self.next_from_scope(current, direction, root_options);
         }
 
         let Some(current) = matched.last().copied() else {
@@ -729,13 +920,17 @@ impl<State, Msg> Surface<State, Msg> {
                 .edge_focus(None, direction)
                 .map_or(FocusAdvance::Ignored, FocusAdvance::Move);
         };
-        self.next_from_scope(current, focus, direction, root_options)
+        self.next_from_scope(current, direction, root_options)
     }
 
+    /// The next focusable node after `current`, walking outwards until a
+    /// scope wraps or the root runs out.
+    ///
+    /// A step that lands back on the node it started from is still a
+    /// `Move`; the caller compares it against the current focus.
     fn next_from_scope(
         &self,
         mut current: usize,
-        focus: &FocusState,
         direction: Step,
         root_options: &ScopeOptions,
     ) -> FocusAdvance {
@@ -773,11 +968,7 @@ impl<State, Msg> Surface<State, Msg> {
                 let mut path = parent.map_or_else(Vec::new, |index| self.path_of(index));
                 self.extend_to_edge(next, direction, &mut path);
                 let next = FocusState::intent(path);
-                return if next == *focus {
-                    FocusAdvance::Consumed
-                } else {
-                    FocusAdvance::Move(next)
-                };
+                return FocusAdvance::Move(next);
             }
             let Some(parent) = parent else {
                 return FocusAdvance::Ignored;
@@ -787,7 +978,15 @@ impl<State, Msg> Surface<State, Msg> {
     }
 }
 
-type DeferredPaint<State> = Box<dyn FnOnce(&mut Painter<'_, '_>, &State)>;
+type DeferredThunk<State> = Box<dyn FnOnce(&mut Painter<'_, '_>, &State)>;
+
+/// One closure registered through [`DeclareCtx::defer_paint`], with the
+/// viewport projection open where it was registered.
+struct DeferredPaint<State> {
+    layer: usize,
+    projection: Option<Viewport>,
+    paint: DeferredThunk<State>,
+}
 
 type PaintThunk<State> = Box<dyn FnOnce(&mut PaintCtx<'_, '_, State>)>;
 
@@ -800,11 +999,19 @@ type PaintThunk<State> = Box<dyn FnOnce(&mut PaintCtx<'_, '_, State>)>;
 /// component is queued where it opens, so its own paint precedes its
 /// descendants'.
 struct QueuedPaint<State> {
-    /// Index into `RenderPass::canvases`, or `None` to paint on the frame.
+    /// The surface fixed where the op was queued.
     /// Fixed where the op was queued, so an op belongs to the layer that was
     /// open at its declaration whatever is open at replay.
-    canvas: Option<usize>,
+    target: PaintDestination,
+    projection: Option<Viewport>,
     op: PaintOp<State>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PaintDestination {
+    Frame,
+    Layer(usize),
+    Viewport(usize),
 }
 
 /// Every op names the node whose position it paints at, because that node is
@@ -826,6 +1033,11 @@ enum PaintOp<State> {
     /// layer's declaration closed — which is what keeps [`DeclareCtx::defer_paint`]
     /// above its layer's content.
     FlushDeferred { layer: usize },
+    /// Seed the visible logical cells with paint already present beneath the
+    /// viewport at this exact point in declaration order.
+    PrimeViewport { viewport: usize },
+    /// Copy a completed logical viewport canvas into its screen allocation.
+    CompositeViewport { viewport: usize },
 }
 
 impl<State> PaintOp<State> {
@@ -836,7 +1048,9 @@ impl<State> PaintOp<State> {
         match self {
             Self::Node { index, .. } => Some(*index),
             Self::Thunk { node, .. } => *node,
-            Self::FlushDeferred { .. } => None,
+            Self::FlushDeferred { .. }
+            | Self::PrimeViewport { .. }
+            | Self::CompositeViewport { .. } => None,
         }
     }
 }
@@ -866,6 +1080,56 @@ pub(crate) struct LayerCanvas {
     area: Rect,
     pub(crate) buffer: Buffer,
     painted: Vec<Rect>,
+    /// Set when a paint into this canvas unwinds. A poisoned canvas never
+    /// composites, so the frame keeps what was under it.
+    failed: bool,
+}
+
+/// Full logical content for one viewport. Widgets paint here with their
+/// original allocations; only the final copy is clipped to the viewport.
+pub(crate) struct ViewportCanvas {
+    viewport: Viewport,
+    pub(crate) buffer: Buffer,
+    painted: Vec<Rect>,
+    /// Set when a paint into this canvas unwinds. A poisoned canvas never
+    /// composites, so the frame keeps what was under it.
+    failed: bool,
+}
+
+impl ViewportCanvas {
+    fn new(viewport: Viewport) -> Self {
+        Self {
+            viewport,
+            buffer: Buffer::empty(viewport.content()),
+            painted: Vec::new(),
+            failed: false,
+        }
+    }
+
+    /// The part of `area` this canvas can hold. Paint outside the logical
+    /// content is clipped away.
+    pub(crate) fn clip(&self, area: Rect) -> Rect {
+        area.intersection(self.viewport.content())
+    }
+
+    /// Paint into this canvas, poisoning it if the closure unwinds. What was
+    /// painted is the caller's to record through [`Self::mark_painted`].
+    pub(crate) fn with_buffer<R>(&mut self, paint: impl FnOnce(&mut Buffer) -> R) -> R {
+        let mut poison = PoisonCanvas {
+            failed: &mut self.failed,
+            armed: true,
+        };
+        let result = paint(&mut self.buffer);
+        poison.armed = false;
+        result
+    }
+
+    pub(crate) fn mark_painted(&mut self, area: Rect) {
+        let clipped = self.clip(area);
+        if !clipped.is_empty() {
+            self.painted.push(clipped);
+        }
+    }
 }
 
 impl LayerCanvas {
@@ -875,7 +1139,20 @@ impl LayerCanvas {
             area,
             buffer: Buffer::empty(area),
             painted: Vec::new(),
+            failed: false,
         }
+    }
+
+    /// Paint into this canvas, poisoning it if the closure unwinds. What was
+    /// painted is the caller's to record through [`Self::mark_painted`].
+    pub(crate) fn with_buffer<R>(&mut self, paint: impl FnOnce(&mut Buffer) -> R) -> R {
+        let mut poison = PoisonCanvas {
+            failed: &mut self.failed,
+            armed: true,
+        };
+        let result = paint(&mut self.buffer);
+        poison.armed = false;
+        result
     }
 
     /// Record that `area` was painted, clipped to the canvas.
@@ -883,6 +1160,21 @@ impl LayerCanvas {
         let clipped = area.intersection(self.area);
         if clipped.width > 0 && clipped.height > 0 {
             self.painted.push(clipped);
+        }
+    }
+}
+
+/// Poisons one canvas when dropped by unwinding, so a paint panic a component
+/// catches still keeps that canvas off the frame.
+struct PoisonCanvas<'a> {
+    failed: &'a mut bool,
+    armed: bool,
+}
+
+impl Drop for PoisonCanvas<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            *self.failed = true;
         }
     }
 }
@@ -984,6 +1276,7 @@ impl NodeRole {
 }
 
 pub(crate) struct RenderPass<State, Msg> {
+    frame_area: Rect,
     surface: Surface<State, Msg>,
     parent_stack: Vec<usize>,
     /// The identity path of the open declaration chain, maintained in step
@@ -996,7 +1289,7 @@ pub(crate) struct RenderPass<State, Msg> {
     /// in: a layer's thunks flush into its canvas when the layer ends, the
     /// base layer's flush onto the frame after every canvas has composited,
     /// which is what makes root-level `defer_paint` the topmost slot.
-    deferred: Vec<(usize, DeferredPaint<State>)>,
+    deferred: Vec<DeferredPaint<State>>,
     /// Every paint this frame owes, in the order the declaration walk reached
     /// it, replayed by [`Self::replay_paint`] once the walk is over.
     paint_queue: Vec<QueuedPaint<State>>,
@@ -1020,8 +1313,15 @@ pub(crate) struct RenderPass<State, Msg> {
     layer_stack: Vec<usize>,
     /// One canvas per declared layer, in discovery order.
     canvases: Vec<LayerCanvas>,
-    /// Indices into `canvases` for the layers currently open, innermost last.
-    canvas_stack: Vec<usize>,
+    /// One canvas per declared viewport, in discovery order and indexed the
+    /// same as [`Surface::viewports`].
+    viewport_canvases: Vec<ViewportCanvas>,
+    /// The open viewport, indexing `viewport_canvases`. A viewport declared
+    /// while one is open panics, so there is at most one.
+    open_viewport: Option<usize>,
+    /// Paint destinations in declaration nesting order; the innermost decides
+    /// where the next paint belongs.
+    destination_stack: Vec<PaintDestination>,
 }
 
 /// Poisons the pass when dropped by unwinding. Drop runs while a panic
@@ -1042,8 +1342,9 @@ impl Drop for PoisonOnUnwind {
 }
 
 impl<State, Msg> RenderPass<State, Msg> {
-    fn new() -> Self {
+    fn new(frame_area: Rect) -> Self {
         Self {
+            frame_area,
             surface: Surface::default(),
             parent_stack: Vec::new(),
             path_cursor: Vec::new(),
@@ -1055,7 +1356,9 @@ impl<State, Msg> RenderPass<State, Msg> {
             layers_declared: 0,
             layer_stack: Vec::new(),
             canvases: Vec::new(),
-            canvas_stack: Vec::new(),
+            viewport_canvases: Vec::new(),
+            open_viewport: None,
+            destination_stack: Vec::new(),
         }
     }
 
@@ -1099,16 +1402,34 @@ impl<State, Msg> RenderPass<State, Msg> {
         self.path_cursor.pop();
     }
 
-    /// The canvas the ops queued right now belong to, or `None` for the
-    /// frame.
-    fn active_canvas(&self) -> Option<usize> {
-        self.canvas_stack.last().copied()
+    /// The innermost declaration destination, or the frame at the root.
+    fn active_target(&self) -> PaintDestination {
+        self.destination_stack
+            .last()
+            .copied()
+            .unwrap_or(PaintDestination::Frame)
     }
 
-    /// Queue an op for the layer currently being declared into.
+    /// Queue an op for the destination currently being declared into.
     fn queue(&mut self, op: PaintOp<State>) {
-        let canvas = self.active_canvas();
-        self.paint_queue.push(QueuedPaint { canvas, op });
+        let target = self.active_target();
+        // A layer inside a viewport escaped the clip but still paints where
+        // the offset puts it, so its ops carry the projection.
+        let projection = match target {
+            PaintDestination::Layer(_) => self.open_projection(),
+            PaintDestination::Frame | PaintDestination::Viewport(_) => None,
+        };
+        self.paint_queue.push(QueuedPaint {
+            target,
+            projection,
+            op,
+        });
+    }
+
+    /// The open viewport's projection, if one is open.
+    fn open_projection(&self) -> Option<Viewport> {
+        self.open_viewport
+            .map(|index| self.viewport_canvases[index].viewport)
     }
 
     /// Queue a closure registered through [`DeclareCtx::paint`], tagged with
@@ -1132,6 +1453,54 @@ impl<State, Msg> RenderPass<State, Msg> {
     /// for the node itself but never for what it draws.
     fn queue_node(&mut self, index: usize, area: Rect) {
         self.queue(PaintOp::Node { index, area });
+    }
+
+    /// Open a viewport, declare its content through `declare`, and close it.
+    pub(crate) fn viewport(
+        &mut self,
+        screen: Rect,
+        content_height: u16,
+        offset: u16,
+        mut env: DeclarationEnv<'_, State>,
+        declare: impl FnOnce(&mut DeclareCtx<'_, State, Msg>),
+    ) {
+        self.guarded(|pass| {
+            assert!(
+                pass.open_viewport.is_none(),
+                "a viewport cannot be declared inside another viewport"
+            );
+            let cells = usize::from(screen.width) * usize::from(content_height);
+            assert!(
+                cells <= MAX_VIEWPORT_CELLS,
+                "viewport content is {cells} cells; the maximum is {MAX_VIEWPORT_CELLS}"
+            );
+            let viewport = Viewport {
+                screen,
+                content_height,
+                offset: offset.min(content_height.saturating_sub(screen.height)),
+            };
+            let index = pass.viewport_canvases.len();
+            pass.viewport_canvases.push(ViewportCanvas::new(viewport));
+            pass.surface.viewports.push(ViewportRecord {
+                viewport,
+                owner: pass.parent_stack.last().copied(),
+                layer: pass.current_layer(),
+            });
+            pass.queue(PaintOp::PrimeViewport { viewport: index });
+            pass.open_viewport = Some(index);
+            pass.destination_stack
+                .push(PaintDestination::Viewport(index));
+            env.area = viewport.content();
+            env.frame_area = viewport.logical_frame(pass.frame_area);
+            pass.with_declare_ctx(env, declare);
+            pass.open_viewport = None;
+            assert_eq!(
+                pass.destination_stack.pop(),
+                Some(PaintDestination::Viewport(index)),
+                "a declared viewport closes its own paint destination"
+            );
+            pass.queue(PaintOp::CompositeViewport { viewport: index });
+        });
     }
 
     /// Open a layer, declare its root subtree through `declare_root`, and
@@ -1159,8 +1528,12 @@ impl<State, Msg> RenderPass<State, Msg> {
         // not just the root.
         debug_assert_eq!(self.surface.layer_policies.len(), self.layers_declared);
         self.surface.layer_policies.push(kind.policy());
+        let area = self.open_projection().map_or(area, |viewport| {
+            viewport.project_rect(area, self.frame_area)
+        });
         self.canvases.push(LayerCanvas::new(kind, area));
-        self.canvas_stack.push(self.canvases.len() - 1);
+        let canvas = self.canvases.len() - 1;
+        self.destination_stack.push(PaintDestination::Layer(canvas));
     }
 
     /// Close the innermost layer, queueing its deferred paint behind
@@ -1173,9 +1546,13 @@ impl<State, Msg> RenderPass<State, Msg> {
         // Queued rather than run here: the layer's own content has only been
         // queued so far, and deferred paint has to land on top of it.
         self.queue(PaintOp::FlushDeferred { layer });
-        self.canvas_stack
-            .pop()
-            .expect("a declared layer opened a canvas");
+        assert!(
+            matches!(
+                self.destination_stack.pop(),
+                Some(PaintDestination::Layer(_))
+            ),
+            "a declared layer closes its own paint destination"
+        );
     }
 
     /// Run the deferred thunks registered in `layer` into its canvas.
@@ -1190,20 +1567,28 @@ impl<State, Msg> RenderPass<State, Msg> {
             let mut thunks = Vec::new();
             let mut index = 0;
             while index < pass.deferred.len() {
-                if pass.deferred[index].0 == layer {
-                    thunks.push(pass.deferred.remove(index).1);
+                if pass.deferred[index].layer == layer {
+                    thunks.push(pass.deferred.remove(index));
                 } else {
                     index += 1;
                 }
             }
-            for thunk in thunks {
-                let mut painter = Painter {
-                    target: PaintTarget::Canvas(&mut pass.canvases[canvas_index]),
-                    theme,
-                };
-                thunk(&mut painter, state);
+            for deferred in thunks {
+                let target =
+                    PaintTarget::Canvas(&mut pass.canvases[canvas_index], deferred.projection);
+                let mut painter = Painter { target, theme };
+                (deferred.paint)(&mut painter, state);
             }
         });
+    }
+
+    /// Whether anything this pass painted into unwound. A canvas poisons
+    /// itself even when component code catches the panic, so this is the one
+    /// question every commit and composite step asks.
+    fn poisoned(&self) -> bool {
+        self.failed.get()
+            || self.canvases.iter().any(|canvas| canvas.failed)
+            || self.viewport_canvases.iter().any(|canvas| canvas.failed)
     }
 
     /// Run `f` as one declaration region: if it unwinds — a panicking
@@ -1246,11 +1631,13 @@ impl<State, Msg> RenderPass<State, Msg> {
         );
         let index = self.surface.nodes.len();
         let layer = self.current_layer();
+        let viewport = self.open_viewport;
         self.surface.nodes.push(Node {
             id,
             parent,
             children: Vec::new(),
             area,
+            viewport,
             options,
             is_scope,
             self_focusable,
@@ -1378,12 +1765,24 @@ impl<State, Msg> RenderPass<State, Msg> {
             "a dismiss hook on a layer kind that never dismisses"
         );
         self.guarded(|pass| {
+            if matches!(kind, LayerKind::Popup | LayerKind::Hint)
+                && !pass.current_viewport_anchor_visible()
+            {
+                return;
+            }
             let area = env.area;
             pass.layer(kind, area, |pass, index| {
                 pass.scope(id, options, env, declare);
                 pass.surface.nodes[index].on_dismiss = on_dismiss;
             });
         });
+    }
+
+    /// Whether the declaration a popup or hint would anchor to is on screen.
+    fn current_viewport_anchor_visible(&self) -> bool {
+        self.parent_stack.last().is_none_or(|&parent| {
+            self.surface.viewport_visibility(parent) != ViewportVisibility::Hidden
+        })
     }
 
     pub(crate) fn scope(
@@ -1419,7 +1818,15 @@ impl<State, Msg> RenderPass<State, Msg> {
             transients,
             depth,
         } = env;
-        let hover_position = self.hover_position;
+        let hover_position = match (self.open_projection(), self.active_target()) {
+            (None, _) => self.hover_position,
+            (Some(viewport), PaintDestination::Viewport(_)) => self
+                .hover_position
+                .and_then(|position| viewport.visible_to_logical(position)),
+            (Some(viewport), PaintDestination::Frame | PaintDestination::Layer(_)) => self
+                .hover_position
+                .and_then(|position| viewport.to_logical(position)),
+        };
         self.guarded(|pass| {
             let mut ctx = DeclareCtx {
                 frame_area,
@@ -1439,7 +1846,11 @@ impl<State, Msg> RenderPass<State, Msg> {
         &mut self,
         paint: impl FnOnce(&mut Painter<'_, '_>, &State) + 'static,
     ) {
-        self.deferred.push((self.current_layer(), Box::new(paint)));
+        self.deferred.push(DeferredPaint {
+            layer: self.current_layer(),
+            projection: self.open_projection(),
+            paint: Box::new(paint),
+        });
     }
 
     /// Draw the frame: run every queued op in declaration order, each onto
@@ -1470,11 +1881,15 @@ impl<State, Msg> RenderPass<State, Msg> {
         // this is reached — and kept as the second half of the guarantee: it
         // is what would still hold if replay were ever moved ahead of the
         // checks.
-        if self.failed.get() {
+        if self.poisoned() {
             return;
         }
         for queued in std::mem::take(&mut self.paint_queue) {
-            let QueuedPaint { canvas, op } = queued;
+            let QueuedPaint {
+                target,
+                projection,
+                op,
+            } = queued;
             let frame = &mut *frame;
             self.guarded(|pass| {
                 // Read before the component borrow below, which needs the
@@ -1486,8 +1901,18 @@ impl<State, Msg> RenderPass<State, Msg> {
                 });
                 let (area, paint) = match op {
                     PaintOp::FlushDeferred { layer } => {
-                        let index = canvas.expect("a layer's flush names that layer's canvas");
+                        let PaintDestination::Layer(index) = target else {
+                            panic!("a layer's flush names that layer's canvas");
+                        };
                         pass.flush_deferred_for(layer, theme, state, index);
+                        return;
+                    }
+                    PaintOp::PrimeViewport { viewport } => {
+                        pass.prime_viewport(viewport, target, frame);
+                        return;
+                    }
+                    PaintOp::CompositeViewport { viewport } => {
+                        pass.composite_viewport(viewport, target, frame);
                         return;
                     }
                     PaintOp::Node { index, area } => {
@@ -1501,9 +1926,25 @@ impl<State, Msg> RenderPass<State, Msg> {
                     }
                     PaintOp::Thunk { area, paint, .. } => (area, PaintBody::Thunk(paint)),
                 };
-                let target = match canvas {
-                    Some(index) => PaintTarget::Canvas(&mut pass.canvases[index]),
-                    None => PaintTarget::Frame(frame),
+                let target = match target {
+                    PaintDestination::Frame => PaintTarget::Frame(frame, projection),
+                    PaintDestination::Layer(index) => {
+                        PaintTarget::Canvas(&mut pass.canvases[index], projection)
+                    }
+                    PaintDestination::Viewport(index) => {
+                        PaintTarget::Viewport(&mut pass.viewport_canvases[index])
+                    }
+                };
+                let hover_position = match (projection, &target) {
+                    (Some(viewport), _) => pass
+                        .hover_position
+                        .and_then(|position| viewport.to_logical(position)),
+                    (None, PaintTarget::Viewport(canvas)) => {
+                        let viewport = canvas.viewport;
+                        pass.hover_position
+                            .and_then(|position| viewport.visible_to_logical(position))
+                    }
+                    (None, _) => pass.hover_position,
                 };
                 let mut ctx = PaintCtx {
                     target,
@@ -1513,7 +1954,7 @@ impl<State, Msg> RenderPass<State, Msg> {
                     contains_focus: flags.contains_focus,
                     hovered: flags.hovered,
                     contains_hover: flags.contains_hover,
-                    hover_position: pass.hover_position,
+                    hover_position,
                     state,
                 };
                 match paint {
@@ -1521,6 +1962,86 @@ impl<State, Msg> RenderPass<State, Msg> {
                     PaintBody::Thunk(paint) => paint(&mut ctx),
                 }
             });
+            if self.poisoned() {
+                return;
+            }
+        }
+    }
+
+    fn prime_viewport(
+        &mut self,
+        viewport_index: usize,
+        target: PaintDestination,
+        frame: &mut Frame,
+    ) {
+        let viewport = self.viewport_canvases[viewport_index].viewport;
+        let destination_area = viewport.visible_content();
+        let source_area = Rect::new(
+            viewport.screen.x,
+            viewport.screen.y,
+            destination_area.width,
+            destination_area.height,
+        );
+        match target {
+            PaintDestination::Frame => {
+                let source = frame.buffer_mut();
+                let destination = &mut self.viewport_canvases[viewport_index].buffer;
+                copy_buffer(source, source_area, destination, destination_area);
+            }
+            PaintDestination::Layer(layer) => {
+                let (viewports, layers) = (&mut self.viewport_canvases, &self.canvases);
+                let source = &layers[layer].buffer;
+                let destination = &mut viewports[viewport_index].buffer;
+                copy_buffer(source, source_area, destination, destination_area);
+            }
+            PaintDestination::Viewport(_) => {
+                panic!("nested viewport priming is not supported")
+            }
+        }
+    }
+
+    fn composite_viewport(
+        &mut self,
+        viewport_index: usize,
+        target: PaintDestination,
+        frame: &mut Frame,
+    ) {
+        if self.viewport_canvases[viewport_index].failed {
+            return;
+        }
+        let viewport = self.viewport_canvases[viewport_index].viewport;
+        let visible = viewport.visible_content();
+        let painted = self.viewport_canvases[viewport_index]
+            .painted
+            .iter()
+            .filter_map(|area| {
+                let source = area.intersection(visible);
+                (!source.is_empty()).then(|| {
+                    let screen = viewport.project_rect(source, viewport.screen);
+                    (source, screen)
+                })
+            })
+            .collect::<Vec<_>>();
+        match target {
+            PaintDestination::Frame => {
+                for (source_area, screen) in painted {
+                    let source = &self.viewport_canvases[viewport_index].buffer;
+                    let destination = frame.buffer_mut();
+                    copy_buffer(source, source_area, destination, screen);
+                }
+            }
+            PaintDestination::Layer(layer) => {
+                for (source_area, screen) in painted {
+                    let (viewports, layers) = (&self.viewport_canvases, &mut self.canvases);
+                    let source = &viewports[viewport_index].buffer;
+                    let destination = &mut layers[layer];
+                    copy_buffer(source, source_area, &mut destination.buffer, screen);
+                    destination.mark_painted(screen);
+                }
+            }
+            PaintDestination::Viewport(_) => {
+                panic!("nested viewport composition is not supported")
+            }
         }
     }
 
@@ -1531,6 +2052,9 @@ impl<State, Msg> RenderPass<State, Msg> {
     /// decoration slot (toast stacks, drag ghosts).
     fn finish_frame(&mut self, frame: &mut Frame, state: &State, theme: &Theme) {
         for canvas in &self.canvases {
+            if canvas.failed {
+                continue;
+            }
             if canvas.kind.policy().dims {
                 dim_background(frame.buffer_mut(), canvas.area, theme.background);
             }
@@ -1550,21 +2074,16 @@ impl<State, Msg> RenderPass<State, Msg> {
             }
         }
         self.guarded(|pass| {
-            let mut painter = Painter {
-                target: PaintTarget::Frame(frame),
-                theme,
-            };
-            for (_, thunk) in pass.deferred.drain(..) {
-                thunk(&mut painter, state);
+            for deferred in pass.deferred.drain(..) {
+                let target = PaintTarget::Frame(frame, deferred.projection);
+                let mut painter = Painter { target, theme };
+                (deferred.paint)(&mut painter, state);
             }
         });
     }
 
     fn assert_valid(&self) {
-        assert!(
-            !self.failed.get(),
-            "cannot commit a failed declaration pass"
-        );
+        assert!(!self.poisoned(), "cannot commit a failed declaration pass");
         assert!(
             self.parent_stack.is_empty() && self.layer_stack.is_empty(),
             "cannot commit a declaration pass with unclosed components or layers"
@@ -2013,7 +2532,7 @@ impl<State, Msg> Ratcn<State, Msg> {
         // builds the tree and queues the paint it owes. Hover is the one
         // interaction fact that predates the pass, so the declaration may ask
         // for it — see [`DeclareCtx::pointer_within`].
-        let mut pass = RenderPass::new();
+        let mut pass = RenderPass::new(frame.area());
         pass.hover_position = self.pointer;
         pass.hover_path.clone_from(&self.hover);
         pass.with_declare_ctx(
@@ -2035,6 +2554,7 @@ impl<State, Msg> Ratcn<State, Msg> {
         let resolved_hover = self.resolve_hover(&pass.surface);
         pass.hover_path.clone_from(&resolved_hover);
         pass.replay_paint(frame, state, theme, &resolved_focus);
+        pass.assert_valid();
         pass.finish_frame(frame, state, theme);
         let next = pass.finish();
         self.commit_surface(next, resolved_hover);
@@ -2296,13 +2816,13 @@ impl<State, Msg> Ratcn<State, Msg> {
                     .surface
                     .next_focus(&focus, direction, &self.root_options)
                 {
-                    FocusAdvance::Move(next) => self.focus_result(next),
+                    FocusAdvance::Move(next) => self.focus_transition_result(next, &focus, state),
                     FocusAdvance::Consumed => EventResult::Consumed,
                     FocusAdvance::Ignored => EventResult::Ignored,
                 }
             }
             None => self
-                .focus_key_jump(key, &chain, &focus)
+                .focus_key_jump(key, &chain, &focus, state)
                 .unwrap_or(EventResult::Ignored),
         }
     }
@@ -2342,10 +2862,11 @@ impl<State, Msg> Ratcn<State, Msg> {
     /// keeps a hotkey for a pane that is not currently declared inert instead
     /// of dead.
     fn focus_key_jump(
-        &self,
+        &mut self,
         key: &KeyEvent,
         chain: &[usize],
         focus: &FocusState,
+        state: &State,
     ) -> Option<EventResult<Msg>> {
         for scope in chain.iter().rev().copied().map(Some).chain([None]) {
             let options = scope.map_or(&self.root_options, |index| {
@@ -2360,11 +2881,7 @@ impl<State, Msg> Ratcn<State, Msg> {
                 let Some(next) = self.surface.explicit_focus(&path) else {
                     continue;
                 };
-                return Some(if next == *focus {
-                    EventResult::Consumed
-                } else {
-                    self.focus_result(next)
-                });
+                return Some(self.focus_transition_result(next, focus, state));
             }
         }
         None
@@ -2647,11 +3164,35 @@ impl<State, Msg> Ratcn<State, Msg> {
             }
             let path = self.surface.path_of(index);
             let area = self.surface.nodes[index].area;
+            let viewport = self.surface.nodes[index]
+                .viewport
+                .map(|viewport| self.surface.viewports[viewport].viewport);
+            // Declaration-space for the component, screen-absolute for the
+            // gesture tracker `EventCtx::drag` keeps.
+            let projected = match (event, viewport) {
+                (Event::Mouse(mouse), Some(viewport)) => {
+                    Event::Mouse(viewport.mouse_to_logical(*mouse))
+                }
+                _ => event.clone(),
+            };
+            let screen_mouse = match event {
+                Event::Mouse(mouse) => Some(*mouse),
+                _ => None,
+            };
             let Some(component) = self.surface.nodes[index].component.as_mut() else {
                 continue;
             };
-            let mut ctx = EventCtx::at(&path, area, &mut self.transients, capture, capture_button);
-            let result = component.handle_event(event, state, &mut ctx);
+            let mut ctx = EventCtx::at(
+                &path,
+                area,
+                &mut self.transients,
+                PointerInputs {
+                    capture: Some(capture),
+                    button: capture_button,
+                    screen_mouse,
+                },
+            );
+            let result = component.handle_event(&projected, state, &mut ctx);
             if !matches!(result, EventResult::Ignored) {
                 return result;
             }
@@ -2810,11 +3351,7 @@ impl<State, Msg> Ratcn<State, Msg> {
             self.surface.extend_to_edge(child, Step::Forward, &mut path);
         }
         let focus = FocusState::intent(path);
-        Some(if focus == current {
-            EventResult::Consumed
-        } else {
-            self.focus_result(focus)
-        })
+        Some(self.focus_transition_result(focus, &current, state))
     }
 
     /// The dismiss message of the topmost popup the press at `point` landed
@@ -2850,7 +3387,7 @@ impl<State, Msg> Ratcn<State, Msg> {
         let stored = self.stored_focus(state);
         let focus = self.surface.resolve_focus(&stored);
         let next = self.surface.hover_focus(path, &focus, &self.root_options)?;
-        Some(self.focus_result(next))
+        Some(self.focus_result(next, state))
     }
 
     /// Point hover at `path`. The event-time writer; a commit writes it from
@@ -2863,12 +3400,62 @@ impl<State, Msg> Ratcn<State, Msg> {
         }
     }
 
-    fn focus_result(&self, focus: FocusState) -> EventResult<Msg> {
+    /// The app's focus message for `focus`, after any viewport clipping the
+    /// destination has been asked to reveal it.
+    ///
+    /// The reveal is a separate channel: it can add to what a focus change
+    /// does, and it never stands in for the message
+    /// [`Ratcn::focus`](Self::focus) bound.
+    fn focus_result(&mut self, focus: FocusState, state: &State) -> EventResult<Msg> {
+        self.reveal_focus(&focus, state);
         self.focus_binding
             .as_ref()
             .map_or(EventResult::Consumed, |binding| {
                 EventResult::Emit((binding.on_change)(focus))
             })
+    }
+
+    /// Ask the component that declared the viewport clipping `focus`'s
+    /// destination to bring it into view. A destination that is already fully
+    /// on screen, or that no viewport clips, reaches nobody.
+    fn reveal_focus(&mut self, focus: &FocusState, state: &State) {
+        let matched = self.surface.nodes_along_path(focus.path());
+        let Some(&target) = matched.last() else {
+            return;
+        };
+        if self.surface.viewport_visibility(target) == ViewportVisibility::Full {
+            return;
+        }
+        let Some(owner) = self
+            .surface
+            .clipping_viewport(target)
+            .and_then(|record| record.owner)
+        else {
+            return;
+        };
+        let reveal = self.surface.nodes[target].area;
+        let path = self.surface.path_of(owner);
+        let area = self.surface.nodes[owner].area;
+        let Some(component) = self.surface.nodes[owner].component.as_mut() else {
+            return;
+        };
+        let mut ctx = EventCtx::at(&path, area, &mut self.transients, PointerInputs::default());
+        component.reveal_in_viewport(reveal, state, &mut ctx);
+    }
+
+    /// The result of a focus step that resolved to `next`. A step that stays
+    /// where it is still reveals its destination.
+    fn focus_transition_result(
+        &mut self,
+        next: FocusState,
+        current: &FocusState,
+        state: &State,
+    ) -> EventResult<Msg> {
+        if next == *current {
+            self.reveal_focus(&next, state);
+            return EventResult::Consumed;
+        }
+        self.focus_result(next, state)
     }
 
     #[cfg(test)]
@@ -2881,6 +3468,27 @@ impl<State, Msg> Ratcn<State, Msg> {
         (0..self.surface.nodes.len())
             .map(|index| self.surface.path_of(index))
             .collect()
+    }
+}
+
+fn copy_buffer(source: &Buffer, source_area: Rect, destination: &mut Buffer, target_area: Rect) {
+    for row in 0..source_area.height.min(target_area.height) {
+        for column in 0..source_area.width.min(target_area.width) {
+            let source_position = (
+                source_area.x.saturating_add(column),
+                source_area.y.saturating_add(row),
+            );
+            let target_position = (
+                target_area.x.saturating_add(column),
+                target_area.y.saturating_add(row),
+            );
+            if let (Some(source_cell), Some(target_cell)) = (
+                source.cell(source_position),
+                destination.cell_mut(target_position),
+            ) {
+                *target_cell = source_cell.clone();
+            }
+        }
     }
 }
 
@@ -10755,5 +11363,385 @@ mod tests {
             ratcn.handle_event(mouse(MouseKind::Up(MouseButton::Left), 1, 0), &state),
             EventResult::Consumed
         );
+    }
+}
+
+/// The contract [`DeclareCtx::viewport`] holds to, independent of any
+/// component that opens one.
+#[cfg(test)]
+mod viewport_tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use ratatui::{
+        Terminal,
+        backend::TestBackend,
+        style::Style,
+        widgets::{Paragraph, StatefulWidget, Widget},
+    };
+
+    use super::*;
+    use crate::runtime::{CellOffset, DragOptions, DragPhase, Modifiers, PopupOptions};
+
+    #[derive(Default)]
+    struct State;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum Msg {
+        Pressed,
+        Dragged(CellOffset),
+    }
+
+    struct Driver {
+        terminal: Terminal<TestBackend>,
+        ratcn: Ratcn<State, Msg>,
+    }
+
+    impl Driver {
+        fn new(width: u16, height: u16) -> Self {
+            Self {
+                terminal: Terminal::new(TestBackend::new(width, height)).expect("terminal"),
+                ratcn: Ratcn::new(),
+            }
+        }
+
+        fn render(&mut self, declare: impl FnOnce(&mut DeclareCtx<'_, State, Msg>)) {
+            let theme = Theme::default_dark();
+            self.terminal
+                .draw(|frame| self.ratcn.render(frame, &State, &theme, declare))
+                .expect("draw");
+        }
+
+        fn event(&mut self, event: Event) -> EventResult<Msg> {
+            self.ratcn.handle_event(event, &State)
+        }
+
+        fn row(&self, row: u16) -> String {
+            let buffer = self.terminal.backend().buffer();
+            (0..buffer.area.width)
+                .map(|column| buffer.cell((column, row)).expect("cell").symbol())
+                .collect()
+        }
+    }
+
+    fn mouse(kind: MouseKind, column: u16, row: u16) -> Event {
+        Event::Mouse(MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: Modifiers::NONE,
+        })
+    }
+
+    fn panic_message(panic: &(dyn std::any::Any + Send)) -> &str {
+        panic
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| panic.downcast_ref::<&str>().copied())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn viewport_cell_limit_accepts_the_boundary_and_rejects_one_row_more() {
+        let mut boundary = Driver::new(1, 1);
+        boundary.render(|ctx| {
+            ctx.viewport(Rect::new(0, 0, 512, 1), 512, 0, |_| {});
+        });
+
+        let mut over = Driver::new(1, 1);
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            over.render(|ctx| {
+                ctx.viewport(Rect::new(0, 0, 512, 1), 513, 0, |_| {});
+            });
+        }));
+        let panic = result.expect_err("a viewport above the cell limit must panic");
+        assert!(
+            panic_message(panic.as_ref()).contains("maximum is 262144"),
+            "{}",
+            panic_message(panic.as_ref())
+        );
+    }
+
+    /// `content_height` is app-computed over data that changes, so an
+    /// allocation one row too tall paints the rows that fit and the frame
+    /// carries on.
+    #[test]
+    fn paint_outside_the_logical_content_is_clipped() {
+        let mut driver = Driver::new(4, 2);
+        driver.render(|ctx| {
+            ctx.viewport(Rect::new(0, 0, 2, 1), 2, 0, |ctx| {
+                ctx.paint_widget(Paragraph::new("wide"), Rect::new(0, 0, 4, 1));
+            });
+        });
+
+        assert_eq!(driver.row(0), "wi  ");
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum CaughtViewportFailure {
+        Widget,
+        StatefulWidget,
+        WithBuffer,
+    }
+
+    struct Leaf;
+
+    impl Component<State, Msg> for Leaf {
+        fn declare(&mut self, _ctx: &mut DeclareCtx<'_, State, Msg>) {}
+
+        fn paint(&mut self, ctx: &mut PaintCtx<'_, '_, State>) {
+            ctx.widget(Paragraph::new("stable"), ctx.area());
+        }
+
+        fn handle_event(
+            &mut self,
+            event: &Event,
+            _state: &State,
+            _ctx: &mut EventCtx<'_>,
+        ) -> EventResult<Msg> {
+            match event {
+                Event::Mouse(mouse) if mouse.kind == MouseKind::Click(MouseButton::Left) => {
+                    EventResult::Emit(Msg::Pressed)
+                }
+                _ => EventResult::Ignored,
+            }
+        }
+
+        fn is_focusable(&self, _state: &State) -> bool {
+            true
+        }
+    }
+
+    struct PanicWidget;
+
+    impl Widget for PanicWidget {
+        fn render(self, _area: Rect, buf: &mut Buffer) {
+            buf[(0, 0)].set_symbol("X");
+            panic!("widget paint failed");
+        }
+    }
+
+    impl StatefulWidget for PanicWidget {
+        type State = ();
+
+        fn render(self, area: Rect, buf: &mut Buffer, _state: &mut Self::State) {
+            Widget::render(self, area, buf);
+        }
+    }
+
+    /// A paint panic a component catches still poisons the pass, and the
+    /// viewport's own paint never reaches the frame.
+    #[test]
+    fn a_caught_viewport_paint_panic_keeps_the_previous_frame_and_surface() {
+        for failure in [
+            CaughtViewportFailure::Widget,
+            CaughtViewportFailure::StatefulWidget,
+            CaughtViewportFailure::WithBuffer,
+        ] {
+            let mut driver = Driver::new(10, 3);
+            driver.render(|ctx| {
+                ctx.component("stable", Leaf, Rect::new(0, 0, 6, 1));
+            });
+            let previous_frame = (0..3).map(|row| driver.row(row)).collect::<Vec<_>>();
+
+            driver
+                .terminal
+                .draw(|frame| {
+                    // The backend clears between draws, so the frame this pass
+                    // must leave alone is painted back first.
+                    frame.render_widget(Paragraph::new("stable"), Rect::new(0, 0, 6, 1));
+                    let failed = catch_unwind(AssertUnwindSafe(|| {
+                        driver
+                            .ratcn
+                            .render(frame, &State, &Theme::default_dark(), move |ctx| {
+                                ctx.viewport(Rect::new(0, 0, 2, 1), 2, 0, move |ctx| {
+                                    ctx.paint(move |ctx| {
+                                        let caught = catch_unwind(AssertUnwindSafe(|| {
+                                            let area = Rect::new(0, 0, 2, 1);
+                                            match failure {
+                                                CaughtViewportFailure::Widget => {
+                                                    ctx.widget(PanicWidget, area);
+                                                }
+                                                CaughtViewportFailure::StatefulWidget => {
+                                                    ctx.stateful_widget(PanicWidget, area, &mut ());
+                                                }
+                                                CaughtViewportFailure::WithBuffer => {
+                                                    ctx.with_buffer(|buffer| {
+                                                        buffer[(0, 0)].set_symbol("X");
+                                                        panic!("component paint failed");
+                                                    });
+                                                }
+                                            }
+                                        }));
+                                        assert!(caught.is_err());
+                                    });
+                                });
+                            });
+                    }));
+                    assert!(failed.is_err(), "{failure:?} must poison the render pass");
+                })
+                .expect("failed pass draw finishes");
+
+            assert_eq!(
+                (0..3).map(|row| driver.row(row)).collect::<Vec<_>>(),
+                previous_frame,
+                "{failure:?} let a poisoned viewport canvas reach the frame"
+            );
+            assert_eq!(
+                driver.event(mouse(MouseKind::Click(MouseButton::Left), 1, 0)),
+                EventResult::Emit(Msg::Pressed),
+                "{failure:?} replaced the previous retained surface"
+            );
+        }
+    }
+
+    /// A layer canvas poisons on the same terms a viewport canvas does.
+    #[test]
+    fn a_caught_layer_paint_panic_keeps_the_previous_frame_and_surface() {
+        let mut driver = Driver::new(10, 3);
+        driver.render(|ctx| {
+            ctx.component("stable", Leaf, Rect::new(0, 0, 6, 1));
+        });
+        let previous_frame = (0..3).map(|row| driver.row(row)).collect::<Vec<_>>();
+
+        driver
+            .terminal
+            .draw(|frame| {
+                frame.render_widget(Paragraph::new("stable"), Rect::new(0, 0, 6, 1));
+                let failed = catch_unwind(AssertUnwindSafe(|| {
+                    driver
+                        .ratcn
+                        .render(frame, &State, &Theme::default_dark(), |ctx| {
+                            ctx.popup(
+                                "popup",
+                                PopupOptions::default(),
+                                Rect::new(0, 0, 4, 1),
+                                |ctx| {
+                                    ctx.paint(|ctx| {
+                                        let caught = catch_unwind(AssertUnwindSafe(|| {
+                                            ctx.widget(PanicWidget, Rect::new(0, 0, 4, 1));
+                                        }));
+                                        assert!(caught.is_err());
+                                    });
+                                },
+                            );
+                        });
+                }));
+                assert!(failed.is_err(), "a caught layer panic must poison the pass");
+            })
+            .expect("failed pass draw finishes");
+
+        assert_eq!(
+            (0..3).map(|row| driver.row(row)).collect::<Vec<_>>(),
+            previous_frame,
+            "a poisoned layer canvas reached the frame"
+        );
+        assert_eq!(
+            driver.event(mouse(MouseKind::Click(MouseButton::Left), 1, 0)),
+            EventResult::Emit(Msg::Pressed),
+            "a poisoned layer canvas replaced the retained surface"
+        );
+    }
+
+    struct DragProbe;
+
+    impl Component<State, Msg> for DragProbe {
+        fn declare(&mut self, _ctx: &mut DeclareCtx<'_, State, Msg>) {}
+
+        fn handle_event(
+            &mut self,
+            event: &Event,
+            _state: &State,
+            ctx: &mut EventCtx<'_>,
+        ) -> EventResult<Msg> {
+            let Event::Mouse(mouse) = event else {
+                return EventResult::Ignored;
+            };
+            match ctx.drag(mouse, DragOptions::default()) {
+                DragPhase::Down | DragPhase::Ended { .. } => EventResult::Consumed,
+                DragPhase::Moved { offset, .. } => EventResult::Emit(Msg::Dragged(offset)),
+                DragPhase::Ignored => EventResult::Ignored,
+            }
+        }
+    }
+
+    fn render_drag_viewport(driver: &mut Driver, offset: u16) {
+        driver.render(|ctx| {
+            ctx.viewport(Rect::new(0, 0, 7, 3), 8, offset, |ctx| {
+                ctx.component("drag", DragProbe, Rect::new(0, 1, 7, 1));
+            });
+        });
+    }
+
+    #[test]
+    fn a_captured_drag_keeps_routing_after_leaving_the_viewport() {
+        let mut driver = Driver::new(8, 5);
+        render_drag_viewport(&mut driver, 0);
+
+        assert_eq!(
+            driver.event(mouse(MouseKind::Down(MouseButton::Left), 1, 1)),
+            EventResult::Consumed
+        );
+        assert_eq!(
+            driver.event(mouse(MouseKind::Moved, 1, 4)),
+            EventResult::Emit(Msg::Dragged(CellOffset::new(0, 3))),
+            "capture, not viewport hit-testing, owns the drag"
+        );
+        assert_eq!(
+            driver.event(mouse(MouseKind::Up(MouseButton::Left), 1, 4)),
+            EventResult::Consumed
+        );
+    }
+
+    /// The drag anchor is screen-absolute, so scrolling under a held pointer
+    /// leaves the travel it measures alone.
+    #[test]
+    fn scrolling_during_a_captured_drag_leaves_its_offset_measuring_travel() {
+        let mut driver = Driver::new(8, 5);
+        render_drag_viewport(&mut driver, 0);
+        assert_eq!(
+            driver.event(mouse(MouseKind::Down(MouseButton::Left), 1, 1)),
+            EventResult::Consumed
+        );
+
+        render_drag_viewport(&mut driver, 2);
+        assert_eq!(
+            driver.event(mouse(MouseKind::Moved, 1, 2)),
+            EventResult::Emit(Msg::Dragged(CellOffset::new(0, 1)))
+        );
+    }
+
+    #[test]
+    fn a_captured_drag_reports_travel_at_the_coordinate_limit() {
+        let mut driver = Driver::new(2, 3);
+        driver.render(|ctx| {
+            ctx.viewport(Rect::new(0, 0, 1, 3), u16::MAX, u16::MAX, |ctx| {
+                ctx.component("drag", DragProbe, Rect::new(0, u16::MAX - 3, 1, 1));
+            });
+        });
+
+        assert_eq!(
+            driver.event(mouse(MouseKind::Down(MouseButton::Left), 0, 0)),
+            EventResult::Consumed
+        );
+        assert_eq!(
+            driver.event(mouse(MouseKind::Moved, 0, 4)),
+            EventResult::Emit(Msg::Dragged(CellOffset::new(0, 4)))
+        );
+    }
+
+    #[test]
+    fn deferred_paint_inside_a_viewport_projects_onto_the_frame() {
+        let mut driver = Driver::new(2, 6);
+        driver.render(|ctx| {
+            ctx.viewport(Rect::new(0, 0, 2, 3), u16::MAX, u16::MAX, |ctx| {
+                ctx.defer_paint(|painter, _| {
+                    painter.with_buffer(|buffer| {
+                        buffer.set_string(0, u16::MAX - 3, "D", Style::default());
+                    });
+                });
+            });
+        });
+
+        assert_eq!(&driver.row(0)[..1], "D");
     }
 }

--- a/crates/ratcn/src/runtime/event.rs
+++ b/crates/ratcn/src/runtime/event.rs
@@ -273,18 +273,20 @@ mod key_chord_tests {
 
 /// A mouse event, normalized across backends.
 ///
-/// `column`/`row` are terminal cells, 0-based and screen-absolute — the same
-/// coordinate space as a component's rendered [`Rect`](ratatui::layout::Rect),
-/// so the runtime can hit-test events against children directly. (crossterm
-/// already speaks cells; the browser backend converts pixels to cells before
-/// constructing this.)
+/// `column`/`row` enter [`Ratcn`](super::Ratcn) as 0-based, screen-absolute
+/// terminal cells. A component receives them in the coordinate space it was
+/// declared with, which matches its
+/// [`EventCtx::area`](super::EventCtx::area): the same cells at the top
+/// level, and content coordinates inside a
+/// [`viewport`](super::DeclareCtx::viewport). (crossterm already speaks cells;
+/// the browser backend converts pixels to cells before constructing this.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MouseEvent {
     /// What the pointer did.
     pub kind: MouseKind,
-    /// Screen-absolute cell column, 0-based.
+    /// Cell column, 0-based, in the receiving component's declaration space.
     pub column: u16,
-    /// Screen-absolute cell row, 0-based.
+    /// Cell row, 0-based, in the receiving component's declaration space.
     pub row: u16,
     /// Ctrl/Alt/Shift state during the event.
     pub modifiers: Modifiers,

--- a/crates/ratcn/tests/public_api.rs
+++ b/crates/ratcn/tests/public_api.rs
@@ -2,7 +2,7 @@
 
 #[cfg(any(feature = "crossterm", feature = "ratzilla"))]
 use ratcn::runtime::Event;
-use ratcn::{Button, Theme, Toast, ToasterState};
+use ratcn::{Button, ScrollArea, ScrollAreaChange, Theme, Toast, ToasterState};
 
 #[test]
 fn documented_root_imports_are_available_to_external_crates() {
@@ -10,6 +10,9 @@ fn documented_root_imports_are_available_to_external_crates() {
     let _ = Theme::default_dark();
     let _ = Toast::new("Saved");
     let _ = ToasterState::default();
+    let _ = ScrollArea::<(), ()>::new(10)
+        .offset(|()| 0, |_: ScrollAreaChange| ())
+        .hover_focus();
 }
 
 #[cfg(any(feature = "crossterm", feature = "ratzilla"))]

--- a/demos/scroll-area/Cargo.toml
+++ b/demos/scroll-area/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "scroll-area"
+publish = false
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+[dependencies]
+demo-shared.workspace = true
+ratatui.workspace = true
+ratcn.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+ratcn = { workspace = true, features = ["ratzilla"] }
+ratzilla.workspace = true

--- a/demos/scroll-area/Trunk.toml
+++ b/demos/scroll-area/Trunk.toml
@@ -1,0 +1,4 @@
+[build]
+target = "index.html"
+dist = "../../docs/public/demos/scroll-area-demo"
+public_url = "./"

--- a/demos/scroll-area/index.html
+++ b/demos/scroll-area/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Iframed into the docs site; the page itself has no content to rank. -->
+    <meta name="robots" content="noindex" />
+    <script type="module" src="./demo-errors.js"></script>
+    <script type="module" src="./ratatui-keyboard-capture.js"></script>
+    <link
+      data-trunk
+      rel="rust"
+      data-wasm-opt-params="--enable-bulk-memory --enable-bulk-memory-opt --enable-sign-ext --enable-nontrapping-float-to-int"
+    />
+    <link data-trunk rel="copy-file" href="../shared/demo-errors.js" />
+    <link data-trunk rel="copy-file" href="../shared/ratatui-keyboard-capture.js" />
+    <link data-trunk rel="copy-file" href="../shared/fonts/JetBrainsMonoNerdFontMono-Regular.ttf" />
+    <link data-trunk rel="copy-file" href="../shared/fonts/OFL.txt" />
+    <link data-trunk rel="css" href="../shared/demo.css" />
+    <title>ratcn scroll-area demo</title>
+  </head>
+  <body tabindex="0"></body>
+</html>

--- a/demos/scroll-area/src/main.rs
+++ b/demos/scroll-area/src/main.rs
@@ -1,0 +1,133 @@
+//! Ten boxes in a `ScrollArea` three of them tall.
+//!
+//! Click a box to focus it, or step through them with Up and Down, which reach
+//! the runtime as the traversal keys it already understands. Focus landing on a
+//! box the viewport is clipping scrolls that box into view.
+
+use std::io;
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Flex, Layout, Rect},
+    style::Style,
+};
+use ratcn::{
+    Button, ButtonSize, ScrollArea, Theme,
+    runtime::{Event, EventResult, FocusState, KeyCode, KeyEvent, Ratcn},
+};
+
+/// One entry per box: its child id, which is also its label.
+const BOXES: [&str; 10] = [
+    "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten",
+];
+
+/// Blank cells between the boxes and the edges of the content.
+const PAD: u16 = 1;
+/// A box and the blank row under it.
+const STEP: u16 = ButtonSize::Large.height() + 1;
+/// Every box, padded above the first and below the last.
+const CONTENT_HEIGHT: u16 = PAD + BOXES.len() as u16 * STEP - 1 + PAD;
+/// The viewport shows three boxes and their padding.
+const VIEWPORT_HEIGHT: u16 = PAD + 3 * STEP - 1 + PAD;
+/// Box width, its padding on both sides, and the scrollbar gutter column.
+const VIEWPORT_WIDTH: u16 = 24 + 2 * PAD + 1;
+
+#[derive(Default)]
+struct AppState {
+    focus: FocusState,
+}
+
+#[derive(Clone)]
+enum Msg {
+    Focus(FocusState),
+    Pressed,
+}
+
+struct App {
+    state: AppState,
+    ratcn: Ratcn<AppState, Msg>,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            state: AppState::default(),
+            ratcn: Ratcn::new().focus(|s: &AppState| &s.focus, Msg::Focus),
+        }
+    }
+
+    fn update(&mut self, msg: Msg) {
+        match msg {
+            Msg::Focus(focus) => self.state.focus = focus,
+            Msg::Pressed => {}
+        }
+    }
+}
+
+/// Up and Down step focus, by handing the runtime Tab and BackTab.
+fn as_traversal(event: Event) -> Event {
+    let code = match &event {
+        Event::Key(key) if !key.modifiers.any() => match key.code {
+            KeyCode::Up => Some(KeyCode::BackTab),
+            KeyCode::Down => Some(KeyCode::Tab),
+            _ => None,
+        },
+        _ => None,
+    };
+    code.map_or(event, |code| Event::Key(KeyEvent::new(code)))
+}
+
+impl demo_shared::Demo for App {
+    fn handle_event(&mut self, event: Event) -> bool {
+        match self.ratcn.handle_event(as_traversal(event), &self.state) {
+            EventResult::Emit(msg) => {
+                self.update(msg);
+                true
+            }
+            EventResult::Consumed => true,
+            EventResult::Ignored => false,
+        }
+    }
+
+    fn draw(&mut self, frame: &mut Frame, theme: &Theme) {
+        let area = frame.area();
+        frame
+            .buffer_mut()
+            .set_style(area, Style::default().bg(theme.background));
+
+        let state = &self.state;
+        self.ratcn.render(frame, state, theme, |ctx| {
+            let [column] = Layout::horizontal([Constraint::Length(VIEWPORT_WIDTH)])
+                .flex(Flex::Center)
+                .areas(area);
+            let [viewport] = Layout::vertical([Constraint::Length(VIEWPORT_HEIGHT)])
+                .flex(Flex::Center)
+                .areas(column);
+
+            let scroll = ScrollArea::new(CONTENT_HEIGHT).content(|ctx| {
+                let content = ctx.area();
+                for (index, label) in BOXES.into_iter().enumerate() {
+                    let top = content.y + PAD + index as u16 * STEP;
+                    ctx.component(
+                        label,
+                        Button::new(label)
+                            .size(ButtonSize::Large)
+                            .secondary()
+                            .on_press(|| Msg::Pressed),
+                        Rect::new(
+                            content.x + PAD,
+                            top,
+                            content.width - 2 * PAD,
+                            ButtonSize::Large.height(),
+                        ),
+                    );
+                }
+            });
+            ctx.component("boxes", scroll, viewport);
+        });
+    }
+}
+
+fn main() -> io::Result<()> {
+    demo_shared::run(App::new())
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -207,6 +207,7 @@ export default defineConfig({
             { text: 'Button', link: '/docs/components/button' },
             { text: 'Dialog', link: '/docs/components/dialog' },
             { text: 'List', link: '/docs/components/list' },
+            { text: 'ScrollArea', link: '/docs/components/scroll-area' },
             { text: 'Select', link: '/docs/components/select' },
             { text: 'Tabs', link: '/docs/components/tabs' },
             { text: 'Toast', link: '/docs/components/toast' },

--- a/docs/docs/components/list.md
+++ b/docs/docs/components/list.md
@@ -150,6 +150,9 @@ index even when items occupy multiple terminal rows.
 List::new(items).scroll(|s: &AppState| s.scroll, Msg::ScrollChanged)
 ```
 
+To scroll something that is not a list — a form, a pane, a tile grid — see
+[ScrollArea](./scroll-area).
+
 `item_focus` calls its message constructor with both the target item and the
 resulting top-item offset. A bound-scroll app must store both in one update:
 

--- a/docs/docs/components/scroll-area.md
+++ b/docs/docs/components/scroll-area.md
@@ -1,0 +1,143 @@
+---
+description: "A vertical viewport for arbitrary interactive ratcn descendants, with clipped paint and pointer routing, focus reveal, and a themed Ratatui scrollbar."
+---
+
+# ScrollArea
+
+`ScrollArea` makes an arbitrary ratcn subtree vertically scrollable without
+changing its layout. You give it the full logical content height; descendants
+receive their real logical allocations however many of their rows are visible.
+
+<div class="ratcn-preview-window" style="--ratcn-preview-height: 360px">
+  <div class="ratcn-preview-chrome" aria-hidden="true">
+    <span class="ratcn-dot"></span>
+    <span class="ratcn-dot"></span>
+    <span class="ratcn-dot"></span>
+    <span class="ratcn-preview-url">cargo run -p scroll-area</span>
+  </div>
+  <div class="ratcn-preview-body">
+    <iframe class="ratcn-component-preview-frame" src="../../../demos/scroll-area-demo/index.html" title="ratcn scroll area demo"></iframe>
+  </div>
+</div>
+
+Ten buttons stand in a viewport three of them tall. Click one to focus it, or
+step through them with Up and Down, which the demo passes to the runtime as Tab
+and BackTab. Focus landing on a button the viewport is clipping scrolls that
+button into view.
+
+```rust
+use ratatui::layout::Rect;
+use ratcn::{Button, ScrollArea};
+
+let scroll = ScrollArea::new(state.content_height).content(|ctx| {
+    let content = ctx.area();
+    ctx.component(
+        "save",
+        Button::new("Save").on_press(|| Msg::Save),
+        Rect::new(content.x, content.y + 20, content.width, 3),
+    );
+});
+
+ctx.component("content", scroll, Rect::new(0, 0, 40, 12));
+```
+
+The area owns its offset. Bind it with `.offset(...)` when the app needs the
+value — to persist it, or to scroll from elsewhere:
+
+```rust
+let scroll = ScrollArea::new(state.content_height)
+    .offset(|state: &AppState| state.scroll_offset, Msg::ScrollAreaChanged);
+```
+
+```rust
+match change {
+    ScrollAreaChange::ScrollTo(offset) => state.scroll_offset = offset,
+}
+```
+
+## Focus
+
+Focus moving to a descendant the viewport is clipping scrolls that descendant
+into view on the same frame. Focus itself travels through
+`Ratcn::focus(read, on_change)` as it does everywhere else: Tab, BackTab, focus
+keys, and pointer focus all produce that message, and the area adds the reveal
+on top of it.
+
+## Layout and clipping
+
+One column on the right is reserved for the scrollbar gutter. The content
+callback receives the remaining width and exactly the configured logical
+height, so ordinary Ratatui layout and real fixed-height allocations work
+inside it.
+
+Paint is rendered against the full logical area, then translated and clipped to
+the viewport. Offscreen descendants stay declared and focusable, and paint,
+hover, and take uncaptured pointer events on the rows that are visible. A
+captured pointer gesture keeps routing to its owner after leaving the viewport,
+so drag components work as they do elsewhere. Paint outside the logical content
+is clipped away.
+
+## Input
+
+The mouse wheel scrolls three rows. Page Up and Page Down scroll by the visible
+height; Home and End jump to the bounds. Descendants receive each event first,
+so a focused list can take Page Down and a nested control can take the wheel.
+An event that leaves the offset where it is — every one of these keys at an
+edge, and a horizontal wheel — bubbles on to the app, which keeps app hotkeys on
+those keys alive.
+
+A bound offset reader runs for every event, so applying each emitted message
+before routing the next one makes repeated wheel or page events compose even
+without a redraw between them.
+
+An area holding no focusable descendant is a focus stop itself, so keyboard
+scrolling stays available for paint-only content.
+
+Pointer motion leaves focus alone. For a pane or tile grid whose direct
+children should take focus as the pointer crosses them, opt in with
+`.hover_focus()`.
+
+Mouse events and `DragPhase` positions arrive in content coordinates, matching
+`EventCtx::area`. A drag anchor is screen-absolute inside the runtime, so
+scrolling under a held pointer leaves the travel it measures alone.
+
+The scrollbar is an indicator of where the view sits.
+
+## Layers
+
+Hints, popups, modals, and `defer_paint` keep their normal layer behavior. They
+are translated from logical coordinates once and escape the viewport clip. A
+popup or hint whose declaring anchor is offscreen is dropped, so an invisible
+trigger leaves no overlay behind.
+
+## Styling
+
+The scrollbar uses Ratatui's `Scrollbar`. Its thumb comes from the theme's
+primary color and its track from the theme border color. Override both with
+`.style(...)`:
+
+```rust
+use ratcn::{ScrollArea, ScrollAreaStyle};
+
+let scroll = ScrollArea::new(100).style(|theme| ScrollAreaStyle {
+    thumb: theme.accent,
+    track: theme.muted_foreground,
+});
+```
+
+## Limits
+
+A `ScrollArea` inside another `ScrollArea` panics. Each viewport is backed by a
+content-sized Ratatui buffer, and content above 262,144 cells panics; for
+larger data sets, window the rows yourself and give the area the height of the
+window.
+
+## See also
+
+- [List](./list) — a scrollable list of items, with its own cursor and offset.
+
+## Full API
+
+See [`ScrollArea`](https://docs.rs/ratcn/latest/ratcn/struct.ScrollArea.html),
+[`ScrollAreaChange`](https://docs.rs/ratcn/latest/ratcn/enum.ScrollAreaChange.html),
+and [`ScrollAreaStyle`](https://docs.rs/ratcn/latest/ratcn/struct.ScrollAreaStyle.html).

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -17,13 +17,13 @@ are worth knowing before you build on it:
 - **There is no install command.** The shadcn resemblance is in how the code is
   structured, not yet in tooling. Copying a component into your project is a
   manual file copy today. A CLI is intended, but it does not exist.
-- **The component set is small and growing.** Eight components ship today:
+- **The component set is small and growing.** Nine components ship today:
   [Button](./components/button), [List](./components/list),
-  [Select](./components/select), [Tabs](./components/tabs),
-  [Dialog](./components/dialog), [Toast](./components/toast),
-  [BarChart](./components/barchart), and [Tooltip](./components/tooltip).
-  Notably missing and planned next are **text input**, **multi-line text
-  area**, and a **scroll area** for content taller than its viewport.
+  [ScrollArea](./components/scroll-area), [Select](./components/select),
+  [Tabs](./components/tabs), [Dialog](./components/dialog),
+  [Toast](./components/toast), [BarChart](./components/barchart), and
+  [Tooltip](./components/tooltip). Notably missing and planned next are **text
+  input** and a **multi-line text area**.
 
 If there are specific components, patterns, or features you would like to see
 included, please [open an issue](https://github.com/kristoferlund/ratcn/issues).

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ onMounted(async () => {
 
 <div class="ratcn-preview-notice">
   <span class="ratcn-preview-notice-dot"></span>
-  <span>Preview release: the API will break, there is no install CLI yet, and more components are coming — text input, text area, and scroll area. Want something specific? Open an issue.</span>
+  <span>Preview release: the API will break, there is no install CLI yet, and more components are coming — text input and text area. Want something specific? Open an issue.</span>
   <a href="https://github.com/kristoferlund/ratcn/issues" aria-label="Open an issue on GitHub">
     <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
     GitHub


### PR DESCRIPTION
## Summary
- `ScrollArea`: a vertical viewport for arbitrary interactive descendants. Offset is area-owned by default; `.offset(read, on_change)` binds it to app state. Wheel, Page Up/Down, Home, End scroll when nothing else handles them and bubble when the area cannot move.
- Runtime: `DeclareCtx::viewport` declares a clipped logical coordinate space; the `Surface` records viewports beside layers; pointer input, hover, capture, escaped layers and focus reveal all go through one `viewport_visibility`. Focus changes inside a viewport reach the app through the ordinary `Ratcn::focus` binding; `Component::reveal_in_viewport` scrolls the destination into view in the same frame.
- `DragPhase` positions are declaration-space; the drag anchor stays screen-absolute.
- Poisoned layer and viewport canvases skip compositing; out-of-bounds viewport paint clips.
- `demos/scroll-area`: ten boxes, three visible, click or Up/Down to move focus; embedded on the component page.

## Scope
Vertical only; nested scroll areas panic; the scrollbar is an indicator. No browser wheel handling.

## Verification
- `cargo test --workspace --all-features` (697), clippy `-D warnings` native and `wasm32-unknown-unknown`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo fmt --check`, `cargo test -p copy-fixture`
- Strict review (four reviewers) and a second adversarial pass on the fixes; 7/7 mutations killed. Findings: vault `260821 - Review PR12 ScrollArea`.