### PR TITLE
Components: Checkbox and Cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   chooses (`[x]`/`[ ]`, `[ON]`/`[off]`), so the same component is the switch.
 - `Cycle`, with `CycleStyle` and `CycleWidget`: shows the current option and
   advances on every act — Enter, Space, arrows, their vi letters, or a click —
-  wrapping at both ends. It paints and hit-tests exactly the columns its
-  current value occupies: a settings row as wide as the text it shows.
+  wrapping at both ends. It paints and hit-tests exactly the columns its value
+  occupies, hugging the edge `align` names; `width()` and `MeasuredComponent`
+  answer with the widest option.
 - `selection_indicator::MarkerGlyphs`: the glyph pair a selection control
   paints. `List::selected_marker`/`unselected_marker`,
   `Select::selected_marker`/`unselected_marker`, and the same methods on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `Checkbox`, with `CheckboxStyle` and `CheckboxWidget`: a labeled boolean
+  control — marker left, label right, the whole row one hit target. The
+  checked and unchecked markers are strings the app chooses (`[x]`/`[ ]`,
+  `[ON]`/`[off]`), so the same component is also the switch and toggle.
+- `Cycle`, with `CycleStyle` and `CycleWidget`: shows the current option and
+  advances on every act — Enter, Space, arrows, their vi letters, or a click —
+  wrapping at both ends. Built for settings rows: setting name left, cycle
+  right.
+- `selection_indicator::MarkerGlyphs`: the glyph pair a selection control
+  paints. `List::selected_marker`/`unselected_marker`,
+  `Select::selected_marker`/`unselected_marker`, and the same methods on both
+  paint widgets override the defaults per control.
 - `list_core::key_intent` and `linear_nav::Axis`: the one key map `List`,
   `Select`, and `Tabs` answer from, with the axis naming which arrows step.
   `RowViewport::wheel` is the same for the wheel.
@@ -106,6 +118,9 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
+- **Breaking:** `selection_indicator::marker` takes a `MarkerGlyphs` pair
+  instead of a `multiple` flag, and `marker_line` follows it — the glyph pair
+  is now the app's to choose.
 - **Breaking:** `ButtonFill` and `ButtonStyle::mode`. A border color is
   `Option<Color>` per state; `Some` paints bordered.
 - **Breaking:** `Button::height`, `ButtonWidget::height`, `SelectWidget::height`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   value occupies, so a row is as wide as the text it shows.
 - `selection_indicator::MarkerGlyphs`: the glyph pair a selection control
   paints. `List::selected_marker`/`unselected_marker`,
-  `Select::selected_marker`/`unselected_marker`, and the same methods on both
-  paint widgets override the defaults per control.
+  `Select::selected_marker`/`unselected_marker`, and the same methods on
+  `SelectWidget` override the defaults per control.
 - `list_core::key_intent` and `linear_nav::Axis`: the one key map `List`,
   `Select`, and `Tabs` answer from, with the axis naming which arrows step.
   `RowViewport::wheel` is the same for the wheel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `Cycle`, with `CycleStyle` and `CycleWidget`: shows the current option and
   advances on every act — Enter, Space, arrows, their vi letters, or a click —
   wrapping at both ends. Built for settings rows: setting name left, cycle
-  right.
+  right. The component paints and hit-tests exactly the columns its current
+  value occupies, so a row is as wide as the text it shows.
 - `selection_indicator::MarkerGlyphs`: the glyph pair a selection control
   paints. `List::selected_marker`/`unselected_marker`,
   `Select::selected_marker`/`unselected_marker`, and the same methods on both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,17 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `[ON]`/`[off]`), so the same component is also the switch and toggle.
 - `Cycle`, with `CycleStyle` and `CycleWidget`: shows the current option and
   advances on every act — Enter, Space, arrows, their vi letters, or a click —
-  wrapping at both ends. Built for settings rows: setting name left, cycle
-  right. The component paints and hit-tests exactly the columns its current
-  value occupies, so a row is as wide as the text it shows.
+  wrapping at both ends. It paints and hit-tests exactly the columns its
+  current value occupies: a settings row as wide as the text it shows.
 - `selection_indicator::MarkerGlyphs`: the glyph pair a selection control
   paints. `List::selected_marker`/`unselected_marker`,
   `Select::selected_marker`/`unselected_marker`, and the same methods on
   `SelectWidget` override the defaults per control.
+- `color::ghost_fills`: the focused and hovered fills a ghost control raises
+  on, shared by the ghost `Button`, `Checkbox`, and `Cycle`.
 - `list_core::key_intent` and `linear_nav::Axis`: the one key map `List`,
   `Select`, and `Tabs` answer from, with the axis naming which arrows step.
+  `linear_nav::step_key` is its one-step subset, which `Cycle` answers.
   `RowViewport::wheel` is the same for the wheel.
 - `SelectWidget::options`, the panel's labels as their own call.
 - `BarChartWidget::span`, the length of the grouping axis.
@@ -119,9 +121,6 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
-- **Breaking:** `selection_indicator::marker` takes a `MarkerGlyphs` pair
-  instead of a `multiple` flag, and `marker_line` follows it — the glyph pair
-  is now the app's to choose.
 - **Breaking:** `ButtonFill` and `ButtonStyle::mode`. A border color is
   `Option<Color>` per state; `Some` paints bordered.
 - **Breaking:** `Button::height`, `ButtonWidget::height`, `SelectWidget::height`,
@@ -197,6 +196,9 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Breaking:** `selection_indicator::marker(selected, multiple)` is now
+  `MarkerGlyphs::marker(selected)` — the glyph pair is a value the app
+  chooses, not a flag.
 - **Breaking:** `PaintCtx<'a, State>` has one lifetime. Every `paint`
   signature loses a `'_`.
 - **Breaking:** `SelectWidget::open` takes a `bool`; the labels go to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - `Checkbox`, with `CheckboxStyle` and `CheckboxWidget`: a labeled boolean
-  control — marker left, label right, the whole row one hit target. The
-  checked and unchecked markers are strings the app chooses (`[x]`/`[ ]`,
-  `[ON]`/`[off]`), so the same component is also the switch and toggle.
+  control — marker left, label right, the whole row one hit target, measured
+  by `width()` and `MeasuredComponent`. The markers are strings the app
+  chooses (`[x]`/`[ ]`, `[ON]`/`[off]`), so the same component is the switch.
 - `Cycle`, with `CycleStyle` and `CycleWidget`: shows the current option and
   advances on every act — Enter, Space, arrows, their vi letters, or a click —
   wrapping at both ends. It paints and hit-tests exactly the columns its

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "checkbox"
+version = "0.0.1"
+dependencies = [
+ "ratatui",
+ "ratcn",
+ "ratzilla",
+ "shared",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +431,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "cycle"
+version = "0.0.1"
+dependencies = [
+ "ratatui",
+ "ratcn",
+ "ratzilla",
+ "shared",
+]
 
 [[package]]
 name = "darling"

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ it:
 - **There is no install command.** The shadcn resemblance is in how the code is
   structured, not yet in tooling. Copying a component into your project is a
   manual file copy today. A CLI is intended, but it does not exist.
-- **The component set is small and growing.** Nine components ship today:
+- **The component set is small and growing.** Eleven components ship today:
   `Button`, `List`, `Select`, `Tabs`, `Dialog`, `ToasterWidget`,
-  `BarChartWidget`, `Tooltip`, and `ScrollArea`. Notably missing and planned
-  next are **text input** and a **multi-line text area**.
+  `BarChartWidget`, `Tooltip`, `ScrollArea`, `Checkbox`, and `Cycle`. Notably
+  missing and planned next are **text input** and a **multi-line text area**.
 
 If you want specific components, patterns, or features, please
 [open an issue](https://github.com/kristoferlund/ratcn/issues).

--- a/crates/copy-fixture/examples/checkbox.rs
+++ b/crates/copy-fixture/examples/checkbox.rs
@@ -1,0 +1,4 @@
+// One component module, copied at build time and compiled alone. See build.rs.
+include!(concat!(env!("OUT_DIR"), "/", env!("CARGO_BIN_NAME"), ".rs"));
+
+fn main() {}

--- a/crates/copy-fixture/examples/cycle.rs
+++ b/crates/copy-fixture/examples/cycle.rs
@@ -1,0 +1,4 @@
+// One component module, copied at build time and compiled alone. See build.rs.
+include!(concat!(env!("OUT_DIR"), "/", env!("CARGO_BIN_NAME"), ".rs"));
+
+fn main() {}

--- a/crates/ratcn/src/color.rs
+++ b/crates/ratcn/src/color.rs
@@ -211,6 +211,23 @@ pub const fn dim(color: Color, toward: Color, amount: u16) -> Color {
     }
 }
 
+/// The fills a ghost control raises on, as `(focused, hovered)`: `secondary`
+/// climbing away from `background`, one [`FOCUS_SHIFT`] and one [`HOVER_SHIFT`]
+/// step out.
+///
+/// At rest a ghost control paints no background at all; these two are what
+/// appears when it gains focus or the pointer. Both climb [`away_from`] the
+/// screen color so the state reads as raised rather than pressed — the shared
+/// rule behind the ghost `Button`, `Checkbox`, and `Cycle`.
+#[must_use]
+pub fn ghost_fills(secondary: Color, background: Color) -> (Color, Color) {
+    let raised = away_from(background);
+    (
+        dim(secondary, raised, FOCUS_SHIFT),
+        dim(secondary, raised, HOVER_SHIFT),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ratcn/src/components/button.rs
+++ b/crates/ratcn/src/components/button.rs
@@ -10,7 +10,9 @@ use ratatui::{
 
 use crate::Theme;
 use crate::button_shape::{BOTTOM_CAP, TOP_CAP, cap_row, filled_middle, shape_width};
-use crate::color::{DISABLED_DIM, FOCUS_SHIFT, HOVER_SHIFT, away_from, dim, nearest_to};
+use crate::color::{
+    DISABLED_DIM, FOCUS_SHIFT, HOVER_SHIFT, away_from, dim, ghost_fills, nearest_to,
+};
 use crate::geometry::fixed_height;
 use crate::runtime::{
     Component, DeclareCtx, Event, EventCtx, EventResult, KeyCode, MeasuredComponent, MouseButton,
@@ -191,20 +193,24 @@ impl ButtonStyle {
                 disabled_background: Color::Reset,
                 disabled_border: Some(theme.border),
             },
-            ButtonVariant::Ghost => Self {
-                foreground: theme.foreground,
-                background: Color::Reset,
-                border: None,
-                focused_foreground: theme.foreground,
-                focused_background: dim(theme.secondary, raised, FOCUS_SHIFT),
-                focused_border: None,
-                hovered_foreground: theme.foreground,
-                hovered_background: dim(theme.secondary, raised, HOVER_SHIFT),
-                hovered_border: None,
-                disabled_foreground: theme.muted_foreground,
-                disabled_background: Color::Reset,
-                disabled_border: None,
-            },
+            ButtonVariant::Ghost => {
+                let (focused_background, hovered_background) =
+                    ghost_fills(theme.secondary, theme.background);
+                Self {
+                    foreground: theme.foreground,
+                    background: Color::Reset,
+                    border: None,
+                    focused_foreground: theme.foreground,
+                    focused_background,
+                    focused_border: None,
+                    hovered_foreground: theme.foreground,
+                    hovered_background,
+                    hovered_border: None,
+                    disabled_foreground: theme.muted_foreground,
+                    disabled_background: Color::Reset,
+                    disabled_border: None,
+                }
+            }
         }
     }
 

--- a/crates/ratcn/src/components/checkbox.rs
+++ b/crates/ratcn/src/components/checkbox.rs
@@ -1,7 +1,7 @@
 //! A labeled boolean control: the marker on the left, the label on the right.
 //!
 //! ```text
-//! ☑ Vim bindings
+//! ■ Vim bindings
 //! ```
 //!
 //! The whole row is one hit target — a click on the label checks the box just
@@ -34,13 +34,14 @@ use crate::{
         Component, DeclareCtx, Event, EventCtx, EventResult, KeyCode, KeyEvent, MouseButton,
         MouseKind, PaintCtx, ScopeOptions,
     },
+    selection_indicator::MarkerGlyphs,
     text_width,
     theme::resolve_style,
 };
 
-// The default markers: the ballot-box pair most terminal fonts carry.
-const CHECKED_MARKER: &str = "☑";
-const UNCHECKED_MARKER: &str = "☐";
+/// The default markers: the boxes a multi-select list ticks its rows with, so
+/// a checked box and a selected row speak the same language.
+const DEFAULT_MARKERS: MarkerGlyphs<'static> = MarkerGlyphs::checkbox();
 
 /// A checkbox's colors.
 ///
@@ -194,8 +195,8 @@ impl<'a> CheckboxWidget<'a> {
         Self {
             label,
             checked,
-            checked_marker: CHECKED_MARKER,
-            unchecked_marker: UNCHECKED_MARKER,
+            checked_marker: DEFAULT_MARKERS.selected,
+            unchecked_marker: DEFAULT_MARKERS.unselected,
             focused: false,
             hovered: false,
             disabled: false,
@@ -384,8 +385,8 @@ impl<S, M> Checkbox<S, M> {
     pub fn new(label: impl Into<String>) -> Self {
         Self {
             label: label.into(),
-            checked_marker: CHECKED_MARKER.to_owned(),
-            unchecked_marker: UNCHECKED_MARKER.to_owned(),
+            checked_marker: DEFAULT_MARKERS.selected.to_owned(),
+            unchecked_marker: DEFAULT_MARKERS.unselected.to_owned(),
             checked: None,
             disabled: false,
             style: None,

--- a/crates/ratcn/src/components/checkbox.rs
+++ b/crates/ratcn/src/components/checkbox.rs
@@ -6,9 +6,9 @@
 //!
 //! The whole row is one hit target — a click on the label checks the box just
 //! as a click on the marker does — and Enter or Space toggles while focused.
-//! Nothing paints a background and hover changes nothing: at rest a checkbox
-//! reads as text on the surface it sits on, not as a control wearing chrome.
-//! Focus is the one visible state, because keyboard users must find it.
+//! At rest a checkbox reads as text on the surface it sits on; hover and
+//! focus lay the quiet ghost-button fill over the row, so keyboard users can
+//! always find it and pointer users can see what they are about to flip.
 //!
 //! Because the checked and unchecked markers are yours to choose, the same
 //! component covers switches and toggles: `[x]`/`[ ]` for an ASCII look, or
@@ -29,7 +29,7 @@ use ratatui::{
 
 use crate::{
     Theme,
-    color::{DISABLED_DIM, dim},
+    color::{FOCUS_SHIFT, HOVER_SHIFT, away_from, dim},
     runtime::{
         Component, DeclareCtx, Event, EventCtx, EventResult, KeyCode, KeyEvent, MouseButton,
         MouseKind, PaintCtx, ScopeOptions,
@@ -46,15 +46,20 @@ const UNCHECKED_MARKER: &str = "☐";
 ///
 /// At rest the label carries [`foreground`](Self::foreground), the checked
 /// marker [`checked_marker_color`](Self::checked_marker_color), and the
-/// unchecked marker [`unchecked_marker_color`](Self::unchecked_marker_color).
-/// Focus recolors the label so a keyboard user can find the box; disabled
-/// mutes everything, and wins over both.
+/// unchecked marker [`unchecked_marker_color`](Self::unchecked_marker_color),
+/// all on nothing — the surface shows through. Hover and focus lay their
+/// background over the row, the way a small ghost button raises; disabled
+/// mutes everything and wins over both.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CheckboxStyle {
     /// Label color at rest.
     pub foreground: Color,
     /// Label color while focused.
     pub focused_foreground: Color,
+    /// Background while focused.
+    pub focused_background: Color,
+    /// Background while hovered.
+    pub hovered_background: Color,
     /// Label and marker color while disabled.
     pub disabled_foreground: Color,
     /// Checked marker color.
@@ -71,22 +76,25 @@ impl CheckboxStyle {
         Self {
             foreground: Color::Gray,
             focused_foreground: Color::Cyan,
+            focused_background: Color::DarkGray,
+            hovered_background: Color::DarkGray,
             disabled_foreground: Color::DarkGray,
             checked_marker_color: Color::Cyan,
             unchecked_marker_color: Color::Gray,
         }
     }
 
-    /// Colors derived from a theme.
-    ///
-    /// The unchecked marker sits with the muted text so an unchecked row of
-    /// boxes reads as a list of questions, and the checked marker takes the
-    /// primary accent so the answers stand out.
+    /// Colors derived from a theme, solving the ghost button's fills: both
+    /// climb away from the screen color, so they read as raised rather than
+    /// pressed.
     #[must_use]
     pub fn from_theme(theme: &Theme) -> Self {
+        let raised = away_from(theme.background);
         Self {
             foreground: theme.foreground,
             focused_foreground: theme.primary,
+            focused_background: dim(theme.secondary, raised, FOCUS_SHIFT),
+            hovered_background: dim(theme.secondary, raised, HOVER_SHIFT),
             disabled_foreground: theme.muted_foreground,
             checked_marker_color: theme.primary,
             unchecked_marker_color: theme.muted_foreground,
@@ -94,8 +102,14 @@ impl CheckboxStyle {
     }
 
     /// One paint pass's colors (see [`Self::from_theme`]). Disabled wins over
-    /// focus, which wins over rest.
-    fn resolve(self, checked: bool, focused: bool, disabled: bool) -> ResolvedCheckboxStyle {
+    /// focus, which wins over hover, which wins over rest.
+    fn resolve(
+        self,
+        checked: bool,
+        focused: bool,
+        hovered: bool,
+        disabled: bool,
+    ) -> ResolvedCheckboxStyle {
         let foreground = if disabled {
             self.disabled_foreground
         } else if focused {
@@ -110,24 +124,29 @@ impl CheckboxStyle {
         } else {
             self.unchecked_marker_color
         };
-        ResolvedCheckboxStyle { foreground, marker }
-    }
-
-    /// A copy with every role muted toward the surface, for a disabled box
-    /// derived by hand rather than from a theme.
-    #[must_use]
-    pub fn disabled(mut self, backdrop: Color) -> Self {
-        self.disabled_foreground = dim(self.disabled_foreground, backdrop, DISABLED_DIM);
-        self.checked_marker_color = dim(self.checked_marker_color, backdrop, DISABLED_DIM);
-        self.unchecked_marker_color = dim(self.unchecked_marker_color, backdrop, DISABLED_DIM);
-        self
+        let background = if disabled {
+            None
+        } else if focused {
+            Some(self.focused_background)
+        } else if hovered {
+            Some(self.hovered_background)
+        } else {
+            None
+        };
+        ResolvedCheckboxStyle {
+            foreground,
+            marker,
+            background,
+        }
     }
 }
 
-/// One paint pass's resolved colors (see [`CheckboxStyle::resolve`]).
+/// One paint pass's resolved colors (see [`CheckboxStyle::resolve`]). A `None`
+/// background leaves the surface behind the checkbox alone.
 struct ResolvedCheckboxStyle {
     foreground: Color,
     marker: Color,
+    background: Option<Color>,
 }
 
 /// A checkbox that only draws — an ordinary ratatui [`Widget`] with no focus,
@@ -142,6 +161,7 @@ pub struct CheckboxWidget<'a> {
     checked_marker: &'a str,
     unchecked_marker: &'a str,
     focused: bool,
+    hovered: bool,
     disabled: bool,
     theme: Option<Theme>,
     style: Option<CheckboxStyle>,
@@ -157,6 +177,7 @@ impl<'a> CheckboxWidget<'a> {
             checked_marker: CHECKED_MARKER,
             unchecked_marker: UNCHECKED_MARKER,
             focused: false,
+            hovered: false,
             disabled: false,
             theme: None,
             style: None,
@@ -194,10 +215,17 @@ impl<'a> CheckboxWidget<'a> {
         self
     }
 
-    /// Paint the focused label color.
+    /// Paint the focused label color and fill.
     #[must_use]
     pub const fn focused(mut self, focused: bool) -> Self {
         self.focused = focused;
+        self
+    }
+
+    /// Paint the hovered fill.
+    #[must_use]
+    pub const fn hovered(mut self, hovered: bool) -> Self {
+        self.hovered = hovered;
         self
     }
 
@@ -238,14 +266,18 @@ impl Widget for CheckboxWidget<'_> {
         if area.width == 0 || area.height == 0 {
             return;
         }
-        let style = self
-            .resolved_style()
-            .resolve(self.checked, self.focused, self.disabled);
-        let marker_style = Style::default().fg(style.marker);
-        let label_style = Style::default().fg(style.foreground);
+        let style =
+            self.resolved_style()
+                .resolve(self.checked, self.focused, self.hovered, self.disabled);
+        let mut marker_style = Style::default().fg(style.marker);
+        let mut label_style = Style::default().fg(style.foreground);
+        if let Some(background) = style.background {
+            marker_style = marker_style.bg(background);
+            label_style = label_style.bg(background);
+            buf.set_style(area, Style::default().bg(background));
+        }
 
-        // Marker column, then one space, then as much label as fits. Only
-        // foregrounds are set: the surface behind shows through everywhere.
+        // Marker column, then one space, then as much label as fits.
         let marker = self.marker();
         let marker_width = text_width::display_width_u16(marker);
         let mut cursor = area.x;
@@ -404,6 +436,7 @@ impl<S: 'static, M: 'static> Component<S, M> for Checkbox<S, M> {
             .checked_marker(&self.checked_marker)
             .unchecked_marker(&self.unchecked_marker)
             .focused(ctx.focused())
+            .hovered(ctx.hovered())
             .disabled(self.disabled)
             .style(style);
         ctx.widget(widget, ctx.area());
@@ -451,7 +484,7 @@ impl<S, M> Checkbox<S, M> {
 mod tests {
 
     use super::*;
-    use crate::runtime::{ChildId, FocusState, Modifiers, Ratcn};
+    use crate::runtime::{ChildId, FocusState, Modifiers, Ratcn, TabWrap};
     use crate::test_support::{Driver, key, key_with, mouse};
 
     #[derive(Default)]
@@ -529,35 +562,59 @@ mod tests {
         );
     }
 
-    /// A checkbox is text on the surface, not a control wearing chrome: hover
-    /// must paint exactly what rest paints, cell for cell and style for style.
+    /// Hover and focus raise the row the ghost-button way: a fill appears
+    /// where rest had none. Pinned on the widget, where both are arguments.
     #[test]
-    fn hover_paints_the_same_frame_as_rest() {
-        let mut driver = driver();
-        let state = State::default();
-        render(&mut driver, &state);
-        let rest = driver.buffer().clone();
+    fn hover_and_focus_lay_a_fill_and_rest_does_not() {
+        let area = Rect::new(0, 0, 20, 1);
+        let theme = Theme::default_dark();
 
-        // Point at the row and redraw. The declaration is identical, so the
-        // only thing that could differ between the frames is hover.
-        driver.event(mouse(MouseKind::Moved, 8, 2), &state);
-        render(&mut driver, &state);
-
+        let mut rest = Buffer::empty(area);
+        CheckboxWidget::new("Vim bindings", true)
+            .themed(&theme)
+            .render(area, &mut rest);
         assert_eq!(
-            *driver.buffer(),
-            rest,
-            "hover changed what a checkbox paints"
+            rest.cell((3, 0)).expect("cell").bg,
+            Color::Reset,
+            "rest painted a background"
+        );
+
+        let mut hovered = Buffer::empty(area);
+        CheckboxWidget::new("Vim bindings", true)
+            .hovered(true)
+            .themed(&theme)
+            .render(area, &mut hovered);
+        assert_ne!(
+            hovered.cell((3, 0)).expect("cell").bg,
+            Color::Reset,
+            "hover must show what the pointer is about to flip"
+        );
+
+        let mut focused = Buffer::empty(area);
+        CheckboxWidget::new("Vim bindings", true)
+            .focused(true)
+            .themed(&theme)
+            .render(area, &mut focused);
+        assert_ne!(
+            focused.cell((3, 0)).expect("cell").bg,
+            Color::Reset,
+            "focus must be findable by its fill"
         );
     }
 
     #[test]
     fn a_resting_checkbox_paints_no_background() {
-        let mut driver = driver();
-        let state = State::default();
-        render(&mut driver, &state);
+        // Pinned on the widget: the runtime focuses the first focusable
+        // control it renders, so a driven frame would already be focused.
+        let theme = Theme::default_dark();
+        let area = Rect::new(0, 0, 22, 1);
+        let mut buffer = Buffer::empty(area);
+        CheckboxWidget::new("Vim bindings", true)
+            .themed(&theme)
+            .render(area, &mut buffer);
 
         for column in 0..22u16 {
-            let cell = driver.cell(column, 2);
+            let cell = buffer.cell((column, 0)).expect("cell");
             assert_eq!(
                 cell.bg,
                 Color::Reset,
@@ -610,5 +667,48 @@ mod tests {
             driver.event(mouse(MouseKind::Click(MouseButton::Left), 8, 2), &state),
             EventResult::Ignored
         ));
+    }
+
+    /// Bound checkboxes are first-class traversal stops: Tab walks between
+    /// them like between any other controls.
+    #[test]
+    fn tab_walks_between_bound_checkboxes() {
+        let mut driver = Driver::with(
+            Ratcn::new()
+                .focus(|state: &State| &state.focus, Msg::Focus)
+                .tab_wrap(TabWrap::Wrap),
+            30,
+            6,
+        );
+        let state = State::default();
+        driver.render(&state, |ctx| {
+            ctx.component(
+                ChildId::Static("first"),
+                Checkbox::new("First").checked(|s: &State| s.vim, Msg::Vim),
+                Rect::new(2, 1, 20, 1),
+            );
+            ctx.component(
+                ChildId::Static("second"),
+                Checkbox::new("Second").checked(|s: &State| s.vim, Msg::Vim),
+                Rect::new(2, 3, 20, 1),
+            );
+        });
+
+        let EventResult::Emit(msg) = driver.event(key(KeyCode::Tab), &state) else {
+            panic!("Tab must reach the first checkbox");
+        };
+        let focus_after_first = match msg {
+            Msg::Focus(focus) => focus,
+            other => panic!("expected a focus message, got {other:?}"),
+        };
+        let state_after_first = State {
+            focus: focus_after_first,
+            ..State::default()
+        };
+
+        let EventResult::Emit(Msg::Focus(_)) = driver.event(key(KeyCode::Tab), &state_after_first)
+        else {
+            panic!("Tab must walk on to the second checkbox");
+        };
     }
 }

--- a/crates/ratcn/src/components/checkbox.rs
+++ b/crates/ratcn/src/components/checkbox.rs
@@ -29,7 +29,7 @@ use ratatui::{
 
 use crate::{
     Theme,
-    color::{FOCUS_SHIFT, HOVER_SHIFT, away_from, dim},
+    color::ghost_fills,
     runtime::{
         Component, DeclareCtx, Event, EventCtx, EventResult, KeyCode, KeyEvent, MouseButton,
         MouseKind, PaintCtx, ScopeOptions,
@@ -48,8 +48,10 @@ const UNCHECKED_MARKER: &str = "☐";
 /// marker [`checked_marker_color`](Self::checked_marker_color), and the
 /// unchecked marker [`unchecked_marker_color`](Self::unchecked_marker_color),
 /// all on nothing — the surface shows through. Hover and focus lay their
-/// background over the row, the way a small ghost button raises; disabled
-/// mutes everything and wins over both.
+/// background over the row, the way a small ghost button raises, each with its
+/// own label color the way [`ButtonStyle`](crate::ButtonStyle) carries one per
+/// state; the markers keep their colors on the fills, the way a list's markers
+/// do on its cursor row. Disabled mutes everything and wins over both.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CheckboxStyle {
     /// Label color at rest.
@@ -58,6 +60,8 @@ pub struct CheckboxStyle {
     pub focused_foreground: Color,
     /// Background while focused.
     pub focused_background: Color,
+    /// Label color while hovered.
+    pub hovered_foreground: Color,
     /// Background while hovered.
     pub hovered_background: Color,
     /// Label and marker color while disabled.
@@ -70,31 +74,36 @@ pub struct CheckboxStyle {
 
 impl CheckboxStyle {
     /// The no-theme starting point: plain ANSI colors that render on any
-    /// terminal, with the same raised fills the ghost button falls back to.
+    /// terminal. The fills and the label colors under them are the ghost
+    /// button's; the marker colors are the list's, chosen to read on the fills
+    /// as well as at rest.
     #[must_use]
     pub const fn fallback() -> Self {
         Self {
             foreground: Color::Gray,
-            focused_foreground: Color::Cyan,
+            focused_foreground: Color::Black,
             focused_background: Color::Cyan,
+            hovered_foreground: Color::Black,
             hovered_background: Color::LightCyan,
             disabled_foreground: Color::DarkGray,
-            checked_marker_color: Color::Cyan,
-            unchecked_marker_color: Color::Gray,
+            checked_marker_color: Color::LightGreen,
+            unchecked_marker_color: Color::DarkGray,
         }
     }
 
-    /// Colors derived from a theme, solving the ghost button's fills: both
-    /// climb away from the screen color, so they read as raised rather than
-    /// pressed.
+    /// Colors derived from a theme: the ghost button's raised fills with the
+    /// label keeping the theme's foreground on them, and the theme's primary
+    /// marking the checked box.
     #[must_use]
     pub fn from_theme(theme: &Theme) -> Self {
-        let raised = away_from(theme.background);
+        let (focused_background, hovered_background) =
+            ghost_fills(theme.secondary, theme.background);
         Self {
             foreground: theme.foreground,
-            focused_foreground: theme.primary,
-            focused_background: dim(theme.secondary, raised, FOCUS_SHIFT),
-            hovered_background: dim(theme.secondary, raised, HOVER_SHIFT),
+            focused_foreground: theme.foreground,
+            focused_background,
+            hovered_foreground: theme.foreground,
+            hovered_background,
             disabled_foreground: theme.muted_foreground,
             checked_marker_color: theme.primary,
             unchecked_marker_color: theme.muted_foreground,
@@ -104,28 +113,38 @@ impl CheckboxStyle {
     /// One paint pass's colors (see [`Self::from_theme`]). Disabled wins over
     /// hover, which wins over focus, which wins over rest — hover beating
     /// focus is what keeps pointing at the box you are on visible.
-    fn resolve(self, checked: bool, shown: Presentation) -> ResolvedCheckboxStyle {
-        let foreground = if shown.disabled {
+    #[allow(
+        clippy::fn_params_excessive_bools,
+        reason = "checked is the content and the other three are the independent interaction states every control carries; none combine into an enum"
+    )]
+    fn resolve(
+        self,
+        checked: bool,
+        focused: bool,
+        hovered: bool,
+        disabled: bool,
+    ) -> ResolvedCheckboxStyle {
+        let foreground = if disabled {
             self.disabled_foreground
-        } else if shown.hovered {
-            self.foreground
-        } else if shown.focused {
+        } else if hovered {
+            self.hovered_foreground
+        } else if focused {
             self.focused_foreground
         } else {
             self.foreground
         };
-        let marker = if shown.disabled {
+        let marker = if disabled {
             self.disabled_foreground
         } else if checked {
             self.checked_marker_color
         } else {
             self.unchecked_marker_color
         };
-        let background = if shown.disabled {
+        let background = if disabled {
             None
-        } else if shown.hovered {
+        } else if hovered {
             Some(self.hovered_background)
-        } else if shown.focused {
+        } else if focused {
             Some(self.focused_background)
         } else {
             None
@@ -136,15 +155,6 @@ impl CheckboxStyle {
             background,
         }
     }
-}
-
-/// How a checkbox is presented this paint pass, beneath what it shows:
-/// the three interaction states every control carries.
-#[derive(Debug, Clone, Copy)]
-struct Presentation {
-    focused: bool,
-    hovered: bool,
-    disabled: bool,
 }
 
 /// One paint pass's resolved colors (see [`CheckboxStyle::resolve`]). A `None`
@@ -160,13 +170,19 @@ struct ResolvedCheckboxStyle {
 ///
 /// At rest nothing paints a background; hover and focus fill the row they are
 /// given.
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "checked is the content and the other three are the independent interaction states every control carries; none combine into an enum"
+)]
 #[derive(Debug)]
 pub struct CheckboxWidget<'a> {
     label: &'a str,
     checked: bool,
     checked_marker: &'a str,
     unchecked_marker: &'a str,
-    shown: Presentation,
+    focused: bool,
+    hovered: bool,
+    disabled: bool,
     theme: Option<Theme>,
     style: Option<CheckboxStyle>,
 }
@@ -180,11 +196,9 @@ impl<'a> CheckboxWidget<'a> {
             checked,
             checked_marker: CHECKED_MARKER,
             unchecked_marker: UNCHECKED_MARKER,
-            shown: Presentation {
-                focused: false,
-                hovered: false,
-                disabled: false,
-            },
+            focused: false,
+            hovered: false,
+            disabled: false,
             theme: None,
             style: None,
         }
@@ -206,8 +220,9 @@ impl<'a> CheckboxWidget<'a> {
 
     /// The marker shown while checked.
     ///
-    /// Any string works, including multi-character pairs like `[x]`; the
-    /// layout measures what you pass.
+    /// Any string works, including multi-character pairs like `[x]`. The
+    /// marker column takes the wider of the two markers, so the label holds
+    /// still as the state flips.
     #[must_use]
     pub const fn checked_marker(mut self, marker: &'a str) -> Self {
         self.checked_marker = marker;
@@ -224,32 +239,36 @@ impl<'a> CheckboxWidget<'a> {
     /// Paint the focused label color and fill.
     #[must_use]
     pub const fn focused(mut self, focused: bool) -> Self {
-        self.shown.focused = focused;
+        self.focused = focused;
         self
     }
 
-    /// Paint the hovered fill.
+    /// Paint the hovered label color and fill.
     #[must_use]
     pub const fn hovered(mut self, hovered: bool) -> Self {
-        self.shown.hovered = hovered;
+        self.hovered = hovered;
         self
     }
 
     /// Paint muted.
     #[must_use]
     pub const fn disabled(mut self, disabled: bool) -> Self {
-        self.shown.disabled = disabled;
+        self.disabled = disabled;
         self
     }
 
-    /// Columns this checkbox paints: marker, one space, label.
+    /// Columns this checkbox paints: the marker column, one space, the label.
+    ///
+    /// The same in both states — the marker column is the wider of the two
+    /// markers — so a layout sized from this never truncates and the label
+    /// holds still as the state flips.
     #[must_use]
     pub fn width(&self) -> u16 {
-        let marker = text_width::display_width_u16(self.marker());
+        let column = self.marker_column();
         if self.label.is_empty() {
-            return marker;
+            return column;
         }
-        marker
+        column
             .saturating_add(1)
             .saturating_add(text_width::display_width_u16(self.label))
     }
@@ -260,6 +279,13 @@ impl<'a> CheckboxWidget<'a> {
         } else {
             self.unchecked_marker
         }
+    }
+
+    /// The columns the marker occupies, whichever state shows: the wider of
+    /// the pair, so the label starts in the same column checked or not.
+    fn marker_column(&self) -> u16 {
+        text_width::display_width_u16(self.checked_marker)
+            .max(text_width::display_width_u16(self.unchecked_marker))
     }
 
     fn resolved_style(&self) -> CheckboxStyle {
@@ -273,10 +299,15 @@ impl<'a> CheckboxWidget<'a> {
 
 impl Widget for CheckboxWidget<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        if area.width == 0 || area.height == 0 {
+        // A checkbox is one row tall: the fill covers exactly the row the
+        // component answers events on, and an area too short holds nothing.
+        let area = crate::geometry::fixed_height(area, 1);
+        if area.width == 0 {
             return;
         }
-        let style = self.resolved_style().resolve(self.checked, self.shown);
+        let style =
+            self.resolved_style()
+                .resolve(self.checked, self.focused, self.hovered, self.disabled);
         let mut marker_style = Style::default().fg(style.marker);
         let mut label_style = Style::default().fg(style.foreground);
         if let Some(background) = style.background {
@@ -285,26 +316,22 @@ impl Widget for CheckboxWidget<'_> {
             buf.set_style(area, Style::default().bg(background));
         }
 
-        // Marker column, then one space, then as much label as fits.
-        let marker = self.marker();
-        let marker_width = text_width::display_width_u16(marker);
-        let mut cursor = area.x;
-        if area.width >= marker_width {
+        // The marker column — as wide as the wider marker, so the label holds
+        // still as the state flips — one space, then as much label as fits.
+        let column = self.marker_column().min(area.width);
+        if column > 0 {
+            let marker = text_width::truncate_to_width(self.marker(), usize::from(column));
             Line::from(marker)
                 .style(marker_style)
-                .render(Rect::new(cursor, area.y, marker_width.max(1), 1), buf);
-            cursor = cursor.saturating_add(marker_width);
+                .render(Rect::new(area.x, area.y, column, 1), buf);
         }
-        let painted = cursor - area.x;
-        if !self.label.is_empty() && area.width > painted {
-            Span::raw(" ")
-                .style(label_style)
-                .render(Rect::new(cursor, area.y, 1, 1), buf);
-            let available = area.width - painted - 1;
+        let after = column.saturating_add(1);
+        if !self.label.is_empty() && area.width > after {
+            let available = area.width - after;
             let label = text_width::truncate_to_width(self.label, usize::from(available));
-            Span::raw(label.to_owned())
+            Span::raw(label)
                 .style(label_style)
-                .render(Rect::new(cursor + 1, area.y, available, 1), buf);
+                .render(Rect::new(area.x + after, area.y, available, 1), buf);
         }
     }
 }
@@ -369,7 +396,8 @@ impl<S, M> Checkbox<S, M> {
     /// The marker shown while checked.
     ///
     /// Any string works, including multi-character pairs like `[x]`; the
-    /// layout measures what you pass. Pair it with
+    /// marker column takes the wider of the pair, so the label holds still as
+    /// the state flips. Pair it with
     /// [`unchecked_marker`](Self::unchecked_marker) so both states read as one
     /// control — `[ON]`/`[off]` is a switch, `[x]`/`[ ]` an ASCII checkbox.
     #[must_use]
@@ -430,6 +458,18 @@ impl<S, M> Checkbox<S, M> {
         };
         EventResult::Emit(on_change(!self.resolved_checked))
     }
+
+    /// The keys a checkbox answers: its commit keys, and nothing else.
+    /// Modified keys belong to the app, so Shift+Enter passes through.
+    fn handle_key(&self, key: KeyEvent) -> EventResult<M> {
+        if key.modifiers.any() {
+            return EventResult::Ignored;
+        }
+        match key.code {
+            KeyCode::Enter | KeyCode::Char(' ') => self.toggle(),
+            _ => EventResult::Ignored,
+        }
+    }
 }
 
 impl<S: 'static, M: 'static> Component<S, M> for Checkbox<S, M> {
@@ -481,20 +521,6 @@ impl<S: 'static, M: 'static> Component<S, M> for Checkbox<S, M> {
         // A checkbox is one row tall; a taller declaration must not leave a
         // strip of itself clickable.
         crate::geometry::fixed_height(area, 1)
-    }
-}
-
-impl<S, M> Checkbox<S, M> {
-    /// The keys a checkbox answers: its commit keys, and nothing else.
-    /// Modified keys belong to the app, so Shift+Enter passes through.
-    fn handle_key(&self, key: KeyEvent) -> EventResult<M> {
-        if key.modifiers.any() {
-            return EventResult::Ignored;
-        }
-        match key.code {
-            KeyCode::Enter | KeyCode::Char(' ') => self.toggle(),
-            _ => EventResult::Ignored,
-        }
     }
 }
 
@@ -639,6 +665,77 @@ mod tests {
                 "column {column} painted a background"
             );
         }
+    }
+
+    /// The fill covers exactly the row the component answers events on: a
+    /// taller declaration must not show a raised strip that nothing answers.
+    #[test]
+    fn the_fill_covers_only_the_row_the_checkbox_answers_on() {
+        let area = Rect::new(0, 0, 20, 3);
+        let theme = Theme::default_dark();
+        let mut buffer = Buffer::empty(area);
+        CheckboxWidget::new("Vim bindings", true)
+            .hovered(true)
+            .themed(&theme)
+            .render(area, &mut buffer);
+
+        assert_ne!(buffer.cell((3, 0)).expect("cell").bg, Color::Reset);
+        for row in 1..3u16 {
+            assert_eq!(
+                buffer.cell((3, row)).expect("cell").bg,
+                Color::Reset,
+                "row {row} filled beyond the checkbox's one row"
+            );
+        }
+    }
+
+    /// The no-theme fallback keeps every state legible: under the focus and
+    /// hover fills, neither the label nor the marker may vanish into the
+    /// background.
+    #[test]
+    fn the_fallback_states_stay_legible() {
+        let area = Rect::new(0, 0, 20, 1);
+        for (name, widget) in [
+            (
+                "focused",
+                CheckboxWidget::new("Vim bindings", true).focused(true),
+            ),
+            (
+                "hovered",
+                CheckboxWidget::new("Vim bindings", true).hovered(true),
+            ),
+        ] {
+            let mut buffer = Buffer::empty(area);
+            widget.render(area, &mut buffer);
+            let marker = buffer.cell((0, 0)).expect("cell");
+            let label = buffer.cell((3, 0)).expect("cell");
+            assert_ne!(marker.fg, marker.bg, "{name}: the marker vanished");
+            assert_ne!(label.fg, label.bg, "{name}: the label vanished");
+        }
+    }
+
+    /// The marker column is the wider of the pair, so an uneven pair like
+    /// `[ON]`/`[off]` neither moves the label nor changes the row's width as
+    /// the state flips.
+    #[test]
+    fn an_uneven_marker_pair_holds_the_label_still() {
+        let theme = Theme::default_dark();
+        let area = Rect::new(0, 0, 24, 1);
+        let mut rows = [String::new(), String::new()];
+        for (row, checked) in rows.iter_mut().zip([true, false]) {
+            let widget = CheckboxWidget::new("Terminal bell", checked)
+                .checked_marker("[ON]")
+                .unchecked_marker("[off]")
+                .themed(&theme);
+            assert_eq!(widget.width(), 19, "checked={checked}");
+            let mut buffer = Buffer::empty(area);
+            widget.render(area, &mut buffer);
+            *row = (0..24u16)
+                .map(|column| buffer.cell((column, 0)).expect("cell").symbol())
+                .collect();
+        }
+        assert!(rows[0].starts_with("[ON]  Terminal bell"), "{:?}", rows[0]);
+        assert!(rows[1].starts_with("[off] Terminal bell"), "{:?}", rows[1]);
     }
 
     #[test]

--- a/crates/ratcn/src/components/checkbox.rs
+++ b/crates/ratcn/src/components/checkbox.rs
@@ -103,32 +103,26 @@ impl CheckboxStyle {
 
     /// One paint pass's colors (see [`Self::from_theme`]). Disabled wins over
     /// focus, which wins over hover, which wins over rest.
-    fn resolve(
-        self,
-        checked: bool,
-        focused: bool,
-        hovered: bool,
-        disabled: bool,
-    ) -> ResolvedCheckboxStyle {
-        let foreground = if disabled {
+    fn resolve(self, checked: bool, shown: Presentation) -> ResolvedCheckboxStyle {
+        let foreground = if shown.disabled {
             self.disabled_foreground
-        } else if focused {
+        } else if shown.focused {
             self.focused_foreground
         } else {
             self.foreground
         };
-        let marker = if disabled {
+        let marker = if shown.disabled {
             self.disabled_foreground
         } else if checked {
             self.checked_marker_color
         } else {
             self.unchecked_marker_color
         };
-        let background = if disabled {
+        let background = if shown.disabled {
             None
-        } else if focused {
+        } else if shown.focused {
             Some(self.focused_background)
-        } else if hovered {
+        } else if shown.hovered {
             Some(self.hovered_background)
         } else {
             None
@@ -139,6 +133,15 @@ impl CheckboxStyle {
             background,
         }
     }
+}
+
+/// How a checkbox is presented this paint pass, beneath what it shows:
+/// the three interaction states every control carries.
+#[derive(Debug, Clone, Copy)]
+struct Presentation {
+    focused: bool,
+    hovered: bool,
+    disabled: bool,
 }
 
 /// One paint pass's resolved colors (see [`CheckboxStyle::resolve`]). A `None`
@@ -152,17 +155,15 @@ struct ResolvedCheckboxStyle {
 /// A checkbox that only draws — an ordinary ratatui [`Widget`] with no focus,
 /// events, or state. One instantiation is one checkbox.
 ///
-/// The marker and label never paint a background, so the surface the checkbox
-/// sits on shows through everywhere.
+/// At rest nothing paints a background; hover and focus fill the row they are
+/// given.
 #[derive(Debug)]
 pub struct CheckboxWidget<'a> {
     label: &'a str,
     checked: bool,
     checked_marker: &'a str,
     unchecked_marker: &'a str,
-    focused: bool,
-    hovered: bool,
-    disabled: bool,
+    shown: Presentation,
     theme: Option<Theme>,
     style: Option<CheckboxStyle>,
 }
@@ -176,9 +177,11 @@ impl<'a> CheckboxWidget<'a> {
             checked,
             checked_marker: CHECKED_MARKER,
             unchecked_marker: UNCHECKED_MARKER,
-            focused: false,
-            hovered: false,
-            disabled: false,
+            shown: Presentation {
+                focused: false,
+                hovered: false,
+                disabled: false,
+            },
             theme: None,
             style: None,
         }
@@ -218,21 +221,21 @@ impl<'a> CheckboxWidget<'a> {
     /// Paint the focused label color and fill.
     #[must_use]
     pub const fn focused(mut self, focused: bool) -> Self {
-        self.focused = focused;
+        self.shown.focused = focused;
         self
     }
 
     /// Paint the hovered fill.
     #[must_use]
     pub const fn hovered(mut self, hovered: bool) -> Self {
-        self.hovered = hovered;
+        self.shown.hovered = hovered;
         self
     }
 
     /// Paint muted.
     #[must_use]
     pub const fn disabled(mut self, disabled: bool) -> Self {
-        self.disabled = disabled;
+        self.shown.disabled = disabled;
         self
     }
 
@@ -266,9 +269,7 @@ impl Widget for CheckboxWidget<'_> {
         if area.width == 0 || area.height == 0 {
             return;
         }
-        let style =
-            self.resolved_style()
-                .resolve(self.checked, self.focused, self.hovered, self.disabled);
+        let style = self.resolved_style().resolve(self.checked, self.shown);
         let mut marker_style = Style::default().fg(style.marker);
         let mut label_style = Style::default().fg(style.foreground);
         if let Some(background) = style.background {
@@ -694,12 +695,10 @@ mod tests {
             );
         });
 
-        let EventResult::Emit(msg) = driver.event(key(KeyCode::Tab), &state) else {
+        let EventResult::Emit(Msg::Focus(focus_after_first)) =
+            driver.event(key(KeyCode::Tab), &state)
+        else {
             panic!("Tab must reach the first checkbox");
-        };
-        let focus_after_first = match msg {
-            Msg::Focus(focus) => focus,
-            other => panic!("expected a focus message, got {other:?}"),
         };
         let state_after_first = State {
             focus: focus_after_first,

--- a/crates/ratcn/src/components/checkbox.rs
+++ b/crates/ratcn/src/components/checkbox.rs
@@ -70,14 +70,14 @@ pub struct CheckboxStyle {
 
 impl CheckboxStyle {
     /// The no-theme starting point: plain ANSI colors that render on any
-    /// terminal.
+    /// terminal, with the same raised fills the ghost button falls back to.
     #[must_use]
     pub const fn fallback() -> Self {
         Self {
             foreground: Color::Gray,
             focused_foreground: Color::Cyan,
-            focused_background: Color::DarkGray,
-            hovered_background: Color::DarkGray,
+            focused_background: Color::Cyan,
+            hovered_background: Color::LightCyan,
             disabled_foreground: Color::DarkGray,
             checked_marker_color: Color::Cyan,
             unchecked_marker_color: Color::Gray,
@@ -245,7 +245,11 @@ impl<'a> CheckboxWidget<'a> {
     /// Columns this checkbox paints: marker, one space, label.
     #[must_use]
     pub fn width(&self) -> u16 {
-        text_width::display_width_u16(self.marker())
+        let marker = text_width::display_width_u16(self.marker());
+        if self.label.is_empty() {
+            return marker;
+        }
+        marker
             .saturating_add(1)
             .saturating_add(text_width::display_width_u16(self.label))
     }
@@ -471,6 +475,12 @@ impl<S: 'static, M: 'static> Component<S, M> for Checkbox<S, M> {
 
     fn scope_options(&self) -> ScopeOptions {
         ScopeOptions::default().focusable(self.can_act())
+    }
+
+    fn interaction_area(&self, area: Rect) -> Rect {
+        // A checkbox is one row tall; a taller declaration must not leave a
+        // strip of itself clickable.
+        crate::geometry::fixed_height(area, 1)
     }
 }
 

--- a/crates/ratcn/src/components/checkbox.rs
+++ b/crates/ratcn/src/components/checkbox.rs
@@ -21,7 +21,7 @@ use std::{fmt, rc::Rc};
 
 use ratatui::{
     buffer::Buffer,
-    layout::Rect,
+    layout::{Rect, Size},
     style::{Color, Style},
     text::{Line, Span},
     widgets::Widget,
@@ -31,8 +31,8 @@ use crate::{
     Theme,
     color::ghost_fills,
     runtime::{
-        Component, DeclareCtx, Event, EventCtx, EventResult, KeyCode, KeyEvent, MouseButton,
-        MouseKind, PaintCtx, ScopeOptions,
+        Component, DeclareCtx, Event, EventCtx, EventResult, KeyCode, KeyEvent, MeasuredComponent,
+        MouseButton, MouseKind, PaintCtx, ScopeOptions,
     },
     selection_indicator::MarkerGlyphs,
     text_width,
@@ -452,6 +452,17 @@ impl<S, M> Checkbox<S, M> {
         !self.disabled && self.is_bound()
     }
 
+    /// Columns this checkbox paints: the marker column (the wider of the two
+    /// markers), one space, the label — the same in both states, so a row
+    /// sized from this holds its label still. See [`CheckboxWidget::width`].
+    #[must_use]
+    pub fn width(&self) -> u16 {
+        CheckboxWidget::new(&self.label, false)
+            .checked_marker(&self.checked_marker)
+            .unchecked_marker(&self.unchecked_marker)
+            .width()
+    }
+
     /// The message that flips the bound state.
     fn toggle(&self) -> EventResult<M> {
         let Some((_, on_change)) = &self.checked else {
@@ -522,6 +533,12 @@ impl<S: 'static, M: 'static> Component<S, M> for Checkbox<S, M> {
         // A checkbox is one row tall; a taller declaration must not leave a
         // strip of itself clickable.
         crate::geometry::fixed_height(area, 1)
+    }
+}
+
+impl<S: 'static, M: 'static> MeasuredComponent<S, M> for Checkbox<S, M> {
+    fn measure(&self) -> Size {
+        Size::new(self.width(), 1)
     }
 }
 
@@ -737,6 +754,18 @@ mod tests {
         }
         assert!(rows[0].starts_with("[ON]  Terminal bell"), "{:?}", rows[0]);
         assert!(rows[1].starts_with("[off] Terminal bell"), "{:?}", rows[1]);
+    }
+
+    /// The component measures the row it paints — one row tall, the marker
+    /// column as wide as the wider marker — so a layout can hug it without
+    /// building the widget itself.
+    #[test]
+    fn the_component_measures_the_row_it_paints() {
+        let checkbox: Checkbox<State, Msg> = Checkbox::new("Terminal bell")
+            .checked_marker("[ON]")
+            .unchecked_marker("[off]");
+        assert_eq!(checkbox.width(), 19);
+        assert_eq!(checkbox.measure(), Size::new(19, 1));
     }
 
     #[test]

--- a/crates/ratcn/src/components/checkbox.rs
+++ b/crates/ratcn/src/components/checkbox.rs
@@ -102,10 +102,13 @@ impl CheckboxStyle {
     }
 
     /// One paint pass's colors (see [`Self::from_theme`]). Disabled wins over
-    /// focus, which wins over hover, which wins over rest.
+    /// hover, which wins over focus, which wins over rest — hover beating
+    /// focus is what keeps pointing at the box you are on visible.
     fn resolve(self, checked: bool, shown: Presentation) -> ResolvedCheckboxStyle {
         let foreground = if shown.disabled {
             self.disabled_foreground
+        } else if shown.hovered {
+            self.foreground
         } else if shown.focused {
             self.focused_foreground
         } else {
@@ -120,10 +123,10 @@ impl CheckboxStyle {
         };
         let background = if shown.disabled {
             None
-        } else if shown.focused {
-            Some(self.focused_background)
         } else if shown.hovered {
             Some(self.hovered_background)
+        } else if shown.focused {
+            Some(self.focused_background)
         } else {
             None
         };
@@ -309,15 +312,19 @@ type StyleFn = Rc<dyn Fn(&Theme) -> CheckboxStyle>;
 /// A boolean control: marker left, label right, the whole row one hit target.
 ///
 /// A click anywhere on the row toggles, as do <kbd>Enter</kbd> and
-/// <kbd>Space</kbd> while focused. Hover paints nothing and nothing looks like
-/// a button; focus recolors the label, which is the one state a keyboard user
-/// needs to see.
+/// <kbd>Space</kbd> while focused. Hover and focus raise the row the way a
+/// small ghost button raises, so pointer and keyboard users both always see
+/// what they are on.
 ///
 /// The checked state lives in app state and arrives through
 /// [`checked`](Self::checked); without that binding the checkbox paints but is
 /// not focusable and answers no events. With the markers chosen freely, the
 /// same component serves as a switch (`[ON]`/`[off]`) or an ASCII toggle
 /// (`[x]`/`[ ]`) — see the [checkbox demo](https://github.com/kristoferlund/ratcn/tree/main/demos/checkbox).
+///
+/// Its markers answer to `checked`/`unchecked` where the selection controls
+/// say `selected`/`unselected`: a checkbox holds one row whose two states are
+/// its content, not a choice among many.
 pub struct Checkbox<S, M> {
     label: String,
     checked_marker: String,
@@ -640,6 +647,52 @@ mod tests {
             .map(|column| buffer.cell((column, 0)).expect("cell").symbol())
             .collect();
         assert!(row.starts_with("[x] Vim bindings"), "{row:?}");
+    }
+
+    /// Disabled is the loudest state: no events, no traversal, and no fill
+    /// even while hovered or focused.
+    #[test]
+    fn a_disabled_checkbox_is_inert_and_paints_muted() {
+        let mut driver = driver();
+        let state = State::default();
+        driver.render(&state, |ctx| {
+            ctx.component(
+                ChildId::Static("off"),
+                Checkbox::new("Off")
+                    .disabled(true)
+                    .checked(|s: &State| s.vim, Msg::Vim),
+                Rect::new(2, 2, 20, 1),
+            );
+        });
+
+        // Inert to the pointer and the keyboard, and invisible to Tab.
+        assert!(matches!(
+            driver.event(mouse(MouseKind::Click(MouseButton::Left), 8, 2), &state),
+            EventResult::Ignored
+        ));
+        assert!(matches!(
+            driver.event(key(KeyCode::Char(' ')), &state),
+            EventResult::Ignored
+        ));
+        assert!(matches!(
+            driver.event(key(KeyCode::Tab), &state),
+            EventResult::Ignored
+        ));
+
+        // Muted beats hover and focus in paint.
+        let area = Rect::new(0, 0, 20, 1);
+        let theme = Theme::default_dark();
+        let mut buffer = Buffer::empty(area);
+        CheckboxWidget::new("Off", true)
+            .hovered(true)
+            .focused(true)
+            .disabled(true)
+            .themed(&theme)
+            .render(area, &mut buffer);
+        for column in 0..20u16 {
+            let cell = buffer.cell((column, 0)).expect("cell");
+            assert_eq!(cell.bg, Color::Reset, "column {column} filled while muted");
+        }
     }
 
     #[test]

--- a/crates/ratcn/src/components/checkbox.rs
+++ b/crates/ratcn/src/components/checkbox.rs
@@ -1,0 +1,614 @@
+//! A labeled boolean control: the marker on the left, the label on the right.
+//!
+//! ```text
+//! ☑ Vim bindings
+//! ```
+//!
+//! The whole row is one hit target — a click on the label checks the box just
+//! as a click on the marker does — and Enter or Space toggles while focused.
+//! Nothing paints a background and hover changes nothing: at rest a checkbox
+//! reads as text on the surface it sits on, not as a control wearing chrome.
+//! Focus is the one visible state, because keyboard users must find it.
+//!
+//! Because the checked and unchecked markers are yours to choose, the same
+//! component covers switches and toggles: `[x]`/`[ ]` for an ASCII look, or
+//! `[ON]`/`[off]` when the words are the point.
+//!
+//! State is app-owned. The component reads `checked` from app state through a
+//! binding and emits a message each time the user asks to flip it.
+
+use std::{fmt, rc::Rc};
+
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::Widget,
+};
+
+use crate::{
+    Theme,
+    color::{DISABLED_DIM, dim},
+    runtime::{
+        Component, DeclareCtx, Event, EventCtx, EventResult, KeyCode, KeyEvent, MouseButton,
+        MouseKind, PaintCtx, ScopeOptions,
+    },
+    text_width,
+    theme::resolve_style,
+};
+
+// The default markers: the ballot-box pair most terminal fonts carry.
+const CHECKED_MARKER: &str = "☑";
+const UNCHECKED_MARKER: &str = "☐";
+
+/// A checkbox's colors.
+///
+/// At rest the label carries [`foreground`](Self::foreground), the checked
+/// marker [`checked_marker_color`](Self::checked_marker_color), and the
+/// unchecked marker [`unchecked_marker_color`](Self::unchecked_marker_color).
+/// Focus recolors the label so a keyboard user can find the box; disabled
+/// mutes everything, and wins over both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CheckboxStyle {
+    /// Label color at rest.
+    pub foreground: Color,
+    /// Label color while focused.
+    pub focused_foreground: Color,
+    /// Label and marker color while disabled.
+    pub disabled_foreground: Color,
+    /// Checked marker color.
+    pub checked_marker_color: Color,
+    /// Unchecked marker color.
+    pub unchecked_marker_color: Color,
+}
+
+impl CheckboxStyle {
+    /// The no-theme starting point: plain ANSI colors that render on any
+    /// terminal.
+    #[must_use]
+    pub const fn fallback() -> Self {
+        Self {
+            foreground: Color::Gray,
+            focused_foreground: Color::Cyan,
+            disabled_foreground: Color::DarkGray,
+            checked_marker_color: Color::Cyan,
+            unchecked_marker_color: Color::Gray,
+        }
+    }
+
+    /// Colors derived from a theme.
+    ///
+    /// The unchecked marker sits with the muted text so an unchecked row of
+    /// boxes reads as a list of questions, and the checked marker takes the
+    /// primary accent so the answers stand out.
+    #[must_use]
+    pub fn from_theme(theme: &Theme) -> Self {
+        Self {
+            foreground: theme.foreground,
+            focused_foreground: theme.primary,
+            disabled_foreground: theme.muted_foreground,
+            checked_marker_color: theme.primary,
+            unchecked_marker_color: theme.muted_foreground,
+        }
+    }
+
+    /// One paint pass's colors (see [`Self::from_theme`]). Disabled wins over
+    /// focus, which wins over rest.
+    fn resolve(self, checked: bool, focused: bool, disabled: bool) -> ResolvedCheckboxStyle {
+        let foreground = if disabled {
+            self.disabled_foreground
+        } else if focused {
+            self.focused_foreground
+        } else {
+            self.foreground
+        };
+        let marker = if disabled {
+            self.disabled_foreground
+        } else if checked {
+            self.checked_marker_color
+        } else {
+            self.unchecked_marker_color
+        };
+        ResolvedCheckboxStyle { foreground, marker }
+    }
+
+    /// A copy with every role muted toward the surface, for a disabled box
+    /// derived by hand rather than from a theme.
+    #[must_use]
+    pub fn disabled(mut self, backdrop: Color) -> Self {
+        self.disabled_foreground = dim(self.disabled_foreground, backdrop, DISABLED_DIM);
+        self.checked_marker_color = dim(self.checked_marker_color, backdrop, DISABLED_DIM);
+        self.unchecked_marker_color = dim(self.unchecked_marker_color, backdrop, DISABLED_DIM);
+        self
+    }
+}
+
+/// One paint pass's resolved colors (see [`CheckboxStyle::resolve`]).
+struct ResolvedCheckboxStyle {
+    foreground: Color,
+    marker: Color,
+}
+
+/// A checkbox that only draws — an ordinary ratatui [`Widget`] with no focus,
+/// events, or state. One instantiation is one checkbox.
+///
+/// The marker and label never paint a background, so the surface the checkbox
+/// sits on shows through everywhere.
+#[derive(Debug)]
+pub struct CheckboxWidget<'a> {
+    label: &'a str,
+    checked: bool,
+    checked_marker: &'a str,
+    unchecked_marker: &'a str,
+    focused: bool,
+    disabled: bool,
+    theme: Option<Theme>,
+    style: Option<CheckboxStyle>,
+}
+
+impl<'a> CheckboxWidget<'a> {
+    /// A checkbox showing `label`, checked when `checked`.
+    #[must_use]
+    pub fn new(label: &'a str, checked: bool) -> Self {
+        Self {
+            label,
+            checked,
+            checked_marker: CHECKED_MARKER,
+            unchecked_marker: UNCHECKED_MARKER,
+            focused: false,
+            disabled: false,
+            theme: None,
+            style: None,
+        }
+    }
+
+    /// Take colors from `theme`.
+    #[must_use]
+    pub const fn themed(mut self, theme: &Theme) -> Self {
+        self.theme = Some(*theme);
+        self
+    }
+
+    /// Exact colors, taking precedence over [`themed`](Self::themed).
+    #[must_use]
+    pub const fn style(mut self, style: CheckboxStyle) -> Self {
+        self.style = Some(style);
+        self
+    }
+
+    /// The marker shown while checked.
+    ///
+    /// Any string works, including multi-character pairs like `[x]`; the
+    /// layout measures what you pass.
+    #[must_use]
+    pub const fn checked_marker(mut self, marker: &'a str) -> Self {
+        self.checked_marker = marker;
+        self
+    }
+
+    /// The marker shown while unchecked.
+    #[must_use]
+    pub const fn unchecked_marker(mut self, marker: &'a str) -> Self {
+        self.unchecked_marker = marker;
+        self
+    }
+
+    /// Paint the focused label color.
+    #[must_use]
+    pub const fn focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    /// Paint muted.
+    #[must_use]
+    pub const fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Columns this checkbox paints: marker, one space, label.
+    #[must_use]
+    pub fn width(&self) -> u16 {
+        text_width::display_width_u16(self.marker())
+            .saturating_add(1)
+            .saturating_add(text_width::display_width_u16(self.label))
+    }
+
+    fn marker(&self) -> &'a str {
+        if self.checked {
+            self.checked_marker
+        } else {
+            self.unchecked_marker
+        }
+    }
+
+    fn resolved_style(&self) -> CheckboxStyle {
+        match (self.style, self.theme) {
+            (Some(style), _) => style,
+            (None, Some(theme)) => CheckboxStyle::from_theme(&theme),
+            (None, None) => CheckboxStyle::fallback(),
+        }
+    }
+}
+
+impl Widget for CheckboxWidget<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let style = self
+            .resolved_style()
+            .resolve(self.checked, self.focused, self.disabled);
+        let marker_style = Style::default().fg(style.marker);
+        let label_style = Style::default().fg(style.foreground);
+
+        // Marker column, then one space, then as much label as fits. Only
+        // foregrounds are set: the surface behind shows through everywhere.
+        let marker = self.marker();
+        let marker_width = text_width::display_width_u16(marker);
+        let mut cursor = area.x;
+        if area.width >= marker_width {
+            Line::from(marker)
+                .style(marker_style)
+                .render(Rect::new(cursor, area.y, marker_width.max(1), 1), buf);
+            cursor = cursor.saturating_add(marker_width);
+        }
+        let painted = cursor - area.x;
+        if !self.label.is_empty() && area.width > painted {
+            Span::raw(" ")
+                .style(label_style)
+                .render(Rect::new(cursor, area.y, 1, 1), buf);
+            let available = area.width - painted - 1;
+            let label = text_width::truncate_to_width(self.label, usize::from(available));
+            Span::raw(label.to_owned())
+                .style(label_style)
+                .render(Rect::new(cursor + 1, area.y, available, 1), buf);
+        }
+    }
+}
+
+type ReadCheckedFn<S> = Rc<dyn Fn(&S) -> bool>;
+type OnToggleFn<M> = Rc<dyn Fn(bool) -> M>;
+type StyleFn = Rc<dyn Fn(&Theme) -> CheckboxStyle>;
+
+/// A boolean control: marker left, label right, the whole row one hit target.
+///
+/// A click anywhere on the row toggles, as do <kbd>Enter</kbd> and
+/// <kbd>Space</kbd> while focused. Hover paints nothing and nothing looks like
+/// a button; focus recolors the label, which is the one state a keyboard user
+/// needs to see.
+///
+/// The checked state lives in app state and arrives through
+/// [`checked`](Self::checked); without that binding the checkbox paints but is
+/// not focusable and answers no events. With the markers chosen freely, the
+/// same component serves as a switch (`[ON]`/`[off]`) or an ASCII toggle
+/// (`[x]`/`[ ]`) — see the [checkbox demo](https://github.com/kristoferlund/ratcn/tree/main/demos/checkbox).
+pub struct Checkbox<S, M> {
+    label: String,
+    checked_marker: String,
+    unchecked_marker: String,
+    checked: Option<(ReadCheckedFn<S>, OnToggleFn<M>)>,
+    disabled: bool,
+    style: Option<StyleFn>,
+    /// The bound checked value, resolved once per declaration.
+    resolved_checked: bool,
+}
+
+impl<S, M> fmt::Debug for Checkbox<S, M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Checkbox")
+            .field("label", &self.label)
+            .field("checked", &self.checked.is_some())
+            .field("disabled", &self.disabled)
+            .field("style", &self.style.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S, M> Checkbox<S, M> {
+    /// Construct a checkbox labelled `label`.
+    #[must_use]
+    pub fn new(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            checked_marker: CHECKED_MARKER.to_owned(),
+            unchecked_marker: UNCHECKED_MARKER.to_owned(),
+            checked: None,
+            disabled: false,
+            style: None,
+            resolved_checked: false,
+        }
+    }
+
+    /// The marker shown while checked.
+    ///
+    /// Any string works, including multi-character pairs like `[x]`; the
+    /// layout measures what you pass. Pair it with
+    /// [`unchecked_marker`](Self::unchecked_marker) so both states read as one
+    /// control — `[ON]`/`[off]` is a switch, `[x]`/`[ ]` an ASCII checkbox.
+    #[must_use]
+    pub fn checked_marker(mut self, marker: impl Into<String>) -> Self {
+        self.checked_marker = marker.into();
+        self
+    }
+
+    /// The marker shown while unchecked.
+    #[must_use]
+    pub fn unchecked_marker(mut self, marker: impl Into<String>) -> Self {
+        self.unchecked_marker = marker.into();
+        self
+    }
+
+    /// Bind the checked state and the message that flips it.
+    ///
+    /// `read` runs against current app state during rendering and event
+    /// handling. `on_change` receives the requested state — `true` after a
+    /// toggle onto checked, `false` after one onto unchecked. Without this
+    /// binding the checkbox is not focusable and answers no events.
+    #[must_use]
+    pub fn checked(
+        mut self,
+        read: impl Fn(&S) -> bool + 'static,
+        on_change: impl Fn(bool) -> M + 'static,
+    ) -> Self {
+        self.checked = Some((Rc::new(read), Rc::new(on_change)));
+        self
+    }
+
+    /// Paint and answer muted, ignoring every event.
+    #[must_use]
+    pub const fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Supply exact colors, taking precedence over the theme.
+    #[must_use]
+    pub fn style(mut self, style: impl Fn(&Theme) -> CheckboxStyle + 'static) -> Self {
+        self.style = Some(Rc::new(style));
+        self
+    }
+
+    fn is_bound(&self) -> bool {
+        self.checked.is_some()
+    }
+
+    fn can_act(&self) -> bool {
+        !self.disabled && self.is_bound()
+    }
+
+    /// The message that flips the bound state.
+    fn toggle(&self) -> EventResult<M> {
+        let Some((_, on_change)) = &self.checked else {
+            return EventResult::Ignored;
+        };
+        EventResult::Emit(on_change(!self.resolved_checked))
+    }
+}
+
+impl<S: 'static, M: 'static> Component<S, M> for Checkbox<S, M> {
+    fn prepare(&mut self, state: &S) {
+        self.resolved_checked = self.checked.as_ref().is_some_and(|(read, _)| read(state));
+    }
+
+    fn declare(&mut self, _ctx: &mut DeclareCtx<'_, S, M>) {
+        // Everything a checkbox is lives on its own node: the paint below and
+        // the events answered here. There is nothing to declare inside it.
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx<'_, S>) {
+        let style = resolve_style(self.style.as_deref(), ctx.theme, CheckboxStyle::from_theme);
+        let widget = CheckboxWidget::new(&self.label, self.resolved_checked)
+            .checked_marker(&self.checked_marker)
+            .unchecked_marker(&self.unchecked_marker)
+            .focused(ctx.focused())
+            .disabled(self.disabled)
+            .style(style);
+        ctx.widget(widget, ctx.area());
+    }
+
+    fn handle_event(
+        &mut self,
+        event: &Event,
+        _state: &S,
+        _ctx: &mut EventCtx<'_>,
+    ) -> EventResult<M> {
+        if !self.can_act() {
+            return EventResult::Ignored;
+        }
+        match event {
+            Event::Mouse(mouse) => match mouse.kind {
+                MouseKind::Click(MouseButton::Left) => self.toggle(),
+                _ => EventResult::Ignored,
+            },
+            Event::Key(key) => self.handle_key(*key),
+            _ => EventResult::Ignored,
+        }
+    }
+
+    fn scope_options(&self) -> ScopeOptions {
+        ScopeOptions::default().focusable(self.can_act())
+    }
+}
+
+impl<S, M> Checkbox<S, M> {
+    /// The keys a checkbox answers: its commit keys, and nothing else.
+    /// Modified keys belong to the app, so Shift+Enter passes through.
+    fn handle_key(&self, key: KeyEvent) -> EventResult<M> {
+        if key.modifiers.any() {
+            return EventResult::Ignored;
+        }
+        match key.code {
+            KeyCode::Enter | KeyCode::Char(' ') => self.toggle(),
+            _ => EventResult::Ignored,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::runtime::{ChildId, FocusState, Modifiers, Ratcn};
+    use crate::test_support::{Driver, key, key_with, mouse};
+
+    #[derive(Default)]
+    struct State {
+        focus: FocusState,
+        vim: bool,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    enum Msg {
+        Focus(FocusState),
+        Vim(bool),
+    }
+
+    fn driver() -> Driver<State, Msg> {
+        Driver::with(
+            Ratcn::new().focus(|state: &State| &state.focus, Msg::Focus),
+            30,
+            6,
+        )
+    }
+
+    fn render(driver: &mut Driver<State, Msg>, state: &State) {
+        driver.render(state, |ctx| {
+            ctx.component(
+                ChildId::Static("vim"),
+                Checkbox::new("Vim bindings").checked(|state: &State| state.vim, Msg::Vim),
+                Rect::new(2, 2, 20, 1),
+            );
+        });
+    }
+
+    /// The whole row is one hit target: the label toggles as well as the
+    /// marker, because a two-cell-wide hit target would be a misery to aim at.
+    #[test]
+    fn a_click_on_the_label_toggles() {
+        let mut driver = driver();
+        let state = State::default();
+        render(&mut driver, &state);
+
+        let result = driver.event(mouse(MouseKind::Click(MouseButton::Left), 8, 2), &state);
+        assert_eq!(result, EventResult::Emit(Msg::Vim(true)));
+    }
+
+    #[test]
+    fn enter_and_space_toggle_and_modified_keys_pass_through() {
+        let mut driver = driver();
+        let state = State {
+            vim: true,
+            ..State::default()
+        };
+        render(&mut driver, &state);
+
+        assert_eq!(
+            driver.event(key(KeyCode::Enter), &state),
+            EventResult::Emit(Msg::Vim(false))
+        );
+        assert_eq!(
+            driver.event(key(KeyCode::Char(' ')), &state),
+            EventResult::Emit(Msg::Vim(false))
+        );
+        // Modified keys belong to the app.
+        assert_eq!(
+            driver.event(
+                key_with(
+                    KeyCode::Enter,
+                    Modifiers {
+                        shift: true,
+                        ..Modifiers::NONE
+                    }
+                ),
+                &state
+            ),
+            EventResult::Ignored
+        );
+    }
+
+    /// A checkbox is text on the surface, not a control wearing chrome: hover
+    /// must paint exactly what rest paints, cell for cell and style for style.
+    #[test]
+    fn hover_paints_the_same_frame_as_rest() {
+        let mut driver = driver();
+        let state = State::default();
+        render(&mut driver, &state);
+        let rest = driver.buffer().clone();
+
+        // Point at the row and redraw. The declaration is identical, so the
+        // only thing that could differ between the frames is hover.
+        driver.event(mouse(MouseKind::Moved, 8, 2), &state);
+        render(&mut driver, &state);
+
+        assert_eq!(
+            *driver.buffer(),
+            rest,
+            "hover changed what a checkbox paints"
+        );
+    }
+
+    #[test]
+    fn a_resting_checkbox_paints_no_background() {
+        let mut driver = driver();
+        let state = State::default();
+        render(&mut driver, &state);
+
+        for column in 0..22u16 {
+            let cell = driver.cell(column, 2);
+            assert_eq!(
+                cell.bg,
+                Color::Reset,
+                "column {column} painted a background"
+            );
+        }
+    }
+
+    #[test]
+    fn the_markers_are_yours_to_choose() {
+        let theme = Theme::default_dark();
+        let area = Rect::new(0, 0, 24, 1);
+        let mut buffer = Buffer::empty(area);
+
+        CheckboxWidget::new("Vim bindings", true)
+            .checked_marker("[x]")
+            .unchecked_marker("[ ]")
+            .themed(&theme)
+            .render(area, &mut buffer);
+
+        let row: String = (0..24u16)
+            .map(|column| buffer.cell((column, 0)).expect("cell").symbol())
+            .collect();
+        assert!(row.starts_with("[x] Vim bindings"), "{row:?}");
+    }
+
+    #[test]
+    fn an_unbound_checkbox_is_not_focusable_and_answers_nothing() {
+        let mut driver = driver();
+        let state = State::default();
+        driver.render(&state, |ctx| {
+            ctx.component(
+                ChildId::Static("unbound"),
+                Checkbox::new("Unbound"),
+                Rect::new(2, 2, 20, 1),
+            );
+        });
+
+        // Nothing here may take or answer focus: were the unbound checkbox
+        // focusable, Tab would resolve into it and emit a focus message.
+        assert!(matches!(
+            driver.event(key(KeyCode::Tab), &state),
+            EventResult::Ignored
+        ));
+        assert!(matches!(
+            driver.event(key(KeyCode::Char(' ')), &state),
+            EventResult::Ignored
+        ));
+        assert!(matches!(
+            driver.event(mouse(MouseKind::Click(MouseButton::Left), 8, 2), &state),
+            EventResult::Ignored
+        ));
+    }
+}

--- a/crates/ratcn/src/components/cycle.rs
+++ b/crates/ratcn/src/components/cycle.rs
@@ -165,17 +165,6 @@ impl<'a> CycleWidget<'a> {
         self
     }
 
-    /// Columns of the widest option — the width that fits every value this
-    /// cycle can ever show.
-    #[must_use]
-    pub fn span(&self) -> u16 {
-        self.options
-            .iter()
-            .map(|option| text_width::display_width_u16(option))
-            .max()
-            .unwrap_or(0)
-    }
-
     fn resolved_style(&self) -> CycleStyle {
         match (self.style, self.theme) {
             (Some(style), _) => style,
@@ -224,6 +213,9 @@ pub struct Cycle<S, M> {
     style: Option<StyleFn>,
     /// The bound selection, resolved and clamped once per declaration.
     resolved_selected: usize,
+    /// The columns the current option paints — the Cycle is as wide as the
+    /// value it shows, no wider.
+    resolved_width: u16,
 }
 
 impl<S, M> fmt::Debug for Cycle<S, M> {
@@ -250,6 +242,7 @@ impl<S, M> Cycle<S, M> {
             disabled: false,
             style: None,
             resolved_selected: 0,
+            resolved_width: 0,
         }
     }
 
@@ -285,6 +278,15 @@ impl<S, M> Cycle<S, M> {
 
     fn can_act(&self) -> bool {
         !self.disabled && !self.options.is_empty() && self.selection.is_some()
+    }
+
+    /// The rect the current value paints in and answers events in: the Cycle
+    /// is exactly as wide as the text it shows.
+    fn value_area(&self, area: Rect) -> Rect {
+        Rect {
+            width: self.resolved_width.min(area.width),
+            ..area
+        }
     }
 
     /// Advance one option. Forward past the end wraps to the first; backward
@@ -325,6 +327,11 @@ impl<S: 'static, M: 'static> Component<S, M> for Cycle<S, M> {
             .as_ref()
             .map_or(0, |(read, _)| read(state))
             .min(self.options.len().saturating_sub(1));
+        self.resolved_width = self
+            .options
+            .get(self.resolved_selected)
+            .map(|option| text_width::display_width_u16(option))
+            .unwrap_or(0);
     }
 
     fn declare(&mut self, _ctx: &mut DeclareCtx<'_, S, M>) {
@@ -344,7 +351,7 @@ impl<S: 'static, M: 'static> Component<S, M> for Cycle<S, M> {
             .hovered(ctx.hovered())
             .disabled(self.disabled)
             .style(style);
-        ctx.widget(widget, ctx.area());
+        ctx.widget(widget, self.value_area(ctx.area()));
     }
 
     fn handle_event(
@@ -368,6 +375,10 @@ impl<S: 'static, M: 'static> Component<S, M> for Cycle<S, M> {
 
     fn scope_options(&self) -> ScopeOptions {
         ScopeOptions::default().focusable(self.can_act())
+    }
+
+    fn interaction_area(&self, area: Rect) -> Rect {
+        self.value_area(area)
     }
 }
 

--- a/crates/ratcn/src/components/cycle.rs
+++ b/crates/ratcn/src/components/cycle.rs
@@ -26,10 +26,11 @@ use ratatui::{
 use crate::{
     Theme,
     button_shape::filled_middle,
-    color::{FOCUS_SHIFT, HOVER_SHIFT, away_from, dim},
+    color::ghost_fills,
+    linear_nav::{Axis, step_key},
     runtime::{
         Component, DeclareCtx, Event, EventCtx, EventResult, KeyCode, KeyEvent, MouseButton,
-        MouseKind, PaintCtx, ScopeOptions,
+        MouseKind, PaintCtx, ScopeOptions, Step,
     },
     text_width,
     theme::resolve_style,
@@ -39,14 +40,20 @@ use crate::{
 ///
 /// At rest only [`foreground`](Self::foreground) paints, on nothing: the
 /// surface shows through. Hover and focus each lay their background over the
-/// declared area — hover beating focus, so pointing at the cycle you are on
-/// stays visible — disabled mutes the text and paints nothing.
+/// value, with their own text color on it the way
+/// [`ButtonStyle`](crate::ButtonStyle) carries one per state — hover beating
+/// focus, so pointing at the cycle you are on stays visible. Disabled mutes
+/// the text and paints nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CycleStyle {
-    /// Value color at rest; also the text color under hover and focus.
+    /// Value color at rest.
     pub foreground: Color,
+    /// Value color while focused.
+    pub focused_foreground: Color,
     /// Background while focused.
     pub focused_background: Color,
+    /// Value color while hovered.
+    pub hovered_foreground: Color,
     /// Background while hovered.
     pub hovered_background: Color,
     /// Value color while disabled.
@@ -55,26 +62,31 @@ pub struct CycleStyle {
 
 impl CycleStyle {
     /// The no-theme starting point: plain ANSI colors that render on any
-    /// terminal.
+    /// terminal — the ghost button's fills, with its text colors on them.
     #[must_use]
     pub const fn fallback() -> Self {
         Self {
             foreground: Color::Gray,
+            focused_foreground: Color::Black,
             focused_background: Color::Cyan,
+            hovered_foreground: Color::Black,
             hovered_background: Color::LightCyan,
             disabled_foreground: Color::DarkGray,
         }
     }
 
-    /// Colors derived from a theme, solving the same fills the ghost button
-    /// solves: both climb away from the screen color, so they read as raised.
+    /// Colors derived from a theme: the ghost button's raised fills with the
+    /// value keeping the theme's foreground on them.
     #[must_use]
     pub fn from_theme(theme: &Theme) -> Self {
-        let raised = away_from(theme.background);
+        let (focused_background, hovered_background) =
+            ghost_fills(theme.secondary, theme.background);
         Self {
             foreground: theme.foreground,
-            focused_background: dim(theme.secondary, raised, FOCUS_SHIFT),
-            hovered_background: dim(theme.secondary, raised, HOVER_SHIFT),
+            focused_foreground: theme.foreground,
+            focused_background,
+            hovered_foreground: theme.foreground,
+            hovered_background,
             disabled_foreground: theme.muted_foreground,
         }
     }
@@ -86,11 +98,11 @@ impl CycleStyle {
             Style::default().fg(self.disabled_foreground)
         } else if hovered {
             Style::default()
-                .fg(self.foreground)
+                .fg(self.hovered_foreground)
                 .bg(self.hovered_background)
         } else if focused {
             Style::default()
-                .fg(self.foreground)
+                .fg(self.focused_foreground)
                 .bg(self.focused_background)
         } else {
             Style::default().fg(self.foreground)
@@ -99,11 +111,13 @@ impl CycleStyle {
 }
 
 /// A cycle that only draws — an ordinary ratatui [`Widget`] with no focus,
-/// events, or state. It paints the current option across `area`.
+/// events, or state. It paints the current option across `area`, the way the
+/// closed [`SelectWidget`](crate::SelectWidget) paints its value: the widget
+/// takes the one string it shows, and which option that is stays the caller's
+/// business.
 #[derive(Debug)]
 pub struct CycleWidget<'a> {
-    options: &'a [&'a str],
-    selected: usize,
+    value: &'a str,
     focused: bool,
     hovered: bool,
     disabled: bool,
@@ -112,16 +126,11 @@ pub struct CycleWidget<'a> {
 }
 
 impl<'a> CycleWidget<'a> {
-    /// A cycle over `options`, showing `options[selected]`.
-    ///
-    /// An out-of-range `selected` paints the first option rather than
-    /// panicking: the widget half has no contract to enforce, and a caller
-    /// that clamps nowhere else still gets a whole frame.
+    /// A cycle showing `value`, its current option.
     #[must_use]
-    pub fn new(options: &'a [&'a str], selected: usize) -> Self {
+    pub const fn new(value: &'a str) -> Self {
         Self {
-            options,
-            selected,
+            value,
             focused: false,
             hovered: false,
             disabled: false,
@@ -176,14 +185,13 @@ impl<'a> CycleWidget<'a> {
 
 impl Widget for CycleWidget<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        if area.width == 0 || area.height == 0 || self.options.is_empty() {
+        if area.width == 0 || area.height == 0 {
             return;
         }
-        let selected = self.selected.min(self.options.len() - 1);
         let style = self
             .resolved_style()
             .resolve(self.focused, self.hovered, self.disabled);
-        Line::from(filled_middle(self.options[selected], area.width as usize))
+        Line::from(filled_middle(self.value, area.width as usize))
             .style(style)
             .render(area, buf);
     }
@@ -208,7 +216,7 @@ type StyleFn = Rc<dyn Fn(&Theme) -> CycleStyle>;
 /// [`selection`](Self::selection) as an index; without that binding the Cycle
 /// paints but is not focusable and answers no events.
 pub struct Cycle<S, M> {
-    options: Rc<[Box<str>]>,
+    options: Vec<String>,
     selection: Option<(ReadSelectedFn<S>, OnChangeFn<M>)>,
     disabled: bool,
     style: Option<StyleFn>,
@@ -235,10 +243,7 @@ impl<S, M> Cycle<S, M> {
     #[must_use]
     pub fn new(options: impl IntoIterator<Item = impl Into<String>>) -> Self {
         Self {
-            options: options
-                .into_iter()
-                .map(|option| option.into().into_boxed_str())
-                .collect(),
+            options: options.into_iter().map(Into::into).collect(),
             selection: None,
             disabled: false,
             style: None,
@@ -308,17 +313,20 @@ impl<S, M> Cycle<S, M> {
         EventResult::Emit(on_change(next))
     }
 
-    /// The key map, horizontal like the tab strip's: Left/Right and their vi
-    /// letters step, the readline chords step too, commit keys advance. Shift
-    /// belongs to the app, so Shift+Space passes through untouched.
+    /// The key map: the one horizontal step map every item control shares —
+    /// Left/Right, their vi letters, and the readline chords, asked first
+    /// because it owns Ctrl+N/Ctrl+P — then the commit keys, which advance.
+    /// Home and End step nothing: a ring has no ends. Shift belongs to the
+    /// app, so Shift+Space passes through untouched.
     fn handle_key(&self, key: KeyEvent) -> EventResult<M> {
-        let plain = !key.modifiers.any();
-        let ctrl_only = key.modifiers.ctrl && !key.modifiers.alt && !key.modifiers.shift;
+        if let Some(step) = step_key(key, Axis::Horizontal) {
+            return self.step(matches!(step, Step::Backward));
+        }
+        if key.modifiers.any() {
+            return EventResult::Ignored;
+        }
         match key.code {
-            KeyCode::Right | KeyCode::Enter | KeyCode::Char('l' | ' ') if plain => self.step(false),
-            KeyCode::Left | KeyCode::Char('h') if plain => self.step(true),
-            KeyCode::Char('n') if ctrl_only => self.step(false),
-            KeyCode::Char('p') if ctrl_only => self.step(true),
+            KeyCode::Enter | KeyCode::Char(' ') => self.step(false),
             _ => EventResult::Ignored,
         }
     }
@@ -343,13 +351,13 @@ impl<S: 'static, M: 'static> Component<S, M> for Cycle<S, M> {
     }
 
     fn paint(&mut self, ctx: &mut PaintCtx<'_, S>) {
+        // `prepare` clamped the selection, so this is `None` only with no
+        // options at all — nothing to show, nothing to paint.
+        let Some(value) = self.options.get(self.resolved_selected) else {
+            return;
+        };
         let style = resolve_style(self.style.as_deref(), ctx.theme, CycleStyle::from_theme);
-        let labels: Vec<&str> = self
-            .options
-            .iter()
-            .map(std::convert::AsRef::as_ref)
-            .collect();
-        let widget = CycleWidget::new(&labels, self.resolved_selected)
+        let widget = CycleWidget::new(value)
             .focused(ctx.focused())
             .hovered(ctx.hovered())
             .disabled(self.disabled)
@@ -517,14 +525,15 @@ mod tests {
         );
     }
 
-    /// The ghost styling is the contract: bare text at rest, a fill when
-    /// focused. Pinned on the widget, where focus is a plain argument.
+    /// The ghost styling is the contract: bare text at rest, a fill with
+    /// readable text when focused. Pinned on the widget, where focus is a
+    /// plain argument.
     #[test]
     fn focus_lays_a_background_over_the_value_and_rest_does_not() {
         let area = Rect::new(0, 0, 12, 1);
 
         let mut rest = Buffer::empty(area);
-        CycleWidget::new(&SIZES, 1).render(area, &mut rest);
+        CycleWidget::new("Medium").render(area, &mut rest);
         assert_eq!(
             rest.cell((3, 0)).expect("cell").bg,
             Color::Reset,
@@ -532,14 +541,16 @@ mod tests {
         );
 
         let mut focused = Buffer::empty(area);
-        CycleWidget::new(&SIZES, 1)
+        CycleWidget::new("Medium")
             .focused(true)
             .render(area, &mut focused);
+        let cell = focused.cell((3, 0)).expect("cell");
         assert_ne!(
-            focused.cell((3, 0)).expect("cell").bg,
+            cell.bg,
             Color::Reset,
             "a focused cycle must be findable by its fill"
         );
+        assert_ne!(cell.fg, cell.bg, "the value must read on the fill");
     }
 
     /// Disabled is the loudest state: no events, no traversal, no fill.
@@ -593,17 +604,45 @@ mod tests {
         ));
     }
 
-    /// A stored index that outlived its options list clamps instead of
-    /// panicking or painting nothing.
+    /// A stored index that outlived its options list clamps to the last
+    /// option instead of panicking: stepping forward from it wraps to the
+    /// first, which only the clamped position gives.
     #[test]
     fn an_out_of_range_selection_clamps_to_the_last_option() {
-        let area = Rect::new(0, 0, 12, 1);
-        let mut buffer = Buffer::empty(area);
-        CycleWidget::new(&SIZES, 9).render(area, &mut buffer);
+        let mut driver = driver();
+        let state = State {
+            size: 9,
+            ..State::default()
+        };
+        render(&mut driver, &state);
 
-        let row: String = (0..12u16)
-            .map(|column| buffer.cell((column, 0)).expect("cell").symbol())
-            .collect();
-        assert!(row.contains("Large"), "{row:?}");
+        assert_eq!(
+            driver.event(key(KeyCode::Right), &state),
+            EventResult::Emit(Msg::Size(0))
+        );
+    }
+
+    /// A Cycle with no options declares, paints nothing, and answers nothing —
+    /// there is no index to show and nothing to advance.
+    #[test]
+    fn a_cycle_with_no_options_is_inert() {
+        let mut driver = driver();
+        let state = State::default();
+        driver.render(&state, |ctx| {
+            ctx.component(
+                ChildId::Static("size"),
+                Cycle::new(Vec::<String>::new()).selection(|s: &State| s.size, Msg::Size),
+                Rect::new(2, 2, 10, 1),
+            );
+        });
+
+        assert!(matches!(
+            driver.event(key(KeyCode::Tab), &state),
+            EventResult::Ignored
+        ));
+        assert!(matches!(
+            driver.event(key(KeyCode::Char(' ')), &state),
+            EventResult::Ignored
+        ));
     }
 }

--- a/crates/ratcn/src/components/cycle.rs
+++ b/crates/ratcn/src/components/cycle.rs
@@ -282,12 +282,15 @@ impl<S, M> Cycle<S, M> {
     }
 
     /// The rect the current value paints in and answers events in: the Cycle
-    /// is exactly as wide as the text it shows.
+    /// is exactly as wide as the text it shows, and one row tall.
     fn value_area(&self, area: Rect) -> Rect {
-        Rect {
-            width: self.resolved_width.min(area.width),
-            ..area
-        }
+        crate::geometry::fixed_height(
+            Rect {
+                width: self.resolved_width.min(area.width),
+                ..area
+            },
+            1,
+        )
     }
 
     /// Advance one option. Forward past the end wraps to the first; backward

--- a/crates/ratcn/src/components/cycle.rs
+++ b/crates/ratcn/src/components/cycle.rs
@@ -17,7 +17,7 @@ use std::{fmt, rc::Rc};
 
 use ratatui::{
     buffer::Buffer,
-    layout::Rect,
+    layout::{Alignment, Rect, Size},
     style::{Color, Style},
     text::Line,
     widgets::Widget,
@@ -29,8 +29,8 @@ use crate::{
     color::ghost_fills,
     linear_nav::{Axis, step_key},
     runtime::{
-        Component, DeclareCtx, Event, EventCtx, EventResult, KeyCode, KeyEvent, MouseButton,
-        MouseKind, PaintCtx, ScopeOptions, Step,
+        Component, DeclareCtx, Event, EventCtx, EventResult, KeyCode, KeyEvent, MeasuredComponent,
+        MouseButton, MouseKind, PaintCtx, ScopeOptions, Step,
     },
     text_width,
     theme::resolve_style,
@@ -220,6 +220,8 @@ pub struct Cycle<S, M> {
     selection: Option<(ReadSelectedFn<S>, OnChangeFn<M>)>,
     disabled: bool,
     style: Option<StyleFn>,
+    /// Which edge of the declared area the value hugs.
+    align: Alignment,
     /// The bound selection, resolved and clamped once per declaration.
     resolved_selected: usize,
     /// The columns the current option paints — the Cycle is as wide as the
@@ -247,9 +249,35 @@ impl<S, M> Cycle<S, M> {
             selection: None,
             disabled: false,
             style: None,
+            align: Alignment::Left,
             resolved_selected: 0,
             resolved_width: 0,
         }
+    }
+
+    /// Which edge of the declared area the value hugs; left by default.
+    ///
+    /// The Cycle stays exactly as wide as its value — this moves that value,
+    /// paint and hit target together, within the area the app declares. With
+    /// `Alignment::Right` a settings row is one declaration: the name painted
+    /// at the left edge, the Cycle hugging the right.
+    #[must_use]
+    pub const fn align(mut self, align: Alignment) -> Self {
+        self.align = align;
+        self
+    }
+
+    /// The columns that fit every option — the widest value, so an area
+    /// reserved from this never truncates and never shifts as the value
+    /// cycles. What the Cycle paints each frame is narrower: exactly its
+    /// current value.
+    #[must_use]
+    pub fn width(&self) -> u16 {
+        self.options
+            .iter()
+            .map(|option| text_width::display_width_u16(option))
+            .max()
+            .unwrap_or(0)
     }
 
     /// Bind the selection and the message that moves it.
@@ -287,15 +315,16 @@ impl<S, M> Cycle<S, M> {
     }
 
     /// The rect the current value paints in and answers events in: the Cycle
-    /// is exactly as wide as the text it shows, and one row tall.
+    /// is exactly as wide as the text it shows, one row tall, hugging the
+    /// [`align`](Self::align) edge of the declared area.
     fn value_area(&self, area: Rect) -> Rect {
-        crate::geometry::fixed_height(
-            Rect {
-                width: self.resolved_width.min(area.width),
-                ..area
-            },
-            1,
-        )
+        let width = self.resolved_width.min(area.width);
+        let x = match self.align {
+            Alignment::Left => area.x,
+            Alignment::Center => area.x + (area.width - width) / 2,
+            Alignment::Right => area.x + (area.width - width),
+        };
+        crate::geometry::fixed_height(Rect { x, width, ..area }, 1)
     }
 
     /// Advance one option. Forward past the end wraps to the first; backward
@@ -390,6 +419,12 @@ impl<S: 'static, M: 'static> Component<S, M> for Cycle<S, M> {
 
     fn interaction_area(&self, area: Rect) -> Rect {
         self.value_area(area)
+    }
+}
+
+impl<S: 'static, M: 'static> MeasuredComponent<S, M> for Cycle<S, M> {
+    fn measure(&self) -> Size {
+        Size::new(self.width(), 1)
     }
 }
 
@@ -602,6 +637,47 @@ mod tests {
             driver.event(key(KeyCode::Char(' ')), &state),
             EventResult::Ignored
         ));
+    }
+
+    /// A right-aligned Cycle hugs the right edge of the area it is declared
+    /// on — paint and hit target together: the value's columns answer, the
+    /// empty columns to their left do not.
+    #[test]
+    fn a_right_aligned_cycle_answers_at_the_right_edge() {
+        let mut driver = driver();
+        let state = State::default();
+        // Declared 20 wide at x=2; "Small" is 5 wide, so it occupies x 17..22.
+        driver.render(&state, |ctx| {
+            ctx.component(
+                ChildId::Static("size"),
+                Cycle::new(SIZES)
+                    .selection(|s: &State| s.size, Msg::Size)
+                    .align(Alignment::Right),
+                Rect::new(2, 2, 20, 1),
+            );
+        });
+
+        assert_eq!(
+            driver.event(mouse(MouseKind::Click(MouseButton::Left), 21, 2), &state),
+            EventResult::Emit(Msg::Size(1)),
+            "the value's own columns must answer"
+        );
+        assert!(
+            matches!(
+                driver.event(mouse(MouseKind::Click(MouseButton::Left), 5, 2), &state),
+                EventResult::Ignored
+            ),
+            "the empty columns left of the value must not"
+        );
+    }
+
+    /// The component measures the columns that fit every option, so a layout
+    /// reserved from it never truncates and never shifts as the value cycles.
+    #[test]
+    fn the_component_measures_its_widest_option() {
+        let cycle: Cycle<State, Msg> = Cycle::new(SIZES);
+        assert_eq!(cycle.width(), 6, "\"Medium\" is the widest option");
+        assert_eq!(cycle.measure(), Size::new(6, 1));
     }
 
     /// A stored index that outlived its options list clamps to the last

--- a/crates/ratcn/src/components/cycle.rs
+++ b/crates/ratcn/src/components/cycle.rs
@@ -330,8 +330,7 @@ impl<S: 'static, M: 'static> Component<S, M> for Cycle<S, M> {
         self.resolved_width = self
             .options
             .get(self.resolved_selected)
-            .map(|option| text_width::display_width_u16(option))
-            .unwrap_or(0);
+            .map_or(0, |option| text_width::display_width_u16(option));
     }
 
     fn declare(&mut self, _ctx: &mut DeclareCtx<'_, S, M>) {

--- a/crates/ratcn/src/components/cycle.rs
+++ b/crates/ratcn/src/components/cycle.rs
@@ -39,8 +39,8 @@ use crate::{
 ///
 /// At rest only [`foreground`](Self::foreground) paints, on nothing: the
 /// surface shows through. Hover and focus each lay their background over the
-/// declared area, disabled mutes the text, and each earlier state wins over
-/// the later ones.
+/// declared area — hover beating focus, so pointing at the cycle you are on
+/// stays visible — disabled mutes the text and paints nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CycleStyle {
     /// Value color at rest; also the text color under hover and focus.
@@ -80,18 +80,18 @@ impl CycleStyle {
     }
 
     /// One paint pass's colors (see [`Self::from_theme`]). Disabled wins over
-    /// focus, which wins over hover, which wins over rest.
+    /// hover, which wins over focus, which wins over rest.
     fn resolve(self, focused: bool, hovered: bool, disabled: bool) -> Style {
         if disabled {
             Style::default().fg(self.disabled_foreground)
-        } else if focused {
-            Style::default()
-                .fg(self.foreground)
-                .bg(self.focused_background)
         } else if hovered {
             Style::default()
                 .fg(self.foreground)
                 .bg(self.hovered_background)
+        } else if focused {
+            Style::default()
+                .fg(self.foreground)
+                .bg(self.focused_background)
         } else {
             Style::default().fg(self.foreground)
         }
@@ -197,7 +197,8 @@ type StyleFn = Rc<dyn Fn(&Theme) -> CycleStyle>;
 /// all it shows, and every click, <kbd>Enter</kbd>, <kbd>Space</kbd>,
 /// <kbd>Right</kbd>/<kbd>l</kbd>, or <kbd>Ctrl+N</kbd> advances to the next,
 /// wrapping at the end. <kbd>Left</kbd>/<kbd>h</kbd> walks backward, as does
-/// <kbd>Ctrl+P</kbd>.
+/// <kbd>Ctrl+P</kbd>. Home and End step nothing: a ring has no ends.
+/// Shift belongs to the app, so Shift+Space passes through untouched.
 ///
 /// The row paints like a small ghost button — plain text at rest, a quiet
 /// fill on hover or focus — so a column of cycles reads as values, not as a
@@ -536,6 +537,35 @@ mod tests {
             Color::Reset,
             "a focused cycle must be findable by its fill"
         );
+    }
+
+    /// Disabled is the loudest state: no events, no traversal, no fill.
+    #[test]
+    fn a_disabled_cycle_is_inert() {
+        let mut driver = driver();
+        let state = State::default();
+        driver.render(&state, |ctx| {
+            ctx.component(
+                ChildId::Static("size"),
+                Cycle::new(SIZES)
+                    .disabled(true)
+                    .selection(|s: &State| s.size, Msg::Size),
+                Rect::new(2, 2, 10, 1),
+            );
+        });
+
+        assert!(matches!(
+            driver.event(key(KeyCode::Char(' ')), &state),
+            EventResult::Ignored
+        ));
+        assert!(matches!(
+            driver.event(mouse(MouseKind::Click(MouseButton::Left), 5, 2), &state),
+            EventResult::Ignored
+        ));
+        assert!(matches!(
+            driver.event(key(KeyCode::Tab), &state),
+            EventResult::Ignored
+        ));
     }
 
     #[test]

--- a/crates/ratcn/src/components/cycle.rs
+++ b/crates/ratcn/src/components/cycle.rs
@@ -1,0 +1,566 @@
+//! A one-of-many control that cycles: it shows the current option, and every
+//! act — a click, Enter, Space, an arrow — advances to the next one.
+//!
+//! ```text
+//! Medium
+//! ```
+//!
+//! A Cycle is the settings-row control for more than two options. Two options
+//! are a [`Checkbox`](crate::Checkbox) wearing the words as its markers; three
+//! or more, or an ordered scale (Small/Medium/Large), are a Cycle.
+//!
+//! The value paints as plain text in the style of a small ghost button: bare
+//! at rest, tinted while hovered or focused, muted while disabled. Nothing
+//! about it reads as chrome, and focus stays findable for keyboard users.
+
+use std::{fmt, rc::Rc};
+
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Style},
+    text::Line,
+    widgets::Widget,
+};
+
+use crate::{
+    Theme,
+    button_shape::filled_middle,
+    color::{FOCUS_SHIFT, HOVER_SHIFT, away_from, dim},
+    runtime::{
+        Component, DeclareCtx, Event, EventCtx, EventResult, KeyCode, KeyEvent, MouseButton,
+        MouseKind, PaintCtx, ScopeOptions,
+    },
+    text_width,
+    theme::resolve_style,
+};
+
+/// A cycle's colors — the small ghost button's palette, one role per state.
+///
+/// At rest only [`foreground`](Self::foreground) paints, on nothing: the
+/// surface shows through. Hover and focus each lay their background over the
+/// declared area, disabled mutes the text, and each earlier state wins over
+/// the later ones.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CycleStyle {
+    /// Value color at rest; also the text color under hover and focus.
+    pub foreground: Color,
+    /// Background while focused.
+    pub focused_background: Color,
+    /// Background while hovered.
+    pub hovered_background: Color,
+    /// Value color while disabled.
+    pub disabled_foreground: Color,
+}
+
+impl CycleStyle {
+    /// The no-theme starting point: plain ANSI colors that render on any
+    /// terminal.
+    #[must_use]
+    pub const fn fallback() -> Self {
+        Self {
+            foreground: Color::Gray,
+            focused_background: Color::Cyan,
+            hovered_background: Color::LightCyan,
+            disabled_foreground: Color::DarkGray,
+        }
+    }
+
+    /// Colors derived from a theme, solving the same fills the ghost button
+    /// solves: both climb away from the screen color, so they read as raised.
+    #[must_use]
+    pub fn from_theme(theme: &Theme) -> Self {
+        let raised = away_from(theme.background);
+        Self {
+            foreground: theme.foreground,
+            focused_background: dim(theme.secondary, raised, FOCUS_SHIFT),
+            hovered_background: dim(theme.secondary, raised, HOVER_SHIFT),
+            disabled_foreground: theme.muted_foreground,
+        }
+    }
+
+    /// One paint pass's colors (see [`Self::from_theme`]). Disabled wins over
+    /// focus, which wins over hover, which wins over rest.
+    fn resolve(self, focused: bool, hovered: bool, disabled: bool) -> Style {
+        if disabled {
+            Style::default().fg(self.disabled_foreground)
+        } else if focused {
+            Style::default()
+                .fg(self.foreground)
+                .bg(self.focused_background)
+        } else if hovered {
+            Style::default()
+                .fg(self.foreground)
+                .bg(self.hovered_background)
+        } else {
+            Style::default().fg(self.foreground)
+        }
+    }
+}
+
+/// A cycle that only draws — an ordinary ratatui [`Widget`] with no focus,
+/// events, or state. It paints the current option across `area`.
+#[derive(Debug)]
+pub struct CycleWidget<'a> {
+    options: &'a [&'a str],
+    selected: usize,
+    focused: bool,
+    hovered: bool,
+    disabled: bool,
+    theme: Option<Theme>,
+    style: Option<CycleStyle>,
+}
+
+impl<'a> CycleWidget<'a> {
+    /// A cycle over `options`, showing `options[selected]`.
+    ///
+    /// An out-of-range `selected` paints the first option rather than
+    /// panicking: the widget half has no contract to enforce, and a caller
+    /// that clamps nowhere else still gets a whole frame.
+    #[must_use]
+    pub fn new(options: &'a [&'a str], selected: usize) -> Self {
+        Self {
+            options,
+            selected,
+            focused: false,
+            hovered: false,
+            disabled: false,
+            theme: None,
+            style: None,
+        }
+    }
+
+    /// Take colors from `theme`.
+    #[must_use]
+    pub const fn themed(mut self, theme: &Theme) -> Self {
+        self.theme = Some(*theme);
+        self
+    }
+
+    /// Exact colors, taking precedence over [`themed`](Self::themed).
+    #[must_use]
+    pub const fn style(mut self, style: CycleStyle) -> Self {
+        self.style = Some(style);
+        self
+    }
+
+    /// Paint the focused background.
+    #[must_use]
+    pub const fn focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    /// Paint the hovered background.
+    #[must_use]
+    pub const fn hovered(mut self, hovered: bool) -> Self {
+        self.hovered = hovered;
+        self
+    }
+
+    /// Paint muted.
+    #[must_use]
+    pub const fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Columns of the widest option — the width that fits every value this
+    /// cycle can ever show.
+    #[must_use]
+    pub fn span(&self) -> u16 {
+        self.options
+            .iter()
+            .map(|option| text_width::display_width_u16(option))
+            .max()
+            .unwrap_or(0)
+    }
+
+    fn resolved_style(&self) -> CycleStyle {
+        match (self.style, self.theme) {
+            (Some(style), _) => style,
+            (None, Some(theme)) => CycleStyle::from_theme(&theme),
+            (None, None) => CycleStyle::fallback(),
+        }
+    }
+}
+
+impl Widget for CycleWidget<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        if area.width == 0 || area.height == 0 || self.options.is_empty() {
+            return;
+        }
+        let selected = self.selected.min(self.options.len() - 1);
+        let style = self
+            .resolved_style()
+            .resolve(self.focused, self.hovered, self.disabled);
+        Line::from(filled_middle(self.options[selected], area.width as usize))
+            .style(style)
+            .render(area, buf);
+    }
+}
+
+type ReadSelectedFn<S> = Rc<dyn Fn(&S) -> usize>;
+type OnChangeFn<M> = Rc<dyn Fn(usize) -> M>;
+type StyleFn = Rc<dyn Fn(&Theme) -> CycleStyle>;
+
+/// A control that cycles through its options in place: the current value is
+/// all it shows, and every click, <kbd>Enter</kbd>, <kbd>Space</kbd>,
+/// <kbd>Right</kbd>/<kbd>l</kbd>, or <kbd>Ctrl+N</kbd> advances to the next,
+/// wrapping at the end. <kbd>Left</kbd>/<kbd>h</kbd> walks backward, as does
+/// <kbd>Ctrl+P</kbd>.
+///
+/// The row paints like a small ghost button — plain text at rest, a quiet
+/// fill on hover or focus — so a column of cycles reads as values, not as a
+/// wall of chrome.
+///
+/// The selection lives in app state and arrives through
+/// [`selection`](Self::selection) as an index; without that binding the Cycle
+/// paints but is not focusable and answers no events.
+pub struct Cycle<S, M> {
+    options: Rc<[Box<str>]>,
+    selection: Option<(ReadSelectedFn<S>, OnChangeFn<M>)>,
+    disabled: bool,
+    style: Option<StyleFn>,
+    /// The bound selection, resolved and clamped once per declaration.
+    resolved_selected: usize,
+}
+
+impl<S, M> fmt::Debug for Cycle<S, M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Cycle")
+            .field("options", &self.options)
+            .field("selection", &self.selection.is_some())
+            .field("disabled", &self.disabled)
+            .field("style", &self.style.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S, M> Cycle<S, M> {
+    /// Construct a Cycle from its options, in cycling order.
+    #[must_use]
+    pub fn new(options: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            options: options
+                .into_iter()
+                .map(|option| option.into().into_boxed_str())
+                .collect(),
+            selection: None,
+            disabled: false,
+            style: None,
+            resolved_selected: 0,
+        }
+    }
+
+    /// Bind the selection and the message that moves it.
+    ///
+    /// `read` returns the index of the option shown; an out-of-range answer
+    /// clamps to the last option rather than panicking. `on_change` receives
+    /// the index the user advanced or backed up to. Without this binding the
+    /// Cycle is not focusable and answers no events.
+    #[must_use]
+    pub fn selection(
+        mut self,
+        read: impl Fn(&S) -> usize + 'static,
+        on_change: impl Fn(usize) -> M + 'static,
+    ) -> Self {
+        self.selection = Some((Rc::new(read), Rc::new(on_change)));
+        self
+    }
+
+    /// Paint and answer muted, ignoring every event.
+    #[must_use]
+    pub const fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Supply exact colors, taking precedence over the theme.
+    #[must_use]
+    pub fn style(mut self, style: impl Fn(&Theme) -> CycleStyle + 'static) -> Self {
+        self.style = Some(Rc::new(style));
+        self
+    }
+
+    fn can_act(&self) -> bool {
+        !self.disabled && !self.options.is_empty() && self.selection.is_some()
+    }
+
+    /// Advance one option. Forward past the end wraps to the first; backward
+    /// before the start wraps to the last.
+    fn step(&self, backward: bool) -> EventResult<M> {
+        let Some((_, on_change)) = &self.selection else {
+            return EventResult::Ignored;
+        };
+        let len = self.options.len();
+        let next = if backward {
+            (self.resolved_selected + len - 1) % len
+        } else {
+            (self.resolved_selected + 1) % len
+        };
+        EventResult::Emit(on_change(next))
+    }
+
+    /// The key map, horizontal like the tab strip's: Left/Right and their vi
+    /// letters step, the readline chords step too, commit keys advance. Shift
+    /// belongs to the app, so Shift+Space passes through untouched.
+    fn handle_key(&self, key: KeyEvent) -> EventResult<M> {
+        let plain = !key.modifiers.any();
+        let ctrl_only = key.modifiers.ctrl && !key.modifiers.alt && !key.modifiers.shift;
+        match key.code {
+            KeyCode::Right | KeyCode::Enter | KeyCode::Char('l' | ' ') if plain => self.step(false),
+            KeyCode::Left | KeyCode::Char('h') if plain => self.step(true),
+            KeyCode::Char('n') if ctrl_only => self.step(false),
+            KeyCode::Char('p') if ctrl_only => self.step(true),
+            _ => EventResult::Ignored,
+        }
+    }
+}
+
+impl<S: 'static, M: 'static> Component<S, M> for Cycle<S, M> {
+    fn prepare(&mut self, state: &S) {
+        self.resolved_selected = self
+            .selection
+            .as_ref()
+            .map_or(0, |(read, _)| read(state))
+            .min(self.options.len().saturating_sub(1));
+    }
+
+    fn declare(&mut self, _ctx: &mut DeclareCtx<'_, S, M>) {
+        // Everything a Cycle is lives on its own node: the paint below and
+        // the events answered here. There is nothing to declare inside it.
+    }
+
+    fn paint(&mut self, ctx: &mut PaintCtx<'_, S>) {
+        let style = resolve_style(self.style.as_deref(), ctx.theme, CycleStyle::from_theme);
+        let labels: Vec<&str> = self
+            .options
+            .iter()
+            .map(std::convert::AsRef::as_ref)
+            .collect();
+        let widget = CycleWidget::new(&labels, self.resolved_selected)
+            .focused(ctx.focused())
+            .hovered(ctx.hovered())
+            .disabled(self.disabled)
+            .style(style);
+        ctx.widget(widget, ctx.area());
+    }
+
+    fn handle_event(
+        &mut self,
+        event: &Event,
+        _state: &S,
+        _ctx: &mut EventCtx<'_>,
+    ) -> EventResult<M> {
+        if !self.can_act() {
+            return EventResult::Ignored;
+        }
+        match event {
+            Event::Mouse(mouse) => match mouse.kind {
+                MouseKind::Click(MouseButton::Left) => self.step(false),
+                _ => EventResult::Ignored,
+            },
+            Event::Key(key) => self.handle_key(*key),
+            _ => EventResult::Ignored,
+        }
+    }
+
+    fn scope_options(&self) -> ScopeOptions {
+        ScopeOptions::default().focusable(self.can_act())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::runtime::{ChildId, FocusState, Modifiers, Ratcn};
+    use crate::test_support::{Driver, key, key_with, mouse};
+
+    #[derive(Default)]
+    struct State {
+        focus: FocusState,
+        size: usize,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    enum Msg {
+        Focus(FocusState),
+        Size(usize),
+    }
+
+    const SIZES: [&str; 3] = ["Small", "Medium", "Large"];
+
+    fn driver() -> Driver<State, Msg> {
+        Driver::with(
+            Ratcn::new().focus(|state: &State| &state.focus, Msg::Focus),
+            30,
+            6,
+        )
+    }
+
+    fn render(driver: &mut Driver<State, Msg>, state: &State) {
+        driver.render(state, |ctx| {
+            ctx.component(
+                ChildId::Static("size"),
+                Cycle::new(SIZES).selection(|state: &State| state.size, Msg::Size),
+                Rect::new(2, 2, 10, 1),
+            );
+        });
+    }
+
+    /// Cycling wraps: the control is a ring, so advancing past the last option
+    /// lands on the first rather than stopping. Each event runs through the
+    /// app's update and a fresh declaration, exactly as a frame would.
+    #[test]
+    fn space_enter_and_right_advance_wrapping() {
+        let mut driver = driver();
+        let mut state = State {
+            size: 2,
+            ..State::default()
+        };
+        render(&mut driver, &state);
+        let EventResult::Emit(msg) = driver.event(key(KeyCode::Char(' ')), &state) else {
+            panic!("Space must cycle");
+        };
+        state.size = match msg {
+            Msg::Size(size) => size,
+            Msg::Focus(_) => panic!("unexpected focus message"),
+        };
+        render(&mut driver, &state);
+
+        assert_eq!(
+            driver.event(key(KeyCode::Enter), &state),
+            EventResult::Emit(Msg::Size(1))
+        );
+    }
+
+    #[test]
+    fn left_h_and_ctrl_p_walk_backward_wrapping() {
+        let mut driver = driver();
+        let mut state = State::default();
+        render(&mut driver, &state);
+
+        assert_eq!(
+            driver.event(key(KeyCode::Left), &state),
+            EventResult::Emit(Msg::Size(2))
+        );
+        state.size = 2;
+        render(&mut driver, &state);
+        assert_eq!(
+            driver.event(key(KeyCode::Char('h')), &state),
+            EventResult::Emit(Msg::Size(1))
+        );
+        state.size = 1;
+        render(&mut driver, &state);
+        assert_eq!(
+            driver.event(
+                key_with(
+                    KeyCode::Char('p'),
+                    Modifiers {
+                        ctrl: true,
+                        ..Modifiers::NONE
+                    }
+                ),
+                &state
+            ),
+            EventResult::Emit(Msg::Size(0))
+        );
+    }
+
+    /// Shift belongs to the app: Shift+Space is not this control's key.
+    #[test]
+    fn modified_commit_keys_pass_through() {
+        let mut driver = driver();
+        let state = State::default();
+        render(&mut driver, &state);
+
+        assert!(matches!(
+            driver.event(
+                key_with(
+                    KeyCode::Char(' '),
+                    Modifiers {
+                        shift: true,
+                        ..Modifiers::NONE
+                    }
+                ),
+                &state
+            ),
+            EventResult::Ignored
+        ));
+    }
+
+    #[test]
+    fn a_click_advances_to_the_next_option() {
+        let mut driver = driver();
+        let state = State::default();
+        render(&mut driver, &state);
+
+        assert_eq!(
+            driver.event(mouse(MouseKind::Click(MouseButton::Left), 5, 2), &state),
+            EventResult::Emit(Msg::Size(1))
+        );
+    }
+
+    /// The ghost styling is the contract: bare text at rest, a fill when
+    /// focused. Pinned on the widget, where focus is a plain argument.
+    #[test]
+    fn focus_lays_a_background_over_the_value_and_rest_does_not() {
+        let area = Rect::new(0, 0, 12, 1);
+
+        let mut rest = Buffer::empty(area);
+        CycleWidget::new(&SIZES, 1).render(area, &mut rest);
+        assert_eq!(
+            rest.cell((3, 0)).expect("cell").bg,
+            Color::Reset,
+            "rest painted a background"
+        );
+
+        let mut focused = Buffer::empty(area);
+        CycleWidget::new(&SIZES, 1)
+            .focused(true)
+            .render(area, &mut focused);
+        assert_ne!(
+            focused.cell((3, 0)).expect("cell").bg,
+            Color::Reset,
+            "a focused cycle must be findable by its fill"
+        );
+    }
+
+    #[test]
+    fn an_unbound_cycle_is_not_focusable_and_answers_nothing() {
+        let mut driver = driver();
+        let state = State::default();
+        driver.render(&state, |ctx| {
+            ctx.component(
+                ChildId::Static("size"),
+                Cycle::new(SIZES),
+                Rect::new(2, 2, 10, 1),
+            );
+        });
+
+        assert!(matches!(
+            driver.event(key(KeyCode::Tab), &state),
+            EventResult::Ignored
+        ));
+        assert!(matches!(
+            driver.event(key(KeyCode::Char(' ')), &state),
+            EventResult::Ignored
+        ));
+    }
+
+    /// A stored index that outlived its options list clamps instead of
+    /// panicking or painting nothing.
+    #[test]
+    fn an_out_of_range_selection_clamps_to_the_last_option() {
+        let area = Rect::new(0, 0, 12, 1);
+        let mut buffer = Buffer::empty(area);
+        CycleWidget::new(&SIZES, 9).render(area, &mut buffer);
+
+        let row: String = (0..12u16)
+            .map(|column| buffer.cell((column, 0)).expect("cell").symbol())
+            .collect();
+        assert!(row.contains("Large"), "{row:?}");
+    }
+}

--- a/crates/ratcn/src/components/list.rs
+++ b/crates/ratcn/src/components/list.rs
@@ -514,6 +514,9 @@ pub struct List<T, S, M> {
     paint_item: Option<PaintItemFn<S, T>>,
     style: Option<StyleFn>,
     focus_symbol: String,
+    /// The markers selection rows show, overriding the radio/checkbox defaults.
+    selected_marker: Option<String>,
+    unselected_marker: Option<String>,
     /// Row height plus the painted offset — render-derived runtime state kept
     /// so hit-testing and wheel arithmetic work against what is on screen,
     /// never a second copy of app-owned scroll.
@@ -555,6 +558,8 @@ impl<T, S, M> List<T, S, M> {
             paint_item: None,
             style: None,
             focus_symbol: String::new(),
+            selected_marker: None,
+            unselected_marker: None,
             viewport: RowViewport::new(1),
         }
     }
@@ -723,6 +728,27 @@ impl<T, S, M> List<T, S, M> {
         self
     }
 
+    /// The marker shown on a selected row, instead of the shape selection
+    /// picks: `●` for a pick-one list, `■` for a multi-select.
+    ///
+    /// Any string works, including multi-character pairs like `[x]`; the row
+    /// indents the label by the marker's width plus one space. Pair it with
+    /// [`unselected_marker`](Self::unselected_marker) so both states read as
+    /// one style of control — `[x]`/`[ ]` turns a multi-select into an ASCII
+    /// checklist.
+    #[must_use]
+    pub fn selected_marker(mut self, marker: impl Into<String>) -> Self {
+        self.selected_marker = Some(marker.into());
+        self
+    }
+
+    /// The marker shown on an unselected row, instead of `○` or `□`.
+    #[must_use]
+    pub fn unselected_marker(mut self, marker: impl Into<String>) -> Self {
+        self.unselected_marker = Some(marker.into());
+        self
+    }
+
     /// Replace the theme-derived [`ListStyle`].
     ///
     /// The closure receives the active theme each render, so a style built from
@@ -884,6 +910,23 @@ impl<T: Clone + PartialEq + 'static, S, M> Component<S, M> for List<T, S, M> {
         } else {
             None
         };
+        // The pair selection rows show: the shape selection picks, with any
+        // marker overrides the app supplied taking each half.
+        let default_glyphs = if selection_mode == Some(true) {
+            selection_indicator::MarkerGlyphs::checkbox()
+        } else {
+            selection_indicator::MarkerGlyphs::radio()
+        };
+        let glyphs = selection_indicator::MarkerGlyphs {
+            selected: self
+                .selected_marker
+                .as_deref()
+                .unwrap_or(default_glyphs.selected),
+            unselected: self
+                .unselected_marker
+                .as_deref()
+                .unwrap_or(default_glyphs.unselected),
+        };
         let rows_per_item = self.viewport.rows_per_item();
         // Only the rows on screen are built, however long the list is. The
         // count rounds up because the area's trailing rows still paint the item
@@ -913,7 +956,7 @@ impl<T: Clone + PartialEq + 'static, S, M> Component<S, M> for List<T, S, M> {
                 }
                 match &self.paint_item {
                     Some(paint_item) => paint_item(state, row),
-                    None => default_item_line(&row, selection_mode, &style),
+                    None => default_item_line(&row, selection_mode.is_some(), glyphs, &style),
                 }
             },
         );
@@ -979,22 +1022,23 @@ impl<T: Clone + PartialEq + 'static, S, M> Component<S, M> for List<T, S, M> {
 
 fn default_item_line<T>(
     row: &ListItemState<'_, T>,
-    selection_mode: Option<bool>,
+    has_markers: bool,
+    glyphs: selection_indicator::MarkerGlyphs<'_>,
     style: &ListStyle,
 ) -> Text<'static> {
-    let Some(multiple) = selection_mode else {
+    if !has_markers {
         return Text::from(row.label.to_string());
-    };
+    }
     Text::from(selection_indicator::marker_line(
         row.label,
         row.selected,
-        multiple,
         row.disabled,
         selection_indicator::MarkerColors {
             disabled: style.disabled_foreground,
             selected: style.selected_marker,
             unselected: style.unselected_marker,
         },
+        glyphs,
     ))
 }
 

--- a/crates/ratcn/src/components/list.rs
+++ b/crates/ratcn/src/components/list.rs
@@ -911,22 +911,22 @@ impl<T: Clone + PartialEq + 'static, S, M> Component<S, M> for List<T, S, M> {
             None
         };
         // The pair selection rows show: the shape selection picks, with any
-        // marker overrides the app supplied taking each half.
-        let default_glyphs = if selection_mode == Some(true) {
-            selection_indicator::MarkerGlyphs::checkbox()
-        } else {
-            selection_indicator::MarkerGlyphs::radio()
-        };
-        let glyphs = selection_indicator::MarkerGlyphs {
-            selected: self
-                .selected_marker
-                .as_deref()
-                .unwrap_or(default_glyphs.selected),
-            unselected: self
-                .unselected_marker
-                .as_deref()
-                .unwrap_or(default_glyphs.unselected),
-        };
+        // marker overrides the app supplied taking each half. No selection, no
+        // markers.
+        let glyphs = selection_mode.map(|multiple| {
+            let defaults = if multiple {
+                selection_indicator::MarkerGlyphs::checkbox()
+            } else {
+                selection_indicator::MarkerGlyphs::radio()
+            };
+            selection_indicator::MarkerGlyphs {
+                selected: self.selected_marker.as_deref().unwrap_or(defaults.selected),
+                unselected: self
+                    .unselected_marker
+                    .as_deref()
+                    .unwrap_or(defaults.unselected),
+            }
+        });
         let rows_per_item = self.viewport.rows_per_item();
         // Only the rows on screen are built, however long the list is. The
         // count rounds up because the area's trailing rows still paint the item
@@ -956,7 +956,7 @@ impl<T: Clone + PartialEq + 'static, S, M> Component<S, M> for List<T, S, M> {
                 }
                 match &self.paint_item {
                     Some(paint_item) => paint_item(state, row),
-                    None => default_item_line(&row, selection_mode.is_some(), glyphs, &style),
+                    None => default_item_line(&row, glyphs, &style),
                 }
             },
         );
@@ -1022,13 +1022,12 @@ impl<T: Clone + PartialEq + 'static, S, M> Component<S, M> for List<T, S, M> {
 
 fn default_item_line<T>(
     row: &ListItemState<'_, T>,
-    has_markers: bool,
-    glyphs: selection_indicator::MarkerGlyphs<'_>,
+    glyphs: Option<selection_indicator::MarkerGlyphs<'_>>,
     style: &ListStyle,
 ) -> Text<'static> {
-    if !has_markers {
+    let Some(glyphs) = glyphs else {
         return Text::from(row.label.to_string());
-    }
+    };
     Text::from(selection_indicator::marker_line(
         row.label,
         row.selected,

--- a/crates/ratcn/src/components/mod.rs
+++ b/crates/ratcn/src/components/mod.rs
@@ -13,6 +13,8 @@
 // shape their `handle_event` implementations share.
 pub(crate) mod barchart;
 pub(crate) mod button;
+pub(crate) mod checkbox;
+pub(crate) mod cycle;
 pub(crate) mod dialog;
 pub(crate) mod list;
 pub(crate) mod scroll_area;

--- a/crates/ratcn/src/components/select.rs
+++ b/crates/ratcn/src/components/select.rs
@@ -226,6 +226,11 @@ pub struct SelectWidget<'a> {
     focused: bool,
     hovered: bool,
     disabled: bool,
+    /// The marker shown on a selected option, when the panel paints its own
+    /// rows.
+    selected_marker: &'a str,
+    /// The marker shown on an unselected option.
+    unselected_marker: &'a str,
     style: SelectStyle,
 }
 
@@ -247,8 +252,27 @@ impl<'a> SelectWidget<'a> {
             focused: false,
             hovered: false,
             disabled: false,
+            selected_marker: selection_indicator::MarkerGlyphs::radio().selected,
+            unselected_marker: selection_indicator::MarkerGlyphs::radio().unselected,
             style: SelectStyle::fallback(),
         }
+    }
+
+    /// The marker shown on a selected option.
+    ///
+    /// Any string works, including multi-character pairs like `[x]`; the row
+    /// indents the label by the marker's width plus one space.
+    #[must_use]
+    pub const fn selected_marker(mut self, marker: &'a str) -> Self {
+        self.selected_marker = marker;
+        self
+    }
+
+    /// The marker shown on an unselected option.
+    #[must_use]
+    pub const fn unselected_marker(mut self, marker: &'a str) -> Self {
+        self.unselected_marker = marker;
+        self
     }
 
     /// Take colors from `theme`.
@@ -491,12 +515,15 @@ impl Widget for SelectPanelWidget<'_> {
             selection_indicator::marker_line(
                 widget.options[index],
                 selected,
-                false,
                 disabled,
                 selection_indicator::MarkerColors {
                     disabled: widget.style.disabled_foreground,
                     selected: widget.style.selected_marker,
                     unselected: widget.style.unselected_marker,
+                },
+                selection_indicator::MarkerGlyphs {
+                    selected: widget.selected_marker,
+                    unselected: widget.unselected_marker,
                 },
             )
             .render(row_area, buf);
@@ -598,6 +625,9 @@ pub struct Select<T, S, M> {
     disabled: bool,
     paint_item: Option<PaintItemFn<S, T>>,
     row_height: u16,
+    /// The markers the option rows show, overriding the radio defaults.
+    selected_marker: Option<String>,
+    unselected_marker: Option<String>,
     style: Option<StyleFn>,
     resolved_open: bool,
     page_size: usize,
@@ -634,6 +664,8 @@ impl<T, S, M> Select<T, S, M> {
             disabled: false,
             paint_item: None,
             row_height: 1,
+            selected_marker: None,
+            unselected_marker: None,
             style: None,
             resolved_open: false,
             page_size: 1,
@@ -766,6 +798,23 @@ impl<T, S, M> Select<T, S, M> {
     #[must_use]
     pub fn style(mut self, style: impl Fn(&Theme) -> SelectStyle + 'static) -> Self {
         self.style = Some(Rc::new(style));
+        self
+    }
+
+    /// The marker shown on the selected option, instead of `●`.
+    ///
+    /// Any string works, including multi-character pairs like `[x]`; the row
+    /// indents the label by the marker's width plus one space.
+    #[must_use]
+    pub fn selected_marker(mut self, marker: impl Into<String>) -> Self {
+        self.selected_marker = Some(marker.into());
+        self
+    }
+
+    /// The marker shown on an unselected option, instead of `○`.
+    #[must_use]
+    pub fn unselected_marker(mut self, marker: impl Into<String>) -> Self {
+        self.unselected_marker = Some(marker.into());
         self
     }
 
@@ -957,6 +1006,8 @@ impl<T: Clone + PartialEq + 'static, S: 'static, M: 'static> Component<S, M> for
             selected: self.selected.clone(),
             on_select: self.on_select.clone(),
             paint_item: self.paint_item.clone(),
+            selected_marker: self.selected_marker.clone(),
+            unselected_marker: self.unselected_marker.clone(),
             style,
             panel_area,
             inner,
@@ -1024,6 +1075,8 @@ struct SelectPanel<T, S, M> {
     selected: Option<ReadFn<S, T>>,
     on_select: Option<OnChangeFn<T, M>>,
     paint_item: Option<PaintItemFn<S, T>>,
+    selected_marker: Option<String>,
+    unselected_marker: Option<String>,
     style: SelectStyle,
     panel_area: Rect,
     /// `panel_area` inside its border: the rows the options themselves occupy.
@@ -1101,6 +1154,12 @@ impl<T: Clone + PartialEq + 'static, S, M> Component<S, M> for SelectPanel<T, S,
             .disabled_items(&disabled)
             .first_item(self.viewport.painted_offset())
             .style(self.style);
+        if let Some(marker) = self.selected_marker.as_deref() {
+            widget = widget.selected_marker(marker);
+        }
+        if let Some(marker) = self.unselected_marker.as_deref() {
+            widget = widget.unselected_marker(marker);
+        }
         if let Some(rows) = &rows {
             widget = widget.visible_item_rows(rows);
         }

--- a/crates/ratcn/src/components/select.rs
+++ b/crates/ratcn/src/components/select.rs
@@ -238,6 +238,7 @@ impl<'a> SelectWidget<'a> {
     /// Construct a closed select showing `value`, or an empty placeholder.
     #[must_use]
     pub const fn new(value: Option<&'a str>) -> Self {
+        let radio = selection_indicator::MarkerGlyphs::radio();
         Self {
             value,
             placeholder: "",
@@ -252,8 +253,8 @@ impl<'a> SelectWidget<'a> {
             focused: false,
             hovered: false,
             disabled: false,
-            selected_marker: selection_indicator::MarkerGlyphs::radio().selected,
-            unselected_marker: selection_indicator::MarkerGlyphs::radio().unselected,
+            selected_marker: radio.selected,
+            unselected_marker: radio.unselected,
             style: SelectStyle::fallback(),
         }
     }

--- a/crates/ratcn/src/lib.rs
+++ b/crates/ratcn/src/lib.rs
@@ -155,6 +155,8 @@ pub mod toast;
 pub use components::{
     barchart::{BarChartGroup, BarChartStyle, BarChartWidget},
     button::{Button, ButtonSize, ButtonStyle, ButtonVariant, ButtonWidget},
+    checkbox::{Checkbox, CheckboxStyle, CheckboxWidget},
+    cycle::{Cycle, CycleStyle, CycleWidget},
     dialog::{Dialog, DialogStyle},
     list::{List, ListStyle, ListWidget},
     scroll_area::{ScrollArea, ScrollAreaStyle},

--- a/crates/ratcn/src/linear_nav.rs
+++ b/crates/ratcn/src/linear_nav.rs
@@ -170,6 +170,23 @@ fn nav_move(key: KeyEvent, axis: Axis) -> Option<NavMove> {
     }
 }
 
+/// The single step a key asks for along `axis` — an arrow, its `vi` letter,
+/// or Ctrl+N/Ctrl+P — or `None` for every other key, including the edge and
+/// page keys.
+///
+/// This is the step subset of the one navigation key map, for controls that
+/// move one item at a time and answer nothing else: a wrapping ring has no
+/// ends for Home and End to reach, so it matches on this rather than on
+/// [`nav_key_target`]. Ask it before any modifier gate — it owns the Ctrl
+/// chords.
+#[must_use]
+pub fn step_key(key: KeyEvent, axis: Axis) -> Option<Step> {
+    match nav_move(key, axis) {
+        Some(NavMove::Step(step)) => Some(step),
+        _ => None,
+    }
+}
+
 /// Does this key step a cursor by exactly one item along `axis` — an arrow,
 /// its `vi` letter, or Ctrl+N/Ctrl+P?
 ///
@@ -177,7 +194,7 @@ fn nav_move(key: KeyEvent, axis: Axis) -> Option<NavMove> {
 /// would move a cursor should first reveal the cursor.
 #[must_use]
 pub fn is_step_key(key: KeyEvent, axis: Axis) -> bool {
-    matches!(nav_move(key, axis), Some(NavMove::Step(_)))
+    step_key(key, axis).is_some()
 }
 
 /// Resolve one navigation key against a cursor over `len` items along `axis`,

--- a/crates/ratcn/src/selection_indicator.rs
+++ b/crates/ratcn/src/selection_indicator.rs
@@ -36,7 +36,7 @@ pub struct MarkerGlyphs<'a> {
     pub unselected: &'a str,
 }
 
-impl MarkerGlyphs<'_> {
+impl<'a> MarkerGlyphs<'a> {
     /// The circles a pick-one control paints by default.
     #[must_use]
     pub const fn radio() -> Self {
@@ -54,15 +54,15 @@ impl MarkerGlyphs<'_> {
             unselected: "□",
         }
     }
-}
 
-/// Marker glyph for a selected or unselected item.
-#[must_use]
-pub const fn marker(selected: bool, glyphs: MarkerGlyphs<'_>) -> &str {
-    if selected {
-        glyphs.selected
-    } else {
-        glyphs.unselected
+    /// The half of the pair one item shows.
+    #[must_use]
+    pub const fn marker(self, selected: bool) -> &'a str {
+        if selected {
+            self.selected
+        } else {
+            self.unselected
+        }
     }
 }
 
@@ -78,7 +78,7 @@ pub const fn color(disabled: bool, selected: bool, colors: MarkerColors) -> Colo
     }
 }
 
-/// The default row of a selection control: a leading space, the [`marker`], a
+/// The default row of a selection control: a leading space, the marker, a
 /// space, then `label`.
 ///
 /// One line, built here rather than in each control, so a list row and a select
@@ -98,7 +98,7 @@ pub fn marker_line(
     colors: MarkerColors,
     glyphs: MarkerGlyphs<'_>,
 ) -> Line<'static> {
-    let marker = marker(selected, glyphs);
+    let marker = glyphs.marker(selected);
     Line::from(vec![
         Span::styled(
             format!(" {marker}"),

--- a/crates/ratcn/src/selection_indicator.rs
+++ b/crates/ratcn/src/selection_indicator.rs
@@ -22,14 +22,47 @@ pub struct MarkerColors {
     pub unselected: Color,
 }
 
+/// The glyph pair one selection control paints: what a selected item shows and
+/// what an unselected one does.
+///
+/// The presets name the two shapes a selection takes — a lone circle for
+/// picking one of many, a box for ticking any number — and any other pair can
+/// be supplied where a control offers its markers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MarkerGlyphs<'a> {
+    /// The marker on a selected item.
+    pub selected: &'a str,
+    /// The marker on an unselected item.
+    pub unselected: &'a str,
+}
+
+impl MarkerGlyphs<'_> {
+    /// The circles a pick-one control paints by default.
+    #[must_use]
+    pub const fn radio() -> Self {
+        Self {
+            selected: "●",
+            unselected: "○",
+        }
+    }
+
+    /// The boxes a tick-any-number control paints by default.
+    #[must_use]
+    pub const fn checkbox() -> Self {
+        Self {
+            selected: "■",
+            unselected: "□",
+        }
+    }
+}
+
 /// Marker glyph for a selected or unselected item.
 #[must_use]
-pub const fn marker(selected: bool, multiple: bool) -> &'static str {
-    match (multiple, selected) {
-        (true, true) => "■",
-        (true, false) => "□",
-        (false, true) => "●",
-        (false, false) => "○",
+pub const fn marker(selected: bool, glyphs: MarkerGlyphs<'_>) -> &str {
+    if selected {
+        glyphs.selected
+    } else {
+        glyphs.unselected
     }
 }
 
@@ -54,17 +87,18 @@ pub const fn color(disabled: bool, selected: bool, colors: MarkerColors) -> Colo
 /// label carries no color of its own, leaving it to inherit whatever row style
 /// is painted beneath it.
 ///
-/// `multiple` picks the checkbox glyphs over the radio ones, as it does in
-/// [`marker`].
+/// `glyphs` picks the pair: [`MarkerGlyphs::radio`] where one option wins,
+/// [`MarkerGlyphs::checkbox`] where any number can be ticked, or whatever the
+/// app supplies.
 #[must_use]
 pub fn marker_line(
     label: &str,
     selected: bool,
-    multiple: bool,
     disabled: bool,
     colors: MarkerColors,
+    glyphs: MarkerGlyphs<'_>,
 ) -> Line<'static> {
-    let marker = marker(selected, multiple);
+    let marker = marker(selected, glyphs);
     Line::from(vec![
         Span::styled(
             format!(" {marker}"),
@@ -88,7 +122,7 @@ mod tests {
             selected: Color::Green,
             unselected: Color::Blue,
         };
-        let line = marker_line("Alpha", true, false, false, colors);
+        let line = marker_line("Alpha", true, false, colors, MarkerGlyphs::radio());
 
         assert_eq!(line.to_string(), " ● Alpha");
         assert_eq!(line.spans[0].style.fg, Some(Color::Green));
@@ -98,15 +132,34 @@ mod tests {
             "the label inherits the row style painted beneath it"
         );
         assert_eq!(
-            marker_line("Alpha", true, true, true, colors).spans[0]
+            marker_line("Alpha", true, true, colors, MarkerGlyphs::checkbox()).spans[0]
                 .style
                 .fg,
             Some(Color::DarkGray),
-            "disabled wins over selected, and multiple picks the checkbox glyph"
+            "disabled wins over selected"
         );
         assert_eq!(
-            marker_line("Alpha", true, true, false, colors).to_string(),
+            marker_line("Alpha", true, false, colors, MarkerGlyphs::checkbox()).to_string(),
             " ■ Alpha"
+        );
+    }
+
+    /// A control's markers are the app's to choose: the same call paints any
+    /// pair it is handed.
+    #[test]
+    fn the_glyph_pair_is_yours_to_choose() {
+        let glyphs = MarkerGlyphs {
+            selected: "[x]",
+            unselected: "[ ]",
+        };
+        let colors = MarkerColors {
+            disabled: Color::DarkGray,
+            selected: Color::Green,
+            unselected: Color::Gray,
+        };
+        assert_eq!(
+            marker_line("Vim bindings", true, false, colors, glyphs).to_string(),
+            " [x] Vim bindings"
         );
     }
 }

--- a/demos/checkbox/Cargo.toml
+++ b/demos/checkbox/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "checkbox"
+publish = false
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+[dependencies]
+demo-shared.workspace = true
+ratatui.workspace = true
+ratcn.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+ratcn = { workspace = true, features = ["ratzilla"] }
+ratzilla.workspace = true

--- a/demos/checkbox/Trunk.toml
+++ b/demos/checkbox/Trunk.toml
@@ -1,0 +1,4 @@
+[build]
+target = "index.html"
+dist = "../../docs/public/demos/checkbox-demo"
+public_url = "./"

--- a/demos/checkbox/index.html
+++ b/demos/checkbox/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Iframed into the docs site; the page itself has no content to rank. -->
+    <meta name="robots" content="noindex" />
+    <script type="module" src="./demo-errors.js"></script>
+    <script type="module" src="./ratatui-keyboard-capture.js"></script>
+    <link
+      data-trunk
+      rel="rust"
+      data-wasm-opt-params="--enable-bulk-memory --enable-bulk-memory-opt --enable-sign-ext --enable-nontrapping-float-to-int"
+    />
+    <link data-trunk rel="copy-file" href="../shared/demo-errors.js" />
+    <link data-trunk rel="copy-file" href="../shared/ratatui-keyboard-capture.js" />
+    <link data-trunk rel="copy-file" href="../shared/fonts/JetBrainsMonoNerdFontMono-Regular.ttf" />
+    <link data-trunk rel="copy-file" href="../shared/fonts/OFL.txt" />
+    <link data-trunk rel="css" href="../shared/demo.css" />
+    <title>ratcn checkbox demo</title>
+  </head>
+  <body tabindex="0"></body>
+</html>

--- a/demos/checkbox/src/main.rs
+++ b/demos/checkbox/src/main.rs
@@ -25,6 +25,17 @@ const DEMO_WIDTH: u16 = 26;
 const DEMO_HEIGHT: u16 = 7;
 const CONTENT_PADDING: Margin = Margin::new(2, 1);
 
+/// The three skins: id, checked marker, unchecked marker, label.
+const ROWS: [(&str, &str, &str, &str); 3] = [
+    ("default", "☑", "☐", "Vim bindings"),
+    ("ascii", "[x]", "[ ]", "ASCII checklist"),
+    ("switch", "[ON]", "[off]", "Terminal bell"),
+];
+
+fn columns(marker: &str, label: &str) -> u16 {
+    ratcn::text_width::display_width_u16(marker) + 1 + ratcn::text_width::display_width_u16(label)
+}
+
 #[derive(Default)]
 struct AppState {
     focus: FocusState,
@@ -97,27 +108,30 @@ impl demo_shared::Demo for App {
                 });
             });
 
-            // One row per checkbox, each exactly as wide as its content.
+            // One row per checkbox, each exactly as wide as its content —
+            // measured from the same strings the checkbox paints.
             let inner = demo.inner(CONTENT_PADDING);
             let [row_a, row_b, row_c] = Layout::vertical([Constraint::Length(1); 3])
                 .spacing(1)
                 .areas(inner);
-            let rows = [
-                ("vim", Rect { width: 17, ..row_a }),
-                ("mouse", Rect { width: 22, ..row_b }),
-                ("bell", Rect { width: 21, ..row_c }),
-            ];
+            let areas = [row_a, row_b, row_c];
 
-            for (id, row_area) in rows {
+            for ((id, checked_marker, unchecked_marker, label), row_area) in
+                ROWS.into_iter().zip(areas)
+            {
+                let row_area = Rect {
+                    width: columns(checked_marker, label),
+                    ..row_area
+                };
                 let checkbox = match id {
-                    "vim" => Checkbox::new("Vim bindings").checked(|s: &AppState| s.vim, Msg::Vim),
-                    "mouse" => Checkbox::new("ASCII checklist")
-                        .checked_marker("[x]")
-                        .unchecked_marker("[ ]")
+                    "default" => Checkbox::new(label).checked(|s: &AppState| s.vim, Msg::Vim),
+                    "ascii" => Checkbox::new(label)
+                        .checked_marker(checked_marker)
+                        .unchecked_marker(unchecked_marker)
                         .checked(|s: &AppState| s.mouse, Msg::Mouse),
-                    _ => Checkbox::new("Terminal bell")
-                        .checked_marker("[ON]")
-                        .unchecked_marker("[off]")
+                    _ => Checkbox::new(label)
+                        .checked_marker(checked_marker)
+                        .unchecked_marker(unchecked_marker)
                         .checked(|s: &AppState| s.bell, Msg::Bell),
                 };
                 ctx.component(id, checkbox, row_area);

--- a/demos/checkbox/src/main.rs
+++ b/demos/checkbox/src/main.rs
@@ -1,6 +1,6 @@
 //! One checkbox, three skins.
 //!
-//! The default ballot-box pair, an ASCII checklist pair, and a switch that
+//! The default boxes, an ASCII checklist pair, and a switch that
 //! wears its state as words. All three are the same [`Checkbox`] component —
 //! the markers are the only thing that differs, which is also how a checkbox
 //! becomes a toggle: give the two states labels instead of glyphs.
@@ -27,7 +27,7 @@ const CONTENT_PADDING: Margin = Margin::new(2, 1);
 
 /// The three skins: id, checked marker, unchecked marker, label.
 const ROWS: [(&str, &str, &str, &str); 3] = [
-    ("default", "☑", "☐", "Vim bindings"),
+    ("default", "■", "□", "Vim bindings"),
     ("ascii", "[x]", "[ ]", "ASCII checklist"),
     ("switch", "[ON]", "[off]", "Terminal bell"),
 ];

--- a/demos/checkbox/src/main.rs
+++ b/demos/checkbox/src/main.rs
@@ -25,20 +25,14 @@ const DEMO_WIDTH: u16 = 26;
 const DEMO_HEIGHT: u16 = 7;
 const CONTENT_PADDING: Margin = Margin::new(2, 1);
 
-/// The three skins: id, checked marker, unchecked marker, label.
-const ROWS: [(&str, &str, &str, &str); 3] = [
-    ("default", "■", "□", "Vim bindings"),
-    ("ascii", "[x]", "[ ]", "ASCII checklist"),
-    ("switch", "[ON]", "[off]", "Terminal bell"),
-];
-
-/// The columns one row needs, measured by the widget that paints it — the
-/// same in both states, so `[ON]`/`[off]` never truncates.
-fn columns(checked_marker: &str, unchecked_marker: &str, label: &str) -> u16 {
-    CheckboxWidget::new(label, false)
+/// A row exactly as wide as its checkbox, measured by the widget that paints
+/// it — the same in both states, so `[ON]`/`[off]` never truncates.
+fn sized(row: Rect, checked_marker: &str, unchecked_marker: &str, label: &str) -> Rect {
+    let width = CheckboxWidget::new(label, false)
         .checked_marker(checked_marker)
         .unchecked_marker(unchecked_marker)
-        .width()
+        .width();
+    Rect { width, ..row }
 }
 
 #[derive(Default)]
@@ -118,28 +112,28 @@ impl demo_shared::Demo for App {
             let [row_a, row_b, row_c] = Layout::vertical([Constraint::Length(1); 3])
                 .spacing(1)
                 .areas(inner);
-            let areas = [row_a, row_b, row_c];
 
-            for ((id, checked_marker, unchecked_marker, label), row_area) in
-                ROWS.into_iter().zip(areas)
-            {
-                let row_area = Rect {
-                    width: columns(checked_marker, unchecked_marker, label),
-                    ..row_area
-                };
-                let checkbox = match id {
-                    "default" => Checkbox::new(label).checked(|s: &AppState| s.vim, Msg::Vim),
-                    "ascii" => Checkbox::new(label)
-                        .checked_marker(checked_marker)
-                        .unchecked_marker(unchecked_marker)
-                        .checked(|s: &AppState| s.mouse, Msg::Mouse),
-                    _ => Checkbox::new(label)
-                        .checked_marker(checked_marker)
-                        .unchecked_marker(unchecked_marker)
-                        .checked(|s: &AppState| s.bell, Msg::Bell),
-                };
-                ctx.component(id, checkbox, row_area);
-            }
+            ctx.component(
+                "default",
+                Checkbox::new("Vim bindings").checked(|s: &AppState| s.vim, Msg::Vim),
+                sized(row_a, "■", "□", "Vim bindings"),
+            );
+            ctx.component(
+                "ascii",
+                Checkbox::new("ASCII checklist")
+                    .checked_marker("[x]")
+                    .unchecked_marker("[ ]")
+                    .checked(|s: &AppState| s.mouse, Msg::Mouse),
+                sized(row_b, "[x]", "[ ]", "ASCII checklist"),
+            );
+            ctx.component(
+                "switch",
+                Checkbox::new("Terminal bell")
+                    .checked_marker("[ON]")
+                    .unchecked_marker("[off]")
+                    .checked(|s: &AppState| s.bell, Msg::Bell),
+                sized(row_c, "[ON]", "[off]", "Terminal bell"),
+            );
         });
     }
 }

--- a/demos/checkbox/src/main.rs
+++ b/demos/checkbox/src/main.rs
@@ -17,7 +17,7 @@ use ratatui::{
     style::Style,
 };
 use ratcn::{
-    Checkbox, Theme,
+    Checkbox, CheckboxWidget, Theme,
     runtime::{Event, EventResult, FocusState, Ratcn, TabWrap},
 };
 
@@ -32,8 +32,13 @@ const ROWS: [(&str, &str, &str, &str); 3] = [
     ("switch", "[ON]", "[off]", "Terminal bell"),
 ];
 
-fn columns(marker: &str, label: &str) -> u16 {
-    ratcn::text_width::display_width_u16(marker) + 1 + ratcn::text_width::display_width_u16(label)
+/// The columns one row needs, measured by the widget that paints it — the
+/// same in both states, so `[ON]`/`[off]` never truncates.
+fn columns(checked_marker: &str, unchecked_marker: &str, label: &str) -> u16 {
+    CheckboxWidget::new(label, false)
+        .checked_marker(checked_marker)
+        .unchecked_marker(unchecked_marker)
+        .width()
 }
 
 #[derive(Default)]
@@ -108,8 +113,7 @@ impl demo_shared::Demo for App {
                 });
             });
 
-            // One row per checkbox, each exactly as wide as its content —
-            // measured from the same strings the checkbox paints.
+            // One row per checkbox, each exactly as wide as its content.
             let inner = demo.inner(CONTENT_PADDING);
             let [row_a, row_b, row_c] = Layout::vertical([Constraint::Length(1); 3])
                 .spacing(1)
@@ -120,7 +124,7 @@ impl demo_shared::Demo for App {
                 ROWS.into_iter().zip(areas)
             {
                 let row_area = Rect {
-                    width: columns(checked_marker, label),
+                    width: columns(checked_marker, unchecked_marker, label),
                     ..row_area
                 };
                 let checkbox = match id {

--- a/demos/checkbox/src/main.rs
+++ b/demos/checkbox/src/main.rs
@@ -4,18 +4,26 @@
 //! wears its state as words. All three are the same [`Checkbox`] component —
 //! the markers are the only thing that differs, which is also how a checkbox
 //! becomes a toggle: give the two states labels instead of glyphs.
+//!
+//! Tab moves between them; Enter, Space, or a click anywhere on a row flips
+//! it. Hover and focus raise the row, exactly as they do on every other
+//! control.
 
 use std::io;
 
 use ratatui::{
     Frame,
-    layout::{Constraint, Flex, Layout},
+    layout::{Constraint, Layout, Margin, Rect},
     style::Style,
 };
 use ratcn::{
     Checkbox, Theme,
-    runtime::{Event, EventResult, FocusState, Ratcn},
+    runtime::{Event, EventResult, FocusState, Ratcn, TabWrap},
 };
+
+const DEMO_WIDTH: u16 = 26;
+const DEMO_HEIGHT: u16 = 7;
+const CONTENT_PADDING: Margin = Margin::new(2, 1);
 
 #[derive(Default)]
 struct AppState {
@@ -42,7 +50,9 @@ impl App {
     fn new() -> Self {
         Self {
             state: AppState::default(),
-            ratcn: Ratcn::new().focus(|s: &AppState| &s.focus, Msg::Focus),
+            ratcn: Ratcn::new()
+                .focus(|s: &AppState| &s.focus, Msg::Focus)
+                .tab_wrap(TabWrap::Wrap),
         }
     }
 
@@ -76,36 +86,42 @@ impl demo_shared::Demo for App {
 
         let state = &self.state;
         self.ratcn.render(frame, state, theme, |ctx| {
-            let [row_a, row_b, row_c] = Layout::vertical([
-                Constraint::Length(1),
-                Constraint::Length(1),
-                Constraint::Length(1),
-            ])
-            .flex(Flex::Start)
-            .spacing(1)
-            .areas(area);
+            let demo = area.centered(
+                Constraint::Length(DEMO_WIDTH),
+                Constraint::Length(DEMO_HEIGHT),
+            );
+            ctx.paint(move |ctx| {
+                let surface = ctx.theme.surface;
+                ctx.with_buffer(|buf| {
+                    buf.set_style(demo, Style::default().bg(surface));
+                });
+            });
 
-            ctx.component(
-                "default",
-                Checkbox::new("Vim bindings").checked(|s: &AppState| s.vim, Msg::Vim),
-                row_a,
-            );
-            ctx.component(
-                "ascii",
-                Checkbox::new("ASCII checklist")
-                    .checked_marker("[x]")
-                    .unchecked_marker("[ ]")
-                    .checked(|s: &AppState| s.mouse, Msg::Mouse),
-                row_b,
-            );
-            ctx.component(
-                "switch",
-                Checkbox::new("Terminal bell")
-                    .checked_marker("[ON]")
-                    .unchecked_marker("[off]")
-                    .checked(|s: &AppState| s.bell, Msg::Bell),
-                row_c,
-            );
+            // One row per checkbox, each exactly as wide as its content.
+            let inner = demo.inner(CONTENT_PADDING);
+            let [row_a, row_b, row_c] = Layout::vertical([Constraint::Length(1); 3])
+                .spacing(1)
+                .areas(inner);
+            let rows = [
+                ("vim", Rect { width: 17, ..row_a }),
+                ("mouse", Rect { width: 22, ..row_b }),
+                ("bell", Rect { width: 21, ..row_c }),
+            ];
+
+            for (id, row_area) in rows {
+                let checkbox = match id {
+                    "vim" => Checkbox::new("Vim bindings").checked(|s: &AppState| s.vim, Msg::Vim),
+                    "mouse" => Checkbox::new("ASCII checklist")
+                        .checked_marker("[x]")
+                        .unchecked_marker("[ ]")
+                        .checked(|s: &AppState| s.mouse, Msg::Mouse),
+                    _ => Checkbox::new("Terminal bell")
+                        .checked_marker("[ON]")
+                        .unchecked_marker("[off]")
+                        .checked(|s: &AppState| s.bell, Msg::Bell),
+                };
+                ctx.component(id, checkbox, row_area);
+            }
         });
     }
 }

--- a/demos/checkbox/src/main.rs
+++ b/demos/checkbox/src/main.rs
@@ -17,23 +17,13 @@ use ratatui::{
     style::Style,
 };
 use ratcn::{
-    Checkbox, CheckboxWidget, Theme,
+    Checkbox, Theme,
     runtime::{Event, EventResult, FocusState, Ratcn, TabWrap},
 };
 
 const DEMO_WIDTH: u16 = 26;
 const DEMO_HEIGHT: u16 = 7;
 const CONTENT_PADDING: Margin = Margin::new(2, 1);
-
-/// A row exactly as wide as its checkbox, measured by the widget that paints
-/// it — the same in both states, so `[ON]`/`[off]` never truncates.
-fn sized(row: Rect, checked_marker: &str, unchecked_marker: &str, label: &str) -> Rect {
-    let width = CheckboxWidget::new(label, false)
-        .checked_marker(checked_marker)
-        .unchecked_marker(unchecked_marker)
-        .width();
-    Rect { width, ..row }
-}
 
 #[derive(Default)]
 struct AppState {
@@ -113,27 +103,32 @@ impl demo_shared::Demo for App {
                 .spacing(1)
                 .areas(inner);
 
-            ctx.component(
-                "default",
-                Checkbox::new("Vim bindings").checked(|s: &AppState| s.vim, Msg::Vim),
-                sized(row_a, "■", "□", "Vim bindings"),
-            );
-            ctx.component(
-                "ascii",
-                Checkbox::new("ASCII checklist")
-                    .checked_marker("[x]")
-                    .unchecked_marker("[ ]")
-                    .checked(|s: &AppState| s.mouse, Msg::Mouse),
-                sized(row_b, "[x]", "[ ]", "ASCII checklist"),
-            );
-            ctx.component(
-                "switch",
-                Checkbox::new("Terminal bell")
-                    .checked_marker("[ON]")
-                    .unchecked_marker("[off]")
-                    .checked(|s: &AppState| s.bell, Msg::Bell),
-                sized(row_c, "[ON]", "[off]", "Terminal bell"),
-            );
+            let vim = Checkbox::new("Vim bindings").checked(|s: &AppState| s.vim, Msg::Vim);
+            let row_a = Rect {
+                width: vim.width(),
+                ..row_a
+            };
+            ctx.component("default", vim, row_a);
+
+            let ascii = Checkbox::new("ASCII checklist")
+                .checked_marker("[x]")
+                .unchecked_marker("[ ]")
+                .checked(|s: &AppState| s.mouse, Msg::Mouse);
+            let row_b = Rect {
+                width: ascii.width(),
+                ..row_b
+            };
+            ctx.component("ascii", ascii, row_b);
+
+            let bell = Checkbox::new("Terminal bell")
+                .checked_marker("[ON]")
+                .unchecked_marker("[off]")
+                .checked(|s: &AppState| s.bell, Msg::Bell);
+            let row_c = Rect {
+                width: bell.width(),
+                ..row_c
+            };
+            ctx.component("switch", bell, row_c);
         });
     }
 }

--- a/demos/checkbox/src/main.rs
+++ b/demos/checkbox/src/main.rs
@@ -1,0 +1,115 @@
+//! One checkbox, three skins.
+//!
+//! The default ballot-box pair, an ASCII checklist pair, and a switch that
+//! wears its state as words. All three are the same [`Checkbox`] component —
+//! the markers are the only thing that differs, which is also how a checkbox
+//! becomes a toggle: give the two states labels instead of glyphs.
+
+use std::io;
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Flex, Layout},
+    style::Style,
+};
+use ratcn::{
+    Checkbox, Theme,
+    runtime::{Event, EventResult, FocusState, Ratcn},
+};
+
+#[derive(Default)]
+struct AppState {
+    focus: FocusState,
+    vim: bool,
+    mouse: bool,
+    bell: bool,
+}
+
+#[derive(Clone)]
+enum Msg {
+    Focus(FocusState),
+    Vim(bool),
+    Mouse(bool),
+    Bell(bool),
+}
+
+struct App {
+    state: AppState,
+    ratcn: Ratcn<AppState, Msg>,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            state: AppState::default(),
+            ratcn: Ratcn::new().focus(|s: &AppState| &s.focus, Msg::Focus),
+        }
+    }
+
+    fn update(&mut self, msg: Msg) {
+        match msg {
+            Msg::Focus(focus) => self.state.focus = focus,
+            Msg::Vim(checked) => self.state.vim = checked,
+            Msg::Mouse(checked) => self.state.mouse = checked,
+            Msg::Bell(checked) => self.state.bell = checked,
+        }
+    }
+}
+
+impl demo_shared::Demo for App {
+    fn handle_event(&mut self, event: Event) -> bool {
+        match self.ratcn.handle_event(event, &self.state) {
+            EventResult::Emit(msg) => {
+                self.update(msg);
+                true
+            }
+            EventResult::Consumed => true,
+            EventResult::Ignored => false,
+        }
+    }
+
+    fn draw(&mut self, frame: &mut Frame, theme: &Theme) {
+        let area = frame.area();
+        frame
+            .buffer_mut()
+            .set_style(area, Style::default().bg(theme.background));
+
+        let state = &self.state;
+        self.ratcn.render(frame, state, theme, |ctx| {
+            let [row_a, row_b, row_c] = Layout::vertical([
+                Constraint::Length(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+            ])
+            .flex(Flex::Start)
+            .spacing(1)
+            .areas(area);
+
+            ctx.component(
+                "default",
+                Checkbox::new("Vim bindings").checked(|s: &AppState| s.vim, Msg::Vim),
+                row_a,
+            );
+            ctx.component(
+                "ascii",
+                Checkbox::new("ASCII checklist")
+                    .checked_marker("[x]")
+                    .unchecked_marker("[ ]")
+                    .checked(|s: &AppState| s.mouse, Msg::Mouse),
+                row_b,
+            );
+            ctx.component(
+                "switch",
+                Checkbox::new("Terminal bell")
+                    .checked_marker("[ON]")
+                    .unchecked_marker("[off]")
+                    .checked(|s: &AppState| s.bell, Msg::Bell),
+                row_c,
+            );
+        });
+    }
+}
+
+fn main() -> io::Result<()> {
+    demo_shared::run(App::new())
+}

--- a/demos/cycle/Cargo.toml
+++ b/demos/cycle/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "cycle"
+publish = false
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+[dependencies]
+demo-shared.workspace = true
+ratatui.workspace = true
+ratcn.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+ratcn = { workspace = true, features = ["ratzilla"] }
+ratzilla.workspace = true

--- a/demos/cycle/Trunk.toml
+++ b/demos/cycle/Trunk.toml
@@ -1,0 +1,4 @@
+[build]
+target = "index.html"
+dist = "../../docs/public/demos/cycle-demo"
+public_url = "./"

--- a/demos/cycle/index.html
+++ b/demos/cycle/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Iframed into the docs site; the page itself has no content to rank. -->
+    <meta name="robots" content="noindex" />
+    <script type="module" src="./demo-errors.js"></script>
+    <script type="module" src="./ratatui-keyboard-capture.js"></script>
+    <link
+      data-trunk
+      rel="rust"
+      data-wasm-opt-params="--enable-bulk-memory --enable-bulk-memory-opt --enable-sign-ext --enable-nontrapping-float-to-int"
+    />
+    <link data-trunk rel="copy-file" href="../shared/demo-errors.js" />
+    <link data-trunk rel="copy-file" href="../shared/ratatui-keyboard-capture.js" />
+    <link data-trunk rel="copy-file" href="../shared/fonts/JetBrainsMonoNerdFontMono-Regular.ttf" />
+    <link data-trunk rel="copy-file" href="../shared/fonts/OFL.txt" />
+    <link data-trunk rel="css" href="../shared/demo.css" />
+    <title>ratcn cycle demo</title>
+  </head>
+  <body tabindex="0"></body>
+</html>

--- a/demos/cycle/src/main.rs
+++ b/demos/cycle/src/main.rs
@@ -1,9 +1,9 @@
 //! Settings rows: the setting's name on the left, a [`Cycle`] on the right.
 //!
-//! The pattern most settings screens want — each row reads "name: value",
+//! The pattern most settings screens want — each row reads "name value",
 //! and the value cycles in place through its options. A Cycle is exactly as
-//! wide as the value it currently shows, so each row hugs its text; here they
-//! are right-aligned against the panel's edge.
+//! wide as the value it currently shows; `.align(Alignment::Right)` hugs it
+//! against the panel's edge, so a row is one declaration, unmeasured.
 //!
 //! Tab moves between rows. Enter, Space, an arrow, or a click advances the
 //! focused one, wrapping at both ends.
@@ -12,11 +12,10 @@ use std::io;
 
 use ratatui::{
     Frame,
-    layout::{Constraint, Layout, Margin},
+    layout::{Alignment, Constraint, Layout, Margin},
     style::Style,
     text::Line,
 };
-use ratcn::text_width;
 use ratcn::{
     Cycle, Theme,
     runtime::{Event, EventResult, FocusState, Ratcn, TabWrap},
@@ -107,33 +106,37 @@ impl demo_shared::Demo for App {
                 .spacing(1)
                 .areas(inner);
 
-            // Each row: the setting's name at the left edge, and the cycle
-            // right-aligned, hugging its current value.
-            let settings = [
-                ("Text size", "size", SIZES[state.size], row_a),
-                ("Refresh", "cadence", CADENCES[state.cadence], row_b),
-                ("Key map", "keymap", KEYMAPS[state.keymap], row_c),
-            ];
+            // Each row is one declaration: the setting's name painted at the
+            // left edge, and the cycle hugging the right edge of the same
+            // row — only the value's own columns respond.
+            let name = Style::default().fg(theme.foreground);
 
-            for (name, id, value, row_area) in settings {
-                let value_width = text_width::display_width_u16(value);
-                let [label_area, value_area] =
-                    Layout::horizontal([Constraint::Min(1), Constraint::Length(value_width)])
-                        .areas(row_area);
+            ctx.paint_widget(Line::from("Text size").style(name), row_a);
+            ctx.component(
+                "size",
+                Cycle::new(SIZES)
+                    .selection(|s: &AppState| s.size, Msg::Size)
+                    .align(Alignment::Right),
+                row_a,
+            );
 
-                ctx.paint_widget(
-                    Line::from(name).style(Style::default().fg(theme.foreground)),
-                    label_area,
-                );
-                let cycle = match id {
-                    "size" => Cycle::new(SIZES).selection(|s: &AppState| s.size, Msg::Size),
-                    "cadence" => {
-                        Cycle::new(CADENCES).selection(|s: &AppState| s.cadence, Msg::Cadence)
-                    }
-                    _ => Cycle::new(KEYMAPS).selection(|s: &AppState| s.keymap, Msg::Keymap),
-                };
-                ctx.component(id, cycle, value_area);
-            }
+            ctx.paint_widget(Line::from("Refresh").style(name), row_b);
+            ctx.component(
+                "cadence",
+                Cycle::new(CADENCES)
+                    .selection(|s: &AppState| s.cadence, Msg::Cadence)
+                    .align(Alignment::Right),
+                row_b,
+            );
+
+            ctx.paint_widget(Line::from("Key map").style(name), row_c);
+            ctx.component(
+                "keymap",
+                Cycle::new(KEYMAPS)
+                    .selection(|s: &AppState| s.keymap, Msg::Keymap)
+                    .align(Alignment::Right),
+                row_c,
+            );
         });
     }
 }

--- a/demos/cycle/src/main.rs
+++ b/demos/cycle/src/main.rs
@@ -122,7 +122,7 @@ impl demo_shared::Demo for App {
                         .areas(row_area);
 
                 ctx.paint_widget(
-                    Line::from(format!("{name}:")).style(Style::default().fg(theme.foreground)),
+                    Line::from(name).style(Style::default().fg(theme.foreground)),
                     label_area,
                 );
                 let cycle = match id {

--- a/demos/cycle/src/main.rs
+++ b/demos/cycle/src/main.rs
@@ -1,20 +1,30 @@
-//! Settings rows: the setting's name on the left, a [`Cycle`] right-aligned.
+//! Settings rows: the setting's name on the left, a [`Cycle`] on the right.
 //!
-//! The pattern most settings screens want — each row reads "name: value", and
-//! the value cycles in place through its options. Tab moves between rows;
-//! Enter, Space, an arrow, or a click advances the focused one.
+//! The pattern most settings screens want — each row reads "name: value",
+//! and the value cycles in place through its options. A Cycle is exactly as
+//! wide as the value it currently shows, so each row hugs its text; here they
+//! are right-aligned against the panel's edge.
+//!
+//! Tab moves between rows. Enter, Space, an arrow, or a click advances the
+//! focused one, wrapping at both ends.
 
 use std::io;
 
 use ratatui::{
     Frame,
-    layout::{Constraint, Flex, Layout, Rect},
+    layout::{Constraint, Layout, Margin},
     style::Style,
+    text::Line,
 };
+use ratcn::text_width;
 use ratcn::{
     Cycle, Theme,
-    runtime::{Event, EventResult, FocusState, Ratcn},
+    runtime::{Event, EventResult, FocusState, Ratcn, TabWrap},
 };
+
+const DEMO_WIDTH: u16 = 34;
+const DEMO_HEIGHT: u16 = 7;
+const CONTENT_PADDING: Margin = Margin::new(2, 1);
 
 const SIZES: [&str; 3] = ["Small", "Medium", "Large"];
 const CADENCES: [&str; 4] = ["Live", "Every minute", "Hourly", "Off"];
@@ -47,7 +57,7 @@ impl App {
             state: AppState::default(),
             ratcn: Ratcn::new()
                 .focus(|s: &AppState| &s.focus, Msg::Focus)
-                .tab_wrap(ratcn::runtime::TabWrap::Wrap),
+                .tab_wrap(TabWrap::Wrap),
         }
     }
 
@@ -81,39 +91,40 @@ impl demo_shared::Demo for App {
 
         let state = &self.state;
         self.ratcn.render(frame, state, theme, |ctx| {
-            // One column per row, split into label on the left and cycle on
-            // the right, with the widest option reserved so every value has
-            // the same hit target.
-            let span = SIZES
-                .iter()
-                .chain(&CADENCES)
-                .chain(&KEYMAPS)
-                .map(|option| option.len() as u16)
-                .max()
-                .unwrap_or(0);
-            let [rows_area] = Layout::vertical([Constraint::Length(3)])
-                .flex(Flex::Center)
-                .areas(area);
+            let demo = area.centered(
+                Constraint::Length(DEMO_WIDTH),
+                Constraint::Length(DEMO_HEIGHT),
+            );
+            ctx.paint(move |ctx| {
+                let surface = ctx.theme.surface;
+                ctx.with_buffer(|buf| {
+                    buf.set_style(demo, Style::default().bg(surface));
+                });
+            });
 
-            for (row, (name, id)) in [
-                ("Text size", "size"),
-                ("Refresh cadence", "cadence"),
-                ("Key map", "keymap"),
-            ]
-            .into_iter()
-            .enumerate()
-            {
-                let row_area = Rect::new(rows_area.x, rows_area.y + row as u16, rows_area.width, 1);
+            let inner = demo.inner(CONTENT_PADDING);
+            let [row_a, row_b, row_c] = Layout::vertical([Constraint::Length(1); 3])
+                .spacing(1)
+                .areas(inner);
+
+            // Each row: the setting's name at the left edge, and the cycle
+            // right-aligned, hugging its current value.
+            let settings = [
+                ("Text size", "size", SIZES[state.size], row_a),
+                ("Refresh", "cadence", CADENCES[state.cadence], row_b),
+                ("Key map", "keymap", KEYMAPS[state.keymap], row_c),
+            ];
+
+            for (name, id, value, row_area) in settings {
+                let value_width = text_width::display_width_u16(value);
                 let [label_area, value_area] =
-                    Layout::horizontal([Constraint::Min(1), Constraint::Length(span + 2)])
+                    Layout::horizontal([Constraint::Min(1), Constraint::Length(value_width)])
                         .areas(row_area);
 
                 ctx.paint_widget(
-                    ratatui::text::Line::from(format!("{name}:"))
-                        .style(Style::default().fg(theme.foreground)),
+                    Line::from(format!("{name}:")).style(Style::default().fg(theme.foreground)),
                     label_area,
                 );
-
                 let cycle = match id {
                     "size" => Cycle::new(SIZES).selection(|s: &AppState| s.size, Msg::Size),
                     "cadence" => {

--- a/demos/cycle/src/main.rs
+++ b/demos/cycle/src/main.rs
@@ -1,0 +1,132 @@
+//! Settings rows: the setting's name on the left, a [`Cycle`] right-aligned.
+//!
+//! The pattern most settings screens want — each row reads "name: value", and
+//! the value cycles in place through its options. Tab moves between rows;
+//! Enter, Space, an arrow, or a click advances the focused one.
+
+use std::io;
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Flex, Layout, Rect},
+    style::Style,
+};
+use ratcn::{
+    Cycle, Theme,
+    runtime::{Event, EventResult, FocusState, Ratcn},
+};
+
+const SIZES: [&str; 3] = ["Small", "Medium", "Large"];
+const CADENCES: [&str; 4] = ["Live", "Every minute", "Hourly", "Off"];
+const KEYMAPS: [&str; 2] = ["Readline", "Vim"];
+
+#[derive(Default)]
+struct AppState {
+    focus: FocusState,
+    size: usize,
+    cadence: usize,
+    keymap: usize,
+}
+
+#[derive(Clone)]
+enum Msg {
+    Focus(FocusState),
+    Size(usize),
+    Cadence(usize),
+    Keymap(usize),
+}
+
+struct App {
+    state: AppState,
+    ratcn: Ratcn<AppState, Msg>,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            state: AppState::default(),
+            ratcn: Ratcn::new()
+                .focus(|s: &AppState| &s.focus, Msg::Focus)
+                .tab_wrap(ratcn::runtime::TabWrap::Wrap),
+        }
+    }
+
+    fn update(&mut self, msg: Msg) {
+        match msg {
+            Msg::Focus(focus) => self.state.focus = focus,
+            Msg::Size(index) => self.state.size = index,
+            Msg::Cadence(index) => self.state.cadence = index,
+            Msg::Keymap(index) => self.state.keymap = index,
+        }
+    }
+}
+
+impl demo_shared::Demo for App {
+    fn handle_event(&mut self, event: Event) -> bool {
+        match self.ratcn.handle_event(event, &self.state) {
+            EventResult::Emit(msg) => {
+                self.update(msg);
+                true
+            }
+            EventResult::Consumed => true,
+            EventResult::Ignored => false,
+        }
+    }
+
+    fn draw(&mut self, frame: &mut Frame, theme: &Theme) {
+        let area = frame.area();
+        frame
+            .buffer_mut()
+            .set_style(area, Style::default().bg(theme.background));
+
+        let state = &self.state;
+        self.ratcn.render(frame, state, theme, |ctx| {
+            // One column per row, split into label on the left and cycle on
+            // the right, with the widest option reserved so every value has
+            // the same hit target.
+            let span = SIZES
+                .iter()
+                .chain(&CADENCES)
+                .chain(&KEYMAPS)
+                .map(|option| option.len() as u16)
+                .max()
+                .unwrap_or(0);
+            let [rows_area] = Layout::vertical([Constraint::Length(3)])
+                .flex(Flex::Center)
+                .areas(area);
+
+            for (row, (name, id)) in [
+                ("Text size", "size"),
+                ("Refresh cadence", "cadence"),
+                ("Key map", "keymap"),
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                let row_area = Rect::new(rows_area.x, rows_area.y + row as u16, rows_area.width, 1);
+                let [label_area, value_area] =
+                    Layout::horizontal([Constraint::Min(1), Constraint::Length(span + 2)])
+                        .areas(row_area);
+
+                ctx.paint_widget(
+                    ratatui::text::Line::from(format!("{name}:"))
+                        .style(Style::default().fg(theme.foreground)),
+                    label_area,
+                );
+
+                let cycle = match id {
+                    "size" => Cycle::new(SIZES).selection(|s: &AppState| s.size, Msg::Size),
+                    "cadence" => {
+                        Cycle::new(CADENCES).selection(|s: &AppState| s.cadence, Msg::Cadence)
+                    }
+                    _ => Cycle::new(KEYMAPS).selection(|s: &AppState| s.keymap, Msg::Keymap),
+                };
+                ctx.component(id, cycle, value_area);
+            }
+        });
+    }
+}
+
+fn main() -> io::Result<()> {
+    demo_shared::run(App::new())
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -204,6 +204,8 @@ export default defineConfig({
           items: [
             { text: 'BarChartWidget', link: '/docs/components/barchart' },
             { text: 'Button', link: '/docs/components/button' },
+            { text: 'Checkbox', link: '/docs/components/checkbox' },
+            { text: 'Cycle', link: '/docs/components/cycle' },
             { text: 'Dialog', link: '/docs/components/dialog' },
             { text: 'List', link: '/docs/components/list' },
             { text: 'ScrollArea', link: '/docs/components/scroll-area' },

--- a/docs/docs/components/checkbox.md
+++ b/docs/docs/components/checkbox.md
@@ -55,7 +55,9 @@ Checkbox::new("Terminal bell")
 ```
 
 The marker column takes the wider of the pair, so an uneven pair like
-`[ON]`/`[off]` never moves the label as it flips.
+`[ON]`/`[off]` never moves the label as it flips. `Checkbox::width()` measures
+the whole row — the same in both states — for layouts that hug it, as the
+demo's rows do.
 
 Two options are a Checkbox wearing its states as labels; three or more are a
 [Cycle](./cycle).

--- a/docs/docs/components/checkbox.md
+++ b/docs/docs/components/checkbox.md
@@ -53,6 +53,9 @@ Checkbox::new("Terminal bell")
     .unchecked_marker("[off]")
 ```
 
+The marker column takes the wider of the pair, so an uneven pair like
+`[ON]`/`[off]` never moves the label as it flips.
+
 Two options are a Checkbox wearing its states as labels; three or more are a
 [Cycle](./cycle).
 
@@ -76,9 +79,9 @@ frame.render_widget(
 );
 ```
 
-`.width()` measures the columns it wants — marker, space, label — for layouts
-that reserve exactly that. Replace `.themed(...)` with `.style(...)` to supply
-exact colors.
+`.width()` measures the columns it wants — marker column, space, label — the
+same in both states, for layouts that reserve exactly that. Replace
+`.themed(...)` with `.style(...)` to supply exact colors.
 
 ## Full API
 

--- a/docs/docs/components/checkbox.md
+++ b/docs/docs/components/checkbox.md
@@ -1,0 +1,94 @@
+---
+description: "A labeled boolean control for Ratatui apps: marker left, label right, the whole row one hit target. The checked and unchecked markers are yours to choose."
+---
+
+# Checkbox
+
+A labeled boolean control: the marker on the left, the label on the right, and
+the whole row as one hit target — a click on the label checks the box exactly
+as a click on the marker does.
+
+<div class="ratcn-preview-window" style="--ratcn-preview-height: 260px">
+  <div class="ratcn-preview-chrome" aria-hidden="true">
+    <span class="ratcn-dot"></span>
+    <span class="ratcn-dot"></span>
+    <span class="ratcn-dot"></span>
+    <span class="ratcn-preview-url">cargo run -p checkbox</span>
+  </div>
+  <div class="ratcn-preview-body">
+    <iframe class="ratcn-component-preview-frame" src="../../../demos/checkbox-demo/index.html" title="ratcn checkbox demo"></iframe>
+  </div>
+</div>
+
+```rust
+use ratcn::{Checkbox, Theme};
+
+// In draw(), declare one Checkbox per option:
+ctx.component(
+    "vim",
+    Checkbox::new("Vim bindings").checked(|state| state.vim, Msg::SetVim),
+    area,
+);
+```
+
+Enter or Space toggles while focused. Nothing paints a background, hover
+changes nothing, and focus recolors the label — a checkbox reads as text on the
+surface it sits on, with the one visible state keyboard users need.
+
+## The markers are yours
+
+The default pair is `☑` / `☐`. Because both markers are strings you choose,
+the same component covers every binary control:
+
+```rust
+// An ASCII checkbox:
+Checkbox::new("Telemetry")
+    .checked_marker("[x]")
+    .unchecked_marker("[ ]")
+
+// A switch — the words are the point:
+Checkbox::new("Terminal bell")
+    .checked_marker("[ON]")
+    .unchecked_marker("[off]")
+```
+
+Two options are a Checkbox wearing its states as labels; three or more are a
+[Cycle](./cycle).
+
+## State
+
+The checked value is app-owned and arrives through `.checked(read, on_change)`:
+`read` answers from app state each frame, `on_change` receives the requested
+state after every toggle. Without the binding the checkbox paints but is not
+focusable and answers no events.
+
+## Paint-only widget
+
+`CheckboxWidget` draws one row without focus, events, or state:
+
+```rust
+use ratcn::CheckboxWidget;
+
+frame.render_widget(
+    CheckboxWidget::new("Vim bindings", state.vim).themed(&theme),
+    area,
+);
+```
+
+`.width()` measures the columns it wants — marker, space, label — for layouts
+that reserve exactly that. Replace `.themed(...)` with `.style(...)` to supply
+exact colors.
+
+## Full API
+
+Every method, with binding requirements and edge-case detail:
+[`Checkbox`](https://docs.rs/ratcn/latest/ratcn/struct.Checkbox.html),
+[`CheckboxWidget`](https://docs.rs/ratcn/latest/ratcn/struct.CheckboxWidget.html),
+[`CheckboxStyle`](https://docs.rs/ratcn/latest/ratcn/struct.CheckboxStyle.html).
+
+Mouse input needs capture enabled in the host. See [Mouse input](../concepts/mouse).
+
+## See also
+
+Use [Cycle](./cycle) when a setting has more than two options, or [List](./list)
+with multi-selection when the user ticks any number of rows in a longer list.

--- a/docs/docs/components/checkbox.md
+++ b/docs/docs/components/checkbox.md
@@ -31,9 +31,10 @@ ctx.component(
 );
 ```
 
-Enter or Space toggles while focused. Nothing paints a background, hover
-changes nothing, and focus recolors the label — a checkbox reads as text on the
-surface it sits on, with the one visible state keyboard users need.
+Enter or Space toggles while focused. At rest a checkbox reads as text on the
+surface it sits on — no chrome — and hover or focus lay the same quiet fill
+over the row that every other control uses, so both kinds of users can always
+see what they are about to flip.
 
 ## The markers are yours
 

--- a/docs/docs/components/checkbox.md
+++ b/docs/docs/components/checkbox.md
@@ -38,7 +38,8 @@ see what they are about to flip.
 
 ## The markers are yours
 
-The default pair is `☑` / `☐`. Because both markers are strings you choose,
+The default pair is `■` / `□` — the boxes a multi-select [List](./list) ticks
+its rows with. Because both markers are strings you choose,
 the same component covers every binary control:
 
 ```rust

--- a/docs/docs/components/cycle.md
+++ b/docs/docs/components/cycle.md
@@ -35,8 +35,25 @@ ctx.component(
 
 The row paints like a small ghost button: plain text at rest, a quiet fill
 while hovered or focused. A column of cycles reads as values, not as a wall of
-chrome — which is what makes the settings-row layout work: the setting's name
-on the left, the Cycle right-aligned on the same row.
+chrome — which is what makes the settings-row layout work: paint the setting's
+name at the left edge and declare the Cycle on the same row with
+`.align(Alignment::Right)` — the value hugs the right edge, paint and hit
+target together, and nothing needs measuring:
+
+```rust
+ctx.paint_widget(Line::from("Text size").style(name), row);
+ctx.component(
+    "size",
+    Cycle::new(["Small", "Medium", "Large"])
+        .selection(|state| state.size, Msg::SetSize)
+        .align(Alignment::Right),
+    row,
+);
+```
+
+For layouts that reserve space instead, `Cycle::width()` (and
+`MeasuredComponent`) answer with the widest option — the columns no value ever
+outgrows.
 
 ## Where a Checkbox ends
 

--- a/docs/docs/components/cycle.md
+++ b/docs/docs/components/cycle.md
@@ -71,6 +71,7 @@ current value occupies — a Cycle is as wide as the text it shows, so rows of
 different settings end at different columns, and a fill on hover or focus
 hugs the value instead of stretching across the row. Replace `.themed(...)`
 with `.style(...)` to supply exact colors.
+
 ## Full API
 
 Every method, with binding requirements and edge-case detail:

--- a/docs/docs/components/cycle.md
+++ b/docs/docs/components/cycle.md
@@ -66,11 +66,11 @@ frame.render_widget(
 );
 ```
 
-`.span()` measures the widest option — the width that fits every value this
-cycle can ever show, which is what keeps a column of cycles from shifting as
-values change. Replace `.themed(...)` with `.style(...)` to supply exact
-colors.
-
+The interactive component paints and answers events in exactly the columns its
+current value occupies — a Cycle is as wide as the text it shows, so rows of
+different settings end at different columns, and a fill on hover or focus
+hugs the value instead of stretching across the row. Replace `.themed(...)`
+with `.style(...)` to supply exact colors.
 ## Full API
 
 Every method, with binding requirements and edge-case detail:

--- a/docs/docs/components/cycle.md
+++ b/docs/docs/components/cycle.md
@@ -1,0 +1,86 @@
+---
+description: "A one-of-many control for Ratatui apps that cycles in place: it shows the current option, and every act advances to the next. Built for settings rows."
+---
+
+# Cycle
+
+A control that cycles through its options in place: the current value is all
+it shows, and every click, <kbd>Enter</kbd>, <kbd>Space</kbd>,
+<kbd>Right</kbd>/<kbd>l</kbd>, or <kbd>Ctrl+N</kbd> advances to the next —
+wrapping at the end. <kbd>Left</kbd>/<kbd>h</kbd> and <kbd>Ctrl+P</kbd> walk
+backward.
+
+<div class="ratcn-preview-window" style="--ratcn-preview-height: 300px">
+  <div class="ratcn-preview-chrome" aria-hidden="true">
+    <span class="ratcn-dot"></span>
+    <span class="ratcn-dot"></span>
+    <span class="ratcn-dot"></span>
+    <span class="ratcn-preview-url">cargo run -p cycle</span>
+  </div>
+  <div class="ratcn-preview-body">
+    <iframe class="ratcn-component-preview-frame" src="../../../demos/cycle-demo/index.html" title="ratcn cycle demo"></iframe>
+  </div>
+</div>
+
+```rust
+use ratcn::Cycle;
+
+ctx.component(
+    "size",
+    Cycle::new(["Small", "Medium", "Large"])
+        .selection(|state| state.size, Msg::SetSize),
+    area,
+);
+```
+
+The row paints like a small ghost button: plain text at rest, a quiet fill
+while hovered or focused. A column of cycles reads as values, not as a wall of
+chrome — which is what makes the settings-row layout work: the setting's name
+on the left, the Cycle right-aligned on the same row.
+
+## Where a Checkbox ends
+
+Two options are a [Checkbox](./checkbox) wearing its states as labels
+(`[ON]`/`[off]`). Three or more options, or an ordered scale such as
+Small/Medium/Large, are a Cycle.
+
+## State
+
+The selection is app-owned and arrives through `.selection(read, on_change)`:
+`read` returns the index shown each frame (an out-of-range answer clamps to
+the last option), and `on_change` receives the index the user moved to.
+Without the binding the Cycle paints but is not focusable and answers no
+events.
+
+## Paint-only widget
+
+`CycleWidget` draws the current option across `area`, with no focus, events,
+or state:
+
+```rust
+use ratcn::CycleWidget;
+
+frame.render_widget(
+    CycleWidget::new(&["Small", "Medium", "Large"], state.size).themed(&theme),
+    area,
+);
+```
+
+`.span()` measures the widest option — the width that fits every value this
+cycle can ever show, which is what keeps a column of cycles from shifting as
+values change. Replace `.themed(...)` with `.style(...)` to supply exact
+colors.
+
+## Full API
+
+Every method, with binding requirements and edge-case detail:
+[`Cycle`](https://docs.rs/ratcn/latest/ratcn/struct.Cycle.html),
+[`CycleWidget`](https://docs.rs/ratcn/latest/ratcn/struct.CycleWidget.html),
+[`CycleStyle`](https://docs.rs/ratcn/latest/ratcn/struct.CycleStyle.html).
+
+Mouse input needs capture enabled in the host. See [Mouse input](../concepts/mouse).
+
+## See also
+
+Use [Checkbox](./checkbox) for two-state settings, or [Select](./select) when
+the whole option list should open for browsing instead of cycling in place.

--- a/docs/docs/components/cycle.md
+++ b/docs/docs/components/cycle.md
@@ -60,10 +60,9 @@ or state:
 ```rust
 use ratcn::CycleWidget;
 
-frame.render_widget(
-    CycleWidget::new(&["Small", "Medium", "Large"], state.size).themed(&theme),
-    area,
-);
+const SIZES: [&str; 3] = ["Small", "Medium", "Large"];
+
+frame.render_widget(CycleWidget::new(SIZES[state.size]).themed(&theme), area);
 ```
 
 The interactive component paints and answers events in exactly the columns its

--- a/docs/docs/components/list.md
+++ b/docs/docs/components/list.md
@@ -121,8 +121,18 @@ List::new(people)
 ```
 
 Every item is the same height, which keeps clicking and paging exact. The
-default markers are `■`/`□` and `●`/`○`; this demo paints ASCII `[x]`/`[ ]`
-instead. The row's state colors are painted underneath what `paint_item`
+default markers are `■`/`□` and `●`/`○`. To change only the markers — ASCII
+`[x]`/`[ ]`, say — use `.selected_marker(...)` and `.unselected_marker(...)`
+instead of repainting the whole row:
+
+```rust
+List::new(todos)
+    .multi_selection(|s: &AppState, item| s.done.contains(item), Msg::Toggled)
+    .selected_marker("[x]")
+    .unselected_marker("[ ]")
+```
+
+The row's state colors are painted underneath what `paint_item`
 returns, so unstyled text picks up the focused, selected, or disabled colors,
 and any color you set explicitly on a `Text`, `Line`, or `Span` is kept.
 

--- a/docs/docs/demos.md
+++ b/docs/docs/demos.md
@@ -53,6 +53,8 @@ the previews embedded on the [component pages](./components/button).
 | [Dialog](./components/dialog) | `dialog` — a modal layer with actions, draggable by its border |
 | [Toast](./components/toast) | `toast` — transient notifications your app owns |
 | [Tooltip](./components/tooltip) | `tooltip` — hover or Tab to a button and its bubble floats above |
+| [Checkbox](./components/checkbox) | `checkbox` — one component as checkbox, ASCII checklist, and switch |
+| [Cycle](./components/cycle) | `cycle` — settings rows with the value cycling in place |
 | [BarChart](./components/barchart) | `barchart`, `barchart-horizontal` — a paint-only widget, no runtime needed |
 
 ## Running them in the browser

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -17,12 +17,13 @@ are worth knowing before you build on it:
 - **There is no install command.** The shadcn resemblance is in how the code is
   structured, not yet in tooling. Copying a component into your project is a
   manual file copy today. A CLI is intended, but it does not exist.
-- **The component set is small and growing.** Nine components ship today:
+- **The component set is small and growing.** Eleven components ship today:
   [Button](./components/button), [List](./components/list),
   [ScrollArea](./components/scroll-area), [Select](./components/select),
   [Tabs](./components/tabs), [Dialog](./components/dialog),
-  [Toast](./components/toast), [BarChart](./components/barchart), and
-  [Tooltip](./components/tooltip). Notably missing and planned next are **text
+  [Toast](./components/toast), [BarChart](./components/barchart),
+  [Tooltip](./components/tooltip), [Checkbox](./components/checkbox), and
+  [Cycle](./components/cycle). Notably missing and planned next are **text
   input** and a **multi-line text area**.
 
 If there are specific components, patterns, or features you would like to see


### PR DESCRIPTION
## Summary

Two new components, plus the shared marker vocabulary they prompted.

**`Checkbox`** (`CheckboxStyle`, `CheckboxWidget`) — a labeled boolean control: marker left, label right, the whole row one hit target. Enter/Space toggle while focused; a click anywhere toggles. At rest it reads as text on the surface; hover and focus lay the ghost-button fill over the row. The checked and unchecked markers are strings the app chooses — `☑`/`☐` by default, `[x]`/`[ ]` for ASCII, `[ON]`/`[off]` for a switch or toggle.

**`Cycle`** (`CycleStyle`, `CycleWidget`) — shows the current option and advances on every act: Enter, Space, Right/`l`, Ctrl+N, or a click; Left/`h` and Ctrl+P walk backward. Wraps at both ends. Paints like a small ghost button: bare at rest, quiet fill on hover or focus. The component paints and hit-tests exactly the columns its current value occupies.

**Marker glyphs, app-chosen.** `selection_indicator::MarkerGlyphs` names the pair a selection control paints (radio circles / checkbox boxes), with presets. `List::selected_marker`/`unselected_marker`, `Select::selected_marker`/`unselected_marker`, and the same methods on `SelectWidget` override the pair per control.

## Breaking

- `selection_indicator::marker` takes a `MarkerGlyphs` pair instead of a `multiple` flag; `marker_line` follows it.

## Demos

- `checkbox` — one component in three skins (default, ASCII checklist, switch).
- `cycle` — settings rows: setting name left, cycle right-aligned, hugging its current value.

Both demos follow the house layout: content centered in a fixed-size surface panel over the theme background.

## Verification

- `cargo test -p ratcn`: 529 tests green, including new intent tests per component (label click toggles; modified keys pass through; Tab traversal between controls; unbound controls answer nothing; hover/focus fills vs rest; wrap-around stepping; out-of-range clamping).
- `cargo test --workspace`, `cargo check -p copy-fixture --examples` (both components compile standalone against the public API).
- `cargo clippy --workspace --all-targets` clean, `cargo fmt --check` clean, docs site builds.

