### PR TITLE
Support hosted component trees in panes and buffers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
         run: cargo test -p ratcn --locked
       - name: Tests, all features
         run: cargo test -p ratcn --all-features --locked
+      # Offline CLI fixtures use all-platform metadata, which needs non-native crates too.
+      - name: Fetch dependencies for offline tests
+        run: cargo fetch --locked
       # The demo crates have tests of their own. The clippy steps below compile
       # them; only this step runs them. ratcn's own ran above.
       - name: Tests, workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Breaking
+
+- `Ratcn::render` now takes `area` second: pass your pane's rectangle, or
+  `frame.area()` for a whole-frame app. Floating placement, layer copies, and
+  modal dimming respect that area; arbitrary base paint remains unclipped.
+
 ### Added
 
 - `cargo-ratcn`: a Cargo subcommand with terminal-only `cargo ratcn init`, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `FocusState::none()` and `is_none()` let a tree have no focused component,
+  distinct from default startup focus. Input can focus it again, and closing
+  a modal restores a saved no-focus state.
 - `Ratcn::render_into(buffer, area, state, theme, declare)` renders directly
   into your own buffer for offscreen pages and previews, without a test terminal.
   You own allocation, clearing, and windowing; no cursor metadata is returned.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `Ratcn::render_into(buffer, area, state, theme, declare)` renders directly
+  into your own buffer for offscreen pages and previews, without a test terminal.
+  You own allocation, clearing, and windowing; no cursor metadata is returned.
 - `cargo-ratcn`: a Cargo subcommand with terminal-only `cargo ratcn init`, which
   can keep Cargo's default `main.rs`, replace it with a minimal app loop, or
   install the Getting started demo; and `cargo ratcn add` for copying a built-in

--- a/crates/cargo-ratcn/templates/first-app.rs
+++ b/crates/cargo-ratcn/templates/first-app.rs
@@ -67,7 +67,7 @@ impl App {
             Constraint::Length(ButtonSize::Large.height()),
         );
 
-        self.ratcn.render(frame, &self.state, theme, |ctx| {
+        self.ratcn.render(frame, area, &self.state, theme, |ctx| {
             ctx.component("hello", button, button_area);
         });
         frame.render_widget(ToasterWidget::new(&self.state.toasts, now).themed(theme), area);

--- a/crates/ratcn/benches/frame.rs
+++ b/crates/ratcn/benches/frame.rs
@@ -112,7 +112,7 @@ mod frame {
         c.bench_function("render", |b| {
             b.iter(|| {
                 terminal
-                    .draw(|frame| ratcn.render(frame, &state, &theme, declare))
+                    .draw(|frame| ratcn.render(frame, frame.area(), &state, &theme, declare))
                     .expect("draw");
             });
         });
@@ -121,7 +121,7 @@ mod frame {
     fn route_click(c: &mut Criterion) {
         let (mut ratcn, mut terminal, state, theme) = surface();
         terminal
-            .draw(|frame| ratcn.render(frame, &state, &theme, declare))
+            .draw(|frame| ratcn.render(frame, frame.area(), &state, &theme, declare))
             .expect("draw");
         let press = mouse(MouseKind::Down(MouseButton::Left));
         let release = mouse(MouseKind::Up(MouseButton::Left));
@@ -146,7 +146,7 @@ mod frame {
                 terminal
                     .draw(|frame| {
                         let area = frame.area();
-                        ratcn.render(frame, &state, &theme, |ctx| {
+                        ratcn.render(frame, area, &state, &theme, |ctx| {
                             ctx.component(
                                 "list",
                                 List::new(items.clone())
@@ -168,7 +168,7 @@ mod frame {
                 terminal
                     .draw(|frame| {
                         let area = frame.area();
-                        ratcn.render(frame, &state, &theme, |ctx| {
+                        ratcn.render(frame, area, &state, &theme, |ctx| {
                             ctx.component(
                                 "dialog",
                                 Dialog::new()

--- a/crates/ratcn/src/lib.rs
+++ b/crates/ratcn/src/lib.rs
@@ -129,7 +129,7 @@
 //! // Declare the current component surface as part of every frame.
 //! terminal.draw(|frame| {
 //!     let area = frame.area();
-//!     ratcn.render(frame, &state, &theme, |ctx| {
+//!     ratcn.render(frame, area, &state, &theme, |ctx| {
 //!         ctx.component(
 //!             "save",
 //!             Button::new("Save")

--- a/crates/ratcn/src/runtime/component.rs
+++ b/crates/ratcn/src/runtime/component.rs
@@ -416,10 +416,18 @@ impl<'a, State, Msg> DeclareCtx<'a, State, Msg> {
     /// and is dimmed with everything else the modal covers.
     ///
     /// Modal policy: the area behind the modal is dimmed, events outside it
-    /// are consumed rather than routed, focus resolves into it, and Tab wraps
+    /// are consumed rather than routed, and Tab wraps
     /// at its boundary. A key nothing inside handles still bubbles to the
     /// modal root rather than escaping beneath, so Esc-to-close works even
     /// when no descendant is focused.
+    ///
+    /// The topmost eligible modal takes over default focus and declared paths
+    /// it covers, when it has a focusable target. Explicit
+    /// [`FocusState::none`](super::FocusState::none) stays unfocused; an intent
+    /// naming an absent path stays parked. Declaring a modal does not reset
+    /// app-held focus. Opening a new modal through
+    /// [`ModalState::open`](super::ModalState::open) saves that focus and resets
+    /// it to default, allowing the modal to take focus; closing restores it.
     ///
     /// An empty interaction area retains the modal path but excludes the modal
     /// and its descendants from focus, hit-testing, and event routing.

--- a/crates/ratcn/src/runtime/component.rs
+++ b/crates/ratcn/src/runtime/component.rs
@@ -159,12 +159,19 @@ impl<'a, State, Msg> DeclareCtx<'a, State, Msg> {
         self.area
     }
 
-    /// The terminal frame area for this declaration pass.
+    /// The root area supplied to [`Ratcn::render`](super::Ratcn::render), in
+    /// this declaration's coordinate space.
     ///
     /// Unlike [`area`](Self::area), this is not changed by component, scope,
-    /// modal, or popup declarations. Composite components use it when placing
-    /// an overlay relative to their declaration while keeping that overlay
-    /// within the terminal bounds.
+    /// or popup declarations. Inside a [`viewport`](Self::viewport), it is
+    /// the root area shifted into logical coordinates by the scroll offset,
+    /// not the viewport's visible or content rectangle. A modal leaves the
+    /// viewport and reads the root area in screen coordinates again.
+    ///
+    /// Floating components use these bounds to stay within their host's pane
+    /// rather than the whole terminal. This does not sandbox base-layer paint:
+    /// widgets may paint outside their rects, and [`PaintCtx::with_buffer`]
+    /// gives unprojected base paint the whole destination buffer.
     #[must_use]
     pub const fn frame_area(&self) -> Rect {
         self.frame_area
@@ -582,8 +589,9 @@ impl<'a, State, Msg> DeclareCtx<'a, State, Msg> {
     /// Deferred paint is decoration only: it has no identity, geometry, focus,
     /// hover, or hit target, and cannot be clicked. Its [`PaintCtx`] therefore
     /// reports all four interaction flags as false, and
-    /// [`area`](PaintCtx::area) is the whole surface it writes to — the
-    /// layer's footprint inside a layer, the frame otherwise.
+    /// [`area`](PaintCtx::area) is the layer's footprint inside a layer, the
+    /// supplied render area otherwise, expressed in the paint's coordinates.
+    /// That area does not clip base-layer paint.
     ///
     /// Because the closure runs after the declaration pass has ended, it does
     /// not get a `DeclareCtx`. It is `'static` and receives a [`PaintCtx`],

--- a/crates/ratcn/src/runtime/component.rs
+++ b/crates/ratcn/src/runtime/component.rs
@@ -159,8 +159,9 @@ impl<'a, State, Msg> DeclareCtx<'a, State, Msg> {
         self.area
     }
 
-    /// The root area supplied to [`Ratcn::render`](super::Ratcn::render), in
-    /// this declaration's coordinate space.
+    /// The root area supplied to [`Ratcn::render`](super::Ratcn::render) or
+    /// [`Ratcn::render_into`](super::Ratcn::render_into), in this declaration's
+    /// coordinate space.
     ///
     /// Unlike [`area`](Self::area), this is not changed by component, scope,
     /// or popup declarations. Inside a [`viewport`](Self::viewport), it is

--- a/crates/ratcn/src/runtime/engine.rs
+++ b/crates/ratcn/src/runtime/engine.rs
@@ -1702,13 +1702,13 @@ impl<State, Msg> RenderPass<State, Msg> {
     /// declaration belonged to, with the flags the finished tree resolved.
     fn replay_paint(
         &mut self,
-        frame: &mut Frame,
+        buffer: &mut Buffer,
         state: &State,
         theme: &Theme,
         resolved: Resolved<'_>,
     ) {
         for QueuedPaint { slot, paint } in std::mem::take(&mut self.paint_queue) {
-            self.paint_op(paint, slot, frame, state, theme, resolved);
+            self.paint_op(paint, slot, buffer, state, theme, resolved);
         }
     }
 
@@ -1718,7 +1718,7 @@ impl<State, Msg> RenderPass<State, Msg> {
         &mut self,
         op: DeclaredPaint<State>,
         slot: PaintSlot,
-        frame: &mut Frame,
+        buffer: &mut Buffer,
         state: &State,
         theme: &Theme,
         resolved: Resolved<'_>,
@@ -1730,7 +1730,7 @@ impl<State, Msg> RenderPass<State, Msg> {
         });
         let hover_position = self.hover_in(slot);
         let target = match slot.layer {
-            None => PaintTarget::frame(frame.buffer_mut(), slot.projection, &mut self.scratch),
+            None => PaintTarget::frame(buffer, slot.projection, &mut self.scratch),
             Some(index) => PaintTarget::canvas(
                 &mut self.canvases[index],
                 slot.projection,
@@ -1767,20 +1767,20 @@ impl<State, Msg> RenderPass<State, Msg> {
     /// Layers composite in declaration order, except that every layer outside
     /// the one that has taken the screen over composites before it: what the
     /// takeover covers is inert, and so must not paint above it either.
-    fn finish_frame(&mut self, frame: &mut Frame, state: &State, theme: &Theme) {
+    fn finish_frame(&mut self, buffer: &mut Buffer, state: &State, theme: &Theme) {
         let mut deferred = std::mem::take(&mut self.deferred);
         let takeover = self.surface.takeover_root();
         for index in 0..self.canvases.len() {
             if self.surface.covered_by_takeover(index, takeover) {
-                self.composite_layer(index, &mut deferred, frame, state, theme);
+                self.composite_layer(index, &mut deferred, buffer, state, theme);
             }
         }
         for index in 0..self.canvases.len() {
             if !self.surface.covered_by_takeover(index, takeover) {
-                self.composite_layer(index, &mut deferred, frame, state, theme);
+                self.composite_layer(index, &mut deferred, buffer, state, theme);
             }
         }
-        self.flush_deferred(&mut deferred, None, frame, state, theme);
+        self.flush_deferred(&mut deferred, None, buffer, state, theme);
     }
 
     /// Copy one layer's canvas onto the frame — dimming beneath it first when
@@ -1790,13 +1790,13 @@ impl<State, Msg> RenderPass<State, Msg> {
         &mut self,
         index: usize,
         deferred: &mut Vec<QueuedPaint<State>>,
-        frame: &mut Frame,
+        buffer: &mut Buffer,
         state: &State,
         theme: &Theme,
     ) {
         if self.surface.policy(Some(index)).takes_over {
             dim_background(
-                frame.buffer_mut(),
+                buffer,
                 self.canvases[index]
                     .buffer
                     .area
@@ -1804,11 +1804,11 @@ impl<State, Msg> RenderPass<State, Msg> {
                 theme.background,
             );
         }
-        self.flush_deferred(deferred, Some(index), frame, state, theme);
+        self.flush_deferred(deferred, Some(index), buffer, state, theme);
         let frame_area = self.frame_area;
         let canvas = &self.canvases[index];
         for &rect in &canvas.painted {
-            copy_rect(&canvas.buffer, frame.buffer_mut(), rect, frame_area);
+            copy_rect(&canvas.buffer, buffer, rect, frame_area);
         }
     }
 
@@ -1818,7 +1818,7 @@ impl<State, Msg> RenderPass<State, Msg> {
         &mut self,
         deferred: &mut Vec<QueuedPaint<State>>,
         layer: Option<usize>,
-        frame: &mut Frame,
+        buffer: &mut Buffer,
         state: &State,
         theme: &Theme,
     ) {
@@ -1832,7 +1832,7 @@ impl<State, Msg> RenderPass<State, Msg> {
             hover: &[],
         };
         for QueuedPaint { slot, paint } in theirs {
-            self.paint_op(paint, slot, frame, state, theme, resolved);
+            self.paint_op(paint, slot, buffer, state, theme, resolved);
         }
     }
 
@@ -2153,7 +2153,8 @@ impl<State, Msg> Ratcn<State, Msg> {
     ///
     /// `area` is the root declaration area, in absolute frame coordinates.
     /// Pass `frame.area()` for a whole-frame app, or a pane's rectangle for a
-    /// hosted tree. It supplies the placement bounds floating components read
+    /// hosted tree. Choose an area within the frame; it is passed unchanged
+    /// for layout, not silently clamped. Floating components read its bounds
     /// through [`DeclareCtx::frame_area`]; layer copies and modal backdrop
     /// dimming are intersected with it. Viewports retain their logical
     /// coordinate transforms, and input events still use screen coordinates.
@@ -2162,6 +2163,10 @@ impl<State, Msg> Ratcn<State, Msg> {
     /// paint is not clipped to `area`: widgets can paint outside their rects,
     /// and [`PaintCtx::with_buffer`] gives unprojected base paint the whole
     /// destination buffer. The host still owns input routing between trees.
+    ///
+    /// This delegates to [`render_into`](Self::render_into) with the frame's
+    /// buffer. Use that entry point for a caller-owned offscreen buffer rather
+    /// than constructing a terminal just to obtain a frame.
     ///
     /// # Declaring, then drawing
     ///
@@ -2208,6 +2213,49 @@ impl<State, Msg> Ratcn<State, Msg> {
         theme: &Theme,
         declare: impl FnOnce(&mut DeclareCtx<'_, State, Msg>),
     ) {
+        self.render_into(frame.buffer_mut(), area, state, theme, declare);
+    }
+
+    /// Declare and paint into a caller-owned buffer, then retain the surface
+    /// for event routing, just like [`render`](Self::render).
+    ///
+    /// Use this for offscreen content, such as a page taller than its visible
+    /// window. For ordinary terminal drawing, prefer [`render`](Self::render).
+    /// Both use the same declaration, validation, focus/hover resolution,
+    /// painting, and commit lifecycle. A rejected declaration leaves the buffer
+    /// untouched; a panic during painting can leave partial writes, but never
+    /// replaces the previously retained surface.
+    ///
+    /// The caller allocates and, when needed, clears or resizes `buffer` before
+    /// the call. This method does not clear it: cells paint leaves alone keep
+    /// their previous contents. Choose `area` within `buffer.area`; it is passed
+    /// unchanged for layout, with no containment validation or silent clamping.
+    /// Areas use the buffer's absolute coordinates, including a nonzero origin,
+    /// not coordinates relative to `area`. Viewports retain their logical
+    /// transforms. The caller owns copying a visible window to the screen and
+    /// translating screen pointer positions back into buffer coordinates before
+    /// [`handle_event`](Self::handle_event).
+    ///
+    /// `area` supplies floating placement bounds and clips layer copies and
+    /// modal dimming, not arbitrary base paint or root hit-testing. Base widgets
+    /// can paint outside their rects, and unprojected [`PaintCtx::with_buffer`]
+    /// receives the whole destination buffer, as it does with `render`.
+    ///
+    /// A bare buffer carries no cursor metadata, and this method reports no
+    /// caret position. Future caret-bearing components may require a caret
+    /// result from this API; the host would decide how to display it.
+    ///
+    /// # Panics
+    ///
+    /// The same declaration and component-paint failures as [`render`](Self::render).
+    pub fn render_into(
+        &mut self,
+        buffer: &mut Buffer,
+        area: Rect,
+        state: &State,
+        theme: &Theme,
+        declare: impl FnOnce(&mut DeclareCtx<'_, State, Msg>),
+    ) {
         let focus_snapshot = self.stored_focus(state);
         // Reveal first: the surface that painted the previous focus is still
         // the one in hand, and it is the tree that can say where the focus now
@@ -2241,7 +2289,7 @@ impl<State, Msg> Ratcn<State, Msg> {
         let resolved_focus = pass.surface.resolve_focus(focus_snapshot);
         let resolved_hover = self.resolve_hover(&pass.surface);
         pass.replay_paint(
-            frame,
+            buffer,
             state,
             theme,
             Resolved {
@@ -2249,7 +2297,7 @@ impl<State, Msg> Ratcn<State, Msg> {
                 hover: &resolved_hover,
             },
         );
-        pass.finish_frame(frame, state, theme);
+        pass.finish_frame(buffer, state, theme);
         self.commit_surface(pass.surface, resolved_hover, resolved_focus);
     }
 

--- a/crates/ratcn/src/runtime/engine.rs
+++ b/crates/ratcn/src/runtime/engine.rs
@@ -820,7 +820,8 @@ impl<State, Msg> Surface<State, Msg> {
     /// the same tree is what guarantees render and routing agree — there is no
     /// second resolution to drift from.
     ///
-    /// - An empty path resolves to the first participating focus candidate,
+    /// - Explicit no-focus stays unfocused, even with a takeover layer.
+    /// - An otherwise empty path resolves to the first participating candidate,
     ///   descended to its first focusable leaf (startup focus).
     /// - A path naming a container descends to the container's first focusable
     ///   leaf.
@@ -830,6 +831,9 @@ impl<State, Msg> Surface<State, Msg> {
     ///   into that layer; an absent path stays parked even then, so render and
     ///   routing agree on it.
     fn resolve_focus(&self, stored: &FocusState) -> FocusState {
+        if stored.is_none() {
+            return FocusState::none();
+        }
         if let Some(root) = self.takeover_root()
             && !self.path_is_prefix_of(root, stored.path())
         {
@@ -3036,7 +3040,11 @@ impl<State, Msg> Ratcn<State, Msg> {
     /// geometry to answer with, and whatever prefix of the path it does
     /// declare belongs to a different node. Focus sits on a whole path or
     /// nowhere, and so does the reveal.
+    /// Explicit no-focus completes immediately: there is no target to wait for.
     fn reveal_focus(&mut self, focus: &FocusState, state: &State) -> bool {
+        if focus.is_none() {
+            return true;
+        }
         let Some(target) = self.surface.leaf_of(focus.path()) else {
             return false;
         };

--- a/crates/ratcn/src/runtime/engine.rs
+++ b/crates/ratcn/src/runtime/engine.rs
@@ -19,7 +19,7 @@ use std::{collections::HashMap, fmt};
 
 use ratatui::{
     Frame,
-    buffer::Buffer,
+    buffer::{Buffer, CellDiffOption, CellWidth},
     layout::{Position, Rect},
 };
 
@@ -1147,12 +1147,12 @@ impl Canvas {
 /// positional parameters, and it is the only thing a [`RenderPass`] method
 /// needs besides the node's own identity and options. `area` rides along
 /// because it is the member that changes per declaration — whoever declares a
-/// child chooses where it goes — while the rest is constant for the whole
-/// pass.
+/// child chooses where it goes. Viewports also express `frame_area` in their
+/// logical coordinates; the state and theme stay constant for the pass.
 pub(crate) struct DeclarationEnv<'a, State> {
-    /// The whole terminal frame. Declaring never paints, so the frame itself
-    /// stays with [`Ratcn::render`] until the replay; its area is the only part
-    /// a declaration can act on, and it is constant for the pass.
+    /// The root area supplied to [`Ratcn::render`], expressed in the current
+    /// declaration's coordinates: screen coordinates outside a viewport,
+    /// logical coordinates inside one.
     pub(crate) frame_area: Rect,
     pub(crate) area: Rect,
     pub(crate) state: &'a State,
@@ -1162,7 +1162,7 @@ pub(crate) struct DeclarationEnv<'a, State> {
 
 impl<'a, State> DeclarationEnv<'a, State> {
     /// The environment for a root declaration: the app's own closure, covering
-    /// the whole frame.
+    /// the supplied render area.
     fn root(
         frame_area: Rect,
         state: &'a State,
@@ -1797,19 +1797,18 @@ impl<State, Msg> RenderPass<State, Msg> {
         if self.surface.policy(Some(index)).takes_over {
             dim_background(
                 frame.buffer_mut(),
-                self.canvases[index].buffer.area,
+                self.canvases[index]
+                    .buffer
+                    .area
+                    .intersection(self.frame_area),
                 theme.background,
             );
         }
         self.flush_deferred(deferred, Some(index), frame, state, theme);
-        let frame_area = frame.area();
+        let frame_area = self.frame_area;
         let canvas = &self.canvases[index];
         for &rect in &canvas.painted {
-            copy_rect(
-                &canvas.buffer,
-                frame.buffer_mut(),
-                rect.intersection(frame_area),
-            );
+            copy_rect(&canvas.buffer, frame.buffer_mut(), rect, frame_area);
         }
     }
 
@@ -2152,6 +2151,18 @@ impl<State, Msg> Ratcn<State, Msg> {
     /// reaches the screen. Only a panic thrown by painting itself, once the
     /// pass has been accepted, can leave cells behind.
     ///
+    /// `area` is the root declaration area, in absolute frame coordinates.
+    /// Pass `frame.area()` for a whole-frame app, or a pane's rectangle for a
+    /// hosted tree. It supplies the placement bounds floating components read
+    /// through [`DeclareCtx::frame_area`]; layer copies and modal backdrop
+    /// dimming are intersected with it. Viewports retain their logical
+    /// coordinate transforms, and input events still use screen coordinates.
+    ///
+    /// This is not a paint sandbox or a root hit-test boundary. Base-layer
+    /// paint is not clipped to `area`: widgets can paint outside their rects,
+    /// and [`PaintCtx::with_buffer`] gives unprojected base paint the whole
+    /// destination buffer. The host still owns input routing between trees.
+    ///
     /// # Declaring, then drawing
     ///
     /// The closure runs once, and nothing draws while it does. Declaration
@@ -2192,6 +2203,7 @@ impl<State, Msg> Ratcn<State, Msg> {
     pub fn render(
         &mut self,
         frame: &mut Frame,
+        area: Rect,
         state: &State,
         theme: &Theme,
         declare: impl FnOnce(&mut DeclareCtx<'_, State, Msg>),
@@ -2208,11 +2220,11 @@ impl<State, Msg> Ratcn<State, Msg> {
         // builds the tree and queues the paint it owes. Hover is the one
         // interaction fact that predates the pass, so the declaration may ask
         // for it — see [`DeclareCtx::pointer_within`].
-        let mut pass = RenderPass::new(frame.area());
+        let mut pass = RenderPass::new(area);
         pass.hover_position = self.pointer;
         pass.hover_path.clone_from(&self.hover);
         pass.with_declare_ctx(
-            DeclarationEnv::root(frame.area(), state, theme, &mut self.transients),
+            DeclarationEnv::root(area, state, theme, &mut self.transients),
             declare,
         );
         // Every reason to reject a pass is known once declaration ends, and
@@ -3034,12 +3046,19 @@ impl<State, Msg> Ratcn<State, Msg> {
     }
 }
 
-/// Copy `area` out of `source` and into `destination`, cell for cell.
-fn copy_rect(source: &Buffer, destination: &mut Buffer, area: Rect) {
+/// Copy `area` through `clip`, blanking glyphs cut by the composite boundary.
+/// A paint rect may cover only part of an otherwise intact glyph.
+fn copy_rect(source: &Buffer, destination: &mut Buffer, area: Rect, clip: Rect) {
+    let clip = clip
+        .intersection(source.area)
+        .intersection(destination.area);
+    let area = area.intersection(clip);
     for position in area.positions() {
-        if let (Some(cell), Some(target)) = (source.cell(position), destination.cell_mut(position))
-        {
-            *target = cell.clone();
+        let cell = &source[position];
+        let target = &mut destination[position];
+        *target = cell.clone();
+        if cell.cell_width() > clip.right() - position.x {
+            target.set_symbol(" ").set_diff_option(CellDiffOption::None);
         }
     }
 }

--- a/crates/ratcn/src/runtime/engine/tests/focus.rs
+++ b/crates/ratcn/src/runtime/engine/tests/focus.rs
@@ -2,6 +2,94 @@
 //! to a path whose target is not in the tree.
 
 use super::*;
+use crate::{ButtonSize, ButtonWidget};
+use ratatui::widgets::Widget;
+
+#[test]
+fn no_focus_paints_neither_button_ring_while_default_and_empty_intent_still_choose_first() {
+    for (focus, auto) in [
+        (FocusState::none(), false),
+        (FocusState::default(), true),
+        (FocusState::intent([] as [&str; 0]), true),
+    ] {
+        let state = FocusTestState { focus };
+        let mut driver = focus_driver(20, 3);
+        driver.render(&state, |ctx| {
+            for (id, x) in [("first", 0), ("last", 10)] {
+                ctx.component(
+                    id,
+                    Button::new(id)
+                        .outline()
+                        .size(ButtonSize::Large)
+                        .on_press(move || FocusTestMsg::Activated(vec![ChildId::Static(id)])),
+                    Rect::new(x, 0, 10, 3),
+                );
+            }
+        });
+
+        let mut expected = Buffer::empty(driver.area());
+        for (id, x) in [("first", 0), ("last", 10)] {
+            ButtonWidget::new(id)
+                .outline()
+                .size(ButtonSize::Large)
+                .themed(&Theme::default_dark())
+                .focused(auto && x == 0)
+                .render(Rect::new(x, 0, 10, 3), &mut expected);
+        }
+        assert_eq!(driver.buffer(), &expected);
+        if !auto {
+            assert!(driver.ratcn.resolved_focus.is_none());
+            assert_eq!(
+                driver.event(Event::Key(KeyEvent::new(KeyCode::Enter)), &state),
+                EventResult::Ignored,
+                "no base control receives keyboard activation while none is focused"
+            );
+        }
+    }
+}
+
+#[test]
+fn traversal_root_hotkeys_and_pointer_focus_can_enter_a_blurred_tree() {
+    for (event, target) in [
+        (Event::Key(KeyEvent::new(KeyCode::Tab)), "first"),
+        (Event::Key(KeyEvent::new(KeyCode::BackTab)), "last"),
+        (Event::Key(KeyEvent::new(KeyCode::Char('x'))), "last"),
+        (mouse(MouseKind::Down(MouseButton::Left), 11, 0), "last"),
+    ] {
+        let mut state = FocusTestState {
+            focus: FocusState::none(),
+        };
+        let mut driver = Driver::with(
+            Ratcn::new()
+                .focus(|state: &FocusTestState| &state.focus, FocusTestMsg::Focus)
+                .focus_key('x', ["last"]),
+            20,
+            1,
+        );
+        driver.render(&state, |ctx| {
+            ctx.component("first", FocusLeaf::enabled(), Rect::new(0, 0, 8, 1));
+            ctx.component("last", FocusLeaf::enabled(), Rect::new(10, 0, 8, 1));
+        });
+
+        let expected = FocusState::intent([target]);
+        assert_eq!(
+            driver.ratcn.focus_path(&[ChildId::Static(target)]),
+            Some(expected.clone()),
+            "programmatic focus requests remain available while blurred"
+        );
+        let EventResult::Emit(FocusTestMsg::Focus(focus)) = driver.event(event, &state) else {
+            panic!("input must be able to focus {target} from none");
+        };
+        assert_eq!(focus, expected);
+        assert!(!focus.is_none());
+        state.focus = focus;
+        assert_eq!(
+            driver.event(Event::Key(KeyEvent::new(KeyCode::Enter)), &state),
+            EventResult::Emit(FocusTestMsg::Activated(vec![ChildId::Static(target)])),
+            "the focus message must leave the tree ready for keyboard input"
+        );
+    }
+}
 
 struct FocusComposite {
     parent_rendered: FocusRenderLog,

--- a/crates/ratcn/src/runtime/engine/tests/hosting.rs
+++ b/crates/ratcn/src/runtime/engine/tests/hosting.rs
@@ -1,0 +1,351 @@
+//! A hosted tree bounds floating layers without sandboxing base paint.
+
+use ratatui::{
+    style::Color,
+    text::Line,
+    widgets::{Block, Paragraph},
+};
+
+use super::*;
+use crate::{ListItem, Select, Tooltip, TooltipSide};
+
+const ROOT: Rect = Rect::new(8, 4, 18, 7);
+
+#[test]
+fn overlapping_style_paint_preserves_a_complete_wide_glyph() {
+    for root in [Rect::new(0, 0, 40, 18), ROOT] {
+        let mut driver = Driver::<(), ()>::new(40, 18);
+        driver
+            .terminal
+            .draw(|frame| {
+                driver
+                    .ratcn
+                    .render(frame, root, &(), &Theme::default_dark(), |ctx| {
+                        ctx.modal_scope(
+                            "modal",
+                            Rect::new(2, 1, 34, 14),
+                            ScopeOptions::default(),
+                            |ctx| {
+                                ctx.paint_widget(Line::from("\u{754c}"), Rect::new(10, 7, 2, 1));
+                                ctx.paint_widget(
+                                    Block::new().style(Color::Green),
+                                    Rect::new(10, 7, 1, 1),
+                                );
+                            },
+                        );
+                    });
+                let blank = Buffer::empty(frame.area());
+                let updates = blank.diff(frame.buffer_mut());
+                let &(_, _, cell) = updates
+                    .iter()
+                    .find(|&&(x, y, _)| x == 10 && y == 7)
+                    .expect("the restyled glyph must reach the terminal");
+                assert_eq!(
+                    cell.symbol(),
+                    "\u{754c}",
+                    "paint rectangles are not clipping boundaries: {root:?}"
+                );
+                assert_eq!(cell.cell_width(), 2);
+                assert_eq!(cell.fg, Color::Green);
+                assert!(!updates.iter().any(|&(x, y, _)| x == 11 && y == 7));
+            })
+            .expect("draw");
+    }
+}
+
+#[test]
+fn clipped_modal_wide_glyph_does_not_emit_over_host_chrome() {
+    // A split glyph on either edge becomes blank; whole glyphs at the edges survive.
+    for (glyph_x, visible) in [(25, false), (24, true), (7, false), (8, true)] {
+        let mut driver = Driver::<(), ()>::new(40, 18);
+        driver
+            .terminal
+            .draw(|frame| {
+                for cell in &mut frame.buffer_mut().content {
+                    cell.set_symbol("#");
+                }
+                let before = frame.buffer_mut().clone();
+                driver
+                    .ratcn
+                    .render(frame, ROOT, &(), &Theme::default_dark(), |ctx| {
+                        ctx.modal_scope(
+                            "modal",
+                            Rect::new(2, 1, 34, 14),
+                            ScopeOptions::default(),
+                            |ctx| {
+                                ctx.paint_widget(
+                                    Line::from("\u{754c}").style(Color::Green),
+                                    Rect::new(glyph_x, 7, 2, 1),
+                                );
+                            },
+                        );
+                    });
+                for position in before
+                    .area
+                    .positions()
+                    .filter(|point| !ROOT.contains(*point))
+                {
+                    assert_eq!(frame.buffer_mut()[position], before[position]);
+                }
+                let blank = Buffer::empty(before.area);
+                // Check both the initial terminal draw and a redraw over existing chrome.
+                for previous in [&blank, &before] {
+                    let updates = previous.diff(frame.buffer_mut());
+                    for &(x, y, cell) in &updates {
+                        if ROOT.contains(Position::new(x, y)) {
+                            assert!(
+                                x + cell.cell_width() <= ROOT.right(),
+                                "diff emits {:?} at ({x}, {y}), width {}; host x=26 emitted: {}",
+                                cell.symbol(),
+                                cell.cell_width(),
+                                updates.iter().any(|&(x, y, _)| x == 26 && y == 7)
+                            );
+                        }
+                    }
+                    assert_eq!(
+                        updates.iter().any(|&(x, y, cell)| x == glyph_x
+                            && y == 7
+                            && cell.symbol() == "\u{754c}"),
+                        visible,
+                        "only whole glyphs should reach the terminal, source x={glyph_x}"
+                    );
+                }
+                let edge = glyph_x.max(ROOT.x);
+                assert_eq!(
+                    frame.buffer_mut()[(edge, 7)].symbol(),
+                    if visible { "\u{754c}" } else { " " }
+                );
+                if glyph_x >= ROOT.x {
+                    assert_eq!(frame.buffer_mut()[(edge, 7)].fg, Color::Green);
+                }
+            })
+            .expect("draw");
+        assert_eq!(driver.cell(7, 7).symbol(), "#");
+        assert_eq!(driver.cell(26, 7).symbol(), "#");
+    }
+}
+
+fn render_hosted(
+    declare: impl FnOnce(&mut DeclareCtx<'_, (), &'static str>),
+) -> Driver<(), &'static str> {
+    let mut driver = Driver::new(40, 18);
+    driver
+        .terminal
+        .draw(|frame| {
+            for cell in &mut frame.buffer_mut().content {
+                cell.set_symbol("#")
+                    .set_fg(Color::Yellow)
+                    .set_bg(Color::Blue);
+            }
+            let before = frame.buffer_mut().clone();
+            driver
+                .ratcn
+                .render(frame, ROOT, &(), &Theme::default_dark(), |ctx| {
+                    assert_eq!(ctx.area(), ROOT);
+                    assert_eq!(ctx.frame_area(), ROOT);
+                    declare(ctx);
+                });
+            for position in before
+                .area
+                .positions()
+                .filter(|point| !ROOT.contains(*point))
+            {
+                assert_eq!(
+                    frame.buffer_mut()[position],
+                    before[position],
+                    "host chrome changed at {position:?}"
+                );
+            }
+        })
+        .expect("draw");
+    driver
+}
+
+#[test]
+fn select_at_the_bottom_of_an_offset_root_keeps_its_options_visible_inside() {
+    let mut driver = render_hosted(|ctx| {
+        ctx.component(
+            "fruit",
+            Select::new(["Mango", "Papaya", "Lychee"].map(|label| ListItem::new(label, label)))
+                .open(|(): &()| true, |_| "open")
+                .selection(|(): &()| None, |value| value),
+            Rect::new(ROOT.x + 1, ROOT.bottom() - 1, 14, 1),
+        );
+    });
+
+    // Clipping a panel still placed against the terminal would lose options.
+    for (row, label) in [(7, "Mango"), (8, "Papaya"), (9, "Lychee")] {
+        assert!(driver.row(row).contains(label), "{}", driver.row(row));
+    }
+    assert_eq!(
+        driver.event(
+            mouse(MouseKind::Click(MouseButton::Left), ROOT.x + 4, 8),
+            &()
+        ),
+        EventResult::Emit("Papaya"),
+        "the relocated option still accepts absolute screen coordinates"
+    );
+}
+
+#[test]
+fn tooltip_at_the_top_of_an_offset_root_flips_below_and_clamps_horizontally() {
+    let mut driver = render_hosted(|ctx| {
+        ctx.component(
+            "tip",
+            Tooltip::new("Save the file")
+                .side(TooltipSide::Top)
+                .open_when(|(): &(), _| true)
+                .trigger(|ctx| {
+                    ctx.component("save", Button::new("Save").on_press(|| "save"), ctx.area());
+                }),
+            Rect::new(ROOT.x, ROOT.y, 6, 1),
+        );
+    });
+
+    assert!(driver.row(ROOT.y).contains("Save"));
+    assert!(
+        driver.row(ROOT.y + 2).contains("Save the file"),
+        "the whole explanation must move below the trigger, not merely be clipped"
+    );
+    assert_eq!(
+        driver.event(
+            mouse(MouseKind::Click(MouseButton::Left), ROOT.x + 1, ROOT.y),
+            &()
+        ),
+        EventResult::Emit("save")
+    );
+}
+
+#[test]
+fn oversized_modal_dims_and_copies_only_inside_the_root() {
+    let driver = render_hosted(|ctx| {
+        ctx.modal_scope(
+            "modal",
+            Rect::new(2, 1, 34, 14),
+            ScopeOptions::default(),
+            |ctx| {
+                assert_eq!(ctx.frame_area(), ROOT);
+                ctx.paint_widget(Line::from("M".repeat(34)), Rect::new(2, 7, 34, 1));
+                ctx.paint_widget(Paragraph::new("V\n".repeat(14)), Rect::new(9, 1, 1, 14));
+            },
+        );
+    });
+
+    for position in ROOT.positions() {
+        let cell = &driver.buffer()[position];
+        if position.x == 9 {
+            assert_eq!(
+                cell.symbol(),
+                "V",
+                "the vertical strip must composite inside"
+            );
+        } else if position.y == 7 {
+            assert_eq!(cell.symbol(), "M", "the modal must still composite inside");
+        } else {
+            assert_eq!(cell.symbol(), "#", "unpainted backdrop retains its glyphs");
+            assert_ne!(cell.fg, Color::Yellow, "backdrop foreground must dim");
+            assert_ne!(cell.bg, Color::Blue, "backdrop background must dim");
+        }
+    }
+}
+
+#[test]
+fn viewport_popup_keeps_logical_root_bounds_and_projects_once() {
+    let mut driver = render_hosted(|ctx| {
+        ctx.viewport(Rect::new(10, 6, 12, 3), 12, 3, |ctx| {
+            let logical_root = Rect::new(8, 7, 18, 7);
+            assert_eq!(ctx.area(), Rect::new(10, 6, 12, 12));
+            assert_eq!(ctx.frame_area(), logical_root);
+            ctx.scope(
+                "anchor",
+                Rect::new(10, 9, 8, 1),
+                ScopeOptions::default(),
+                |ctx| {
+                    assert_eq!(ctx.frame_area(), logical_root);
+                    ctx.popup("popup", logical_root, PopupOptions::default(), |ctx| {
+                        assert_eq!(ctx.area(), logical_root);
+                        assert_eq!(ctx.frame_area(), logical_root);
+                        ctx.component(
+                            "button",
+                            Button::new("Go").on_press(|| "popup"),
+                            Rect::new(10, 9, 6, 1),
+                        );
+                        ctx.defer_paint(move |ctx| {
+                            assert_eq!(ctx.area(), logical_root);
+                            ctx.widget(Line::from("T"), Rect::new(8, 7, 1, 1));
+                            ctx.widget(Line::from("B"), Rect::new(8, 13, 1, 1));
+                        });
+                    });
+                },
+            );
+        });
+    });
+
+    assert_eq!(driver.cell(ROOT.x, ROOT.y).symbol(), "T");
+    assert_eq!(driver.cell(ROOT.x, ROOT.bottom() - 1).symbol(), "B");
+    assert!(driver.row(6).contains("Go"));
+    assert_eq!(
+        driver.event(mouse(MouseKind::Click(MouseButton::Left), 11, 6), &()),
+        EventResult::Emit("popup"),
+        "popup input is translated once, just like its paint"
+    );
+}
+
+#[test]
+fn viewport_modal_restores_screen_root_bounds_and_can_open_its_own_viewport() {
+    let mut driver = render_hosted(|ctx| {
+        ctx.viewport(Rect::new(10, 6, 12, 3), 12, 3, |ctx| {
+            ctx.modal_scope(
+                "modal",
+                Rect::new(11, 10, 8, 3),
+                ScopeOptions::default(),
+                |ctx| {
+                    assert_eq!(ctx.area(), Rect::new(11, 7, 8, 3));
+                    assert_eq!(ctx.frame_area(), ROOT);
+                    ctx.viewport(Rect::new(11, 7, 8, 2), 6, 2, |ctx| {
+                        assert_eq!(ctx.frame_area(), Rect::new(8, 6, 18, 7));
+                        ctx.component(
+                            "button",
+                            Button::new("Go").on_press(|| "modal"),
+                            Rect::new(11, 9, 6, 1),
+                        );
+                    });
+                },
+            );
+            assert_eq!(ctx.frame_area(), Rect::new(8, 7, 18, 7));
+        });
+        assert_eq!(ctx.frame_area(), ROOT);
+    });
+
+    assert!(driver.row(7).contains("Go"));
+    assert_eq!(
+        driver.event(mouse(MouseKind::Click(MouseButton::Left), 12, 7), &()),
+        EventResult::Emit("modal")
+    );
+}
+
+#[test]
+fn root_area_guides_deferred_paint_but_does_not_sandbox_base_writes() {
+    let mut driver = Driver::<(), ()>::new(40, 18);
+    driver
+        .terminal
+        .draw(|frame| {
+            let destination = frame.area();
+            driver
+                .ratcn
+                .render(frame, ROOT, &(), &Theme::default_dark(), |ctx| {
+                    ctx.paint_widget(Line::from("W"), Rect::new(1, 0, 1, 1));
+                    ctx.defer_paint(move |ctx| {
+                        assert_eq!(ctx.area(), ROOT);
+                        ctx.with_buffer(|buffer| {
+                            assert_eq!(buffer.area, destination);
+                            buffer[(0, 0)].set_symbol("D");
+                        });
+                    });
+                });
+        })
+        .expect("draw");
+
+    assert_eq!(driver.cell(0, 0).symbol(), "D");
+    assert_eq!(driver.cell(1, 0).symbol(), "W");
+}

--- a/crates/ratcn/src/runtime/engine/tests/mod.rs
+++ b/crates/ratcn/src/runtime/engine/tests/mod.rs
@@ -21,6 +21,7 @@ use crate::{
 mod declaration;
 mod focus;
 mod gesture;
+mod hosting;
 mod hover;
 mod modal;
 mod paint;

--- a/crates/ratcn/src/runtime/engine/tests/modal.rs
+++ b/crates/ratcn/src/runtime/engine/tests/modal.rs
@@ -3,6 +3,74 @@
 
 use super::*;
 
+#[test]
+fn a_modal_opened_over_no_focus_takes_focus_and_restores_none_on_close() {
+    let mut state = ModalTestState {
+        focus: FocusState::none(),
+        ..ModalTestState::default()
+    };
+    let mut driver = Driver::with(
+        Ratcn::new()
+            .focus(|state: &ModalTestState| &state.focus, ModalTestMsg::Focus)
+            .modals(|state: &ModalTestState| &state.modals),
+        10,
+        1,
+    );
+    let render = |driver: &mut Driver<ModalTestState, ModalTestMsg>, state: &ModalTestState| {
+        let area = driver.area();
+        driver.render(state, |ctx| {
+            ctx.component(
+                "base",
+                Button::new("Base").on_press(|| ModalTestMsg::Routed("base")),
+                area,
+            );
+            if state.modals.is_open("dialog") {
+                ctx.modal(
+                    "dialog",
+                    Button::new("OK").on_press(|| ModalTestMsg::Routed("dialog")),
+                    area,
+                );
+            }
+        });
+    };
+
+    state.modals.open("dialog", &mut state.focus).expect("open");
+    assert_eq!(state.focus, FocusState::default());
+    render(&mut driver, &state);
+    assert_eq!(driver.ratcn.resolved_focus, FocusState::intent(["dialog"]));
+    assert_eq!(
+        driver.event(Event::Key(KeyEvent::new(KeyCode::Enter)), &state),
+        EventResult::Emit(ModalTestMsg::Routed("dialog"))
+    );
+
+    state.focus = FocusState::none();
+    render(&mut driver, &state);
+    assert!(
+        driver.ratcn.resolved_focus.is_none(),
+        "explicit none wins over modal takeover"
+    );
+    let EventResult::Emit(ModalTestMsg::Focus(focus)) =
+        driver.event(Event::Key(KeyEvent::new(KeyCode::Tab)), &state)
+    else {
+        panic!("Tab must re-enter the modal from none");
+    };
+    state.focus = focus;
+    assert_eq!(state.focus, FocusState::intent(["dialog"]));
+
+    assert_eq!(
+        state.modals.close(&mut state.focus),
+        Some(ChildId::Static("dialog"))
+    );
+    assert_eq!(state.focus, FocusState::none());
+    render(&mut driver, &state);
+    assert!(driver.ratcn.resolved_focus.is_none());
+    assert_eq!(
+        driver.event(Event::Key(KeyEvent::new(KeyCode::Enter)), &state),
+        EventResult::Ignored,
+        "closing the modal must not silently focus the first base control"
+    );
+}
+
 struct ModalRoute(&'static str);
 
 impl Component<ModalTestState, ModalTestMsg> for ModalRoute {

--- a/crates/ratcn/src/runtime/engine/tests/paint.rs
+++ b/crates/ratcn/src/runtime/engine/tests/paint.rs
@@ -230,7 +230,7 @@ fn a_pass_rejected_by_the_modal_stack_never_touches_the_screen() {
             // Nothing is open in the app's stack, so this modal root is a
             // declaration the runtime refuses to retain.
             let rejected = catch_unwind(AssertUnwindSafe(|| {
-                ratcn.render(frame, &state, &theme, |ctx| {
+                ratcn.render(frame, area, &state, &theme, |ctx| {
                     ctx.modal(ChildId::Static("sheet"), GlyphLeaf("B"), area);
                 });
             }));
@@ -278,7 +278,7 @@ fn a_rejected_pass_never_paints_its_base_layer_either() {
             let area = frame.area();
             frame.render_widget(ratatui::text::Line::from("A"), area);
             let rejected = catch_unwind(AssertUnwindSafe(|| {
-                ratcn.render(frame, &state, &theme, |ctx| {
+                ratcn.render(frame, area, &state, &theme, |ctx| {
                     // Base-layer content, which paints straight onto the
                     // frame, declared alongside the modal root the app's
                     // empty stack refuses.

--- a/crates/ratcn/src/runtime/engine/tests/viewport.rs
+++ b/crates/ratcn/src/runtime/engine/tests/viewport.rs
@@ -228,9 +228,10 @@ fn a_caught_viewport_paint_panic_writes_nothing_and_commits() {
                 // The backend clears between draws, so the frame this pass
                 // must leave alone is painted back first.
                 frame.render_widget(Paragraph::new("stable"), Rect::new(0, 0, 6, 1));
+                let area = frame.area();
                 driver
                     .ratcn
-                    .render(frame, &State, &Theme::default_dark(), move |ctx| {
+                    .render(frame, area, &State, &Theme::default_dark(), move |ctx| {
                         ctx.viewport(Rect::new(0, 0, 2, 1), 2, 0, move |ctx| {
                             ctx.paint(move |ctx| {
                                 let caught = catch_unwind(AssertUnwindSafe(|| {
@@ -285,7 +286,7 @@ fn a_caught_layer_paint_panic_composites_nothing_and_commits() {
             frame.render_widget(Paragraph::new("stable"), Rect::new(0, 0, 6, 1));
             driver
                 .ratcn
-                .render(frame, &State, &Theme::default_dark(), |ctx| {
+                .render(frame, frame.area(), &State, &Theme::default_dark(), |ctx| {
                     ctx.popup(
                         "popup",
                         Rect::new(0, 0, 4, 1),

--- a/crates/ratcn/src/runtime/engine/tests/viewport.rs
+++ b/crates/ratcn/src/runtime/engine/tests/viewport.rs
@@ -742,6 +742,49 @@ fn render_reveal(
     });
 }
 
+#[test]
+fn explicit_no_focus_cancels_a_pending_reveal_without_scrolling_to_a_late_target() {
+    let log = RevealLog::default();
+    let mut driver = reveal_driver();
+    let mut state = RevealState {
+        focus: FocusState::none(),
+        ..RevealState::default()
+    };
+    render_reveal(&mut driver, &state, &log);
+    assert!(
+        !driver.ratcn.reveal_pending,
+        "starting blurred owes no reveal"
+    );
+
+    state.focus = FocusState::intent(["area", "late"]);
+    render_reveal(&mut driver, &state, &log);
+    render_reveal(&mut driver, &state, &log);
+    assert!(
+        driver.ratcn.reveal_pending,
+        "an absent explicit target still waits"
+    );
+
+    state.focus = FocusState::none();
+    render_reveal(&mut driver, &state, &log);
+    assert!(
+        !driver.ratcn.reveal_pending,
+        "explicit none completes the pending reveal"
+    );
+    state.late = true;
+    render_reveal(&mut driver, &state, &log);
+    render_reveal(&mut driver, &state, &log);
+    assert!(!driver.ratcn.reveal_pending);
+    assert!(
+        log.borrow().is_empty(),
+        "the cancelled target must not scroll the viewport"
+    );
+
+    state.focus = FocusState::intent(["area", "late"]);
+    render_reveal(&mut driver, &state, &log);
+    assert_eq!(log.borrow().as_slice(), [Rect::new(0, 3, 4, 1)]);
+    assert!(!driver.ratcn.reveal_pending);
+}
+
 /// Focus the runtime moves itself reveals its destination: the app stores the
 /// path the focus message carried, and the frame that reads it back asks the
 /// viewport for it.

--- a/crates/ratcn/src/runtime/focus.rs
+++ b/crates/ratcn/src/runtime/focus.rs
@@ -35,15 +35,49 @@ use super::ChildId;
 ///
 /// Events that arrive before the first successful render are ignored, so an
 /// unresolved empty path never receives input.
+///
+/// # Explicitly no focus
+///
+/// [`none`](Self::none) means "nothing focused", unlike the default or an
+/// empty [`intent`](Self::intent). It paints no component as focused, even
+/// inside a modal. This is not an input-disable switch: Tab and Shift+Tab
+/// enter the first and last eligible targets, root focus keys still work,
+/// and pointer input can focus a control. The host decides which events to
+/// deliver to an inactive tree.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FocusState {
     pub(crate) path: Vec<ChildId>,
+    blurred: bool,
 }
 
 /// The empty path, borrowable: what a runtime with no focus binding reads.
-pub(crate) static UNRESOLVED: FocusState = FocusState { path: Vec::new() };
+pub(crate) static UNRESOLVED: FocusState = FocusState {
+    path: Vec::new(),
+    blurred: false,
+};
 
 impl FocusState {
+    /// Nothing is focused. Distinct from `default()`, which asks the runtime
+    /// to choose the first focusable leaf.
+    ///
+    /// The path is empty and every [`contains_path`](Self::contains_path)
+    /// query is false, including an empty query. Input is still enabled:
+    /// traversal, focus keys, and pointer focus can enter the tree again.
+    #[must_use]
+    pub fn none() -> Self {
+        Self {
+            path: Vec::new(),
+            blurred: true,
+        }
+    }
+
+    /// Whether this explicitly requests no focus, rather than default focus
+    /// or a path that happens to name no declared component.
+    #[must_use]
+    pub const fn is_none(&self) -> bool {
+        self.blurred
+    }
+
     /// Build a focus path directly, without checking that it exists.
     ///
     /// The constructor for a path already in hand: an app jumping to a pane
@@ -55,10 +89,12 @@ impl FocusState {
     ///
     /// Stopping the path at a container is fine and usual — the runtime
     /// descends from there to that container's first focusable leaf.
+    /// An empty path asks for default focus, not [`none`](Self::none).
     #[must_use]
     pub fn intent(path: impl IntoIterator<Item = impl Into<ChildId>>) -> Self {
         Self {
             path: path.into_iter().map(Into::into).collect(),
+            blurred: false,
         }
     }
 
@@ -69,13 +105,19 @@ impl FocusState {
     /// [`PaintCtx::contains_focus`](super::PaintCtx::contains_focus) flag a
     /// component sees, useful for things like accenting a pane whose contents
     /// hold focus.
+    /// Always false for [`none`](Self::none), including an empty query.
     #[must_use]
     pub fn contains_path(&self, path: impl IntoIterator<Item = impl Into<ChildId>>) -> bool {
+        if self.blurred {
+            return false;
+        }
         let mut ids = self.path.iter();
         path.into_iter().all(|id| ids.next() == Some(&id.into()))
     }
 
     /// The focus path, root declaration's child first, leaf last.
+    /// Empty for both default focus and [`none`](Self::none); use
+    /// [`is_none`](Self::is_none) to distinguish them.
     #[must_use]
     pub fn path(&self) -> &[ChildId] {
         &self.path
@@ -85,6 +127,24 @@ impl FocusState {
 #[cfg(test)]
 mod tests {
     use super::FocusState;
+
+    #[test]
+    fn no_focus_is_distinct_from_default_and_matches_no_subtree() {
+        let empty: [&str; 0] = [];
+        let none = FocusState::none();
+        assert!(none.is_none());
+        assert!(none.path().is_empty());
+        assert_eq!(none.clone(), none);
+        assert_ne!(none, FocusState::default());
+        assert!(!none.contains_path(empty));
+        assert!(!none.contains_path(["pane"]));
+        assert!(!none.contains_path(["pane", "save"]));
+
+        assert_eq!(FocusState::intent(empty), FocusState::default());
+        assert_eq!(super::UNRESOLVED, FocusState::default());
+        assert!(!FocusState::default().is_none());
+        assert!(!FocusState::intent(["absent"]).is_none());
+    }
 
     #[test]
     fn contains_path_matches_prefixes_of_the_path() {

--- a/crates/ratcn/src/runtime/modal.rs
+++ b/crates/ratcn/src/runtime/modal.rs
@@ -53,9 +53,10 @@ impl ModalState {
     /// Push `id` onto the stack and move focus into it.
     ///
     /// `focus` is your app's focus state, taken by `&mut` because this does two
-    /// things with it: it copies the current path into this modal's saved
-    /// history, then clears it, so the newly opened layer resolves focus to
-    /// its own first focusable leaf. [`close`](Self::close) reverses both.
+    /// things with it: it saves the current snapshot, including explicit
+    /// [`FocusState::none`], then replaces it with `FocusState::default()` so
+    /// the newly opened layer resolves focus to its own first focusable leaf.
+    /// [`close`](Self::close) reverses both.
     ///
     /// Re-opening whatever is already on top is a no-op — it will not overwrite
     /// the focus that modal saved when it first opened.
@@ -89,7 +90,7 @@ impl ModalState {
     ///
     /// The restored path is the exact one that was current when that modal
     /// opened, including a path whose component is not declared — focus parks
-    /// there.
+    /// there. A saved [`FocusState::none`] restores no focus.
     ///
     /// Returns the closed modal id, or `None` when the stack is already empty,
     /// in which case `focus` is left alone.

--- a/crates/ratcn/src/test_support.rs
+++ b/crates/ratcn/src/test_support.rs
@@ -50,7 +50,7 @@ impl<State, Msg> Driver<State, Msg> {
         let theme = Theme::default_dark();
         let Self { terminal, ratcn } = self;
         terminal
-            .draw(|frame| ratcn.render(frame, state, &theme, declare))
+            .draw(|frame| ratcn.render(frame, frame.area(), state, &theme, declare))
             .expect("draw");
     }
 

--- a/crates/ratcn/tests/render_api.rs
+++ b/crates/ratcn/tests/render_api.rs
@@ -1,9 +1,17 @@
 //! Integration tests for the public render and event-routing entry points.
 
-use ratatui::{Terminal, backend::TestBackend};
+use ratatui::{
+    Terminal,
+    backend::TestBackend,
+    buffer::{Buffer, Cell},
+    layout::Rect,
+    style::{Color, Style},
+    text::Line,
+    widgets::Block,
+};
 use ratcn::runtime::{
     ChildId, Component, DeclareCtx, Event, EventResult, FocusState, KeyCode, KeyEvent, PaintCtx,
-    Ratcn, ScopeOptions,
+    PopupOptions, Ratcn, ScopeOptions,
 };
 use ratcn::{Dialog, Theme};
 
@@ -85,4 +93,128 @@ fn unified_render_apis_are_usable_from_an_external_crate() {
         ratcn.handle_event(Event::Key(KeyEvent::new(KeyCode::Enter)), &state),
         EventResult::Emit(Msg::Activated)
     );
+}
+
+fn layered_surface(ctx: &mut DeclareCtx<'_, State, Msg>) {
+    let area = ctx.area();
+    ctx.paint_widget(
+        Block::new().style(Style::new().fg(Color::Yellow).bg(Color::Blue)),
+        area,
+    );
+    ctx.modal_scope("modal", area, ScopeOptions::default(), |ctx| {
+        ctx.viewport(Rect::new(area.x + 2, area.y + 2, 12, 2), 8, 3, |ctx| {
+            let row = Rect::new(area.x + 2, area.y + 5, 12, 1);
+            ctx.component("probe", Probe, row);
+            ctx.paint_widget(Line::from("scrolled"), row);
+            ctx.popup(
+                "popup",
+                Rect::new(area.x + 2, area.y + 7, 12, 1),
+                PopupOptions::default(),
+                |ctx| ctx.paint_widget(Line::from("popup"), ctx.area()),
+            );
+        });
+        ctx.defer_paint(move |ctx| {
+            ctx.widget(
+                Line::from("modal"),
+                Rect::new(area.x + 18, area.y + 8, 8, 1),
+            );
+        });
+    });
+    ctx.defer_paint(move |ctx| {
+        ctx.widget(Line::from("root"), Rect::new(area.x, area.y, 4, 1));
+    });
+}
+
+#[test]
+fn offscreen_rendering_matches_frame_cells_and_retains_the_same_interactive_tree() {
+    let state = State {
+        marker: 7,
+        ..State::default()
+    };
+    let theme = Theme::default_dark();
+    let area = Rect::new(4, 2, 30, 12);
+    let mut direct = Buffer::filled(Rect::new(0, 0, 40, 18), Cell::new("#"));
+    let mut frame_runtime = Ratcn::new();
+    let mut buffer_runtime = Ratcn::new();
+    let mut terminal = Terminal::new(TestBackend::new(40, 18)).expect("terminal");
+
+    terminal
+        .draw(|frame| {
+            *frame.buffer_mut() = direct.clone();
+            frame_runtime.render(frame, area, &state, &theme, layered_surface);
+            buffer_runtime.render_into(&mut direct, area, &state, &theme, layered_surface);
+            assert_eq!(frame.buffer_mut(), &direct);
+        })
+        .expect("draw");
+
+    // Both paths must actually composite, project the viewport, and flush each layer.
+    assert_eq!(direct[(6, 4)].symbol(), "s");
+    assert_eq!(direct[(6, 6)].symbol(), "p");
+    assert_eq!(direct[(22, 10)].symbol(), "m");
+    assert_eq!(direct[(4, 2)].symbol(), "r");
+    assert_ne!(
+        direct[(33, 3)].bg,
+        Color::Blue,
+        "the modal backdrop must dim"
+    );
+    assert_eq!(direct[(0, 0)].symbol(), "#");
+    for runtime in [&mut frame_runtime, &mut buffer_runtime] {
+        assert_eq!(
+            runtime.handle_event(Event::Key(KeyEvent::new(KeyCode::Enter)), &state),
+            EventResult::Emit(Msg::Activated),
+            "offscreen rendering still commits a surface that routes input"
+        );
+    }
+}
+
+#[test]
+fn a_tall_offset_buffer_keeps_below_fold_content_without_clearing_untouched_cells() {
+    let allocation = Rect::new(7, 11, 24, 200);
+    let area = Rect::new(9, 13, 20, 196);
+    let mut buffer = Buffer::filled(allocation, Cell::new("#"));
+    let mut runtime = Ratcn::<(), ()>::new();
+    runtime.render_into(&mut buffer, area, &(), &Theme::default_dark(), |ctx| {
+        assert_eq!(ctx.area(), area);
+        assert_eq!(ctx.frame_area(), area);
+        ctx.paint_widget(Line::from("Top"), Rect::new(area.x, area.y, area.width, 1));
+        ctx.paint_widget(
+            Line::from("Below fold"),
+            Rect::new(area.x, area.bottom() - 1, area.width, 1),
+        );
+    });
+
+    let bottom: String = (area.x..area.right())
+        .map(|x| buffer[(x, area.bottom() - 1)].symbol())
+        .collect();
+    assert!(bottom.starts_with("Below fold"), "{bottom}");
+    assert_eq!(buffer[(9, 13)].symbol(), "T");
+    assert_eq!(buffer.area, allocation, "the caller owns the allocation");
+    assert_eq!(
+        buffer[(9, 100)].symbol(),
+        "#",
+        "rendering does not clear the page"
+    );
+    assert_eq!(buffer[(7, 11)].symbol(), "#");
+}
+
+#[test]
+fn rendering_into_a_frame_buffer_releases_the_borrow_for_host_widgets() {
+    let mut terminal = Terminal::new(TestBackend::new(16, 6)).expect("terminal");
+    let mut runtime = Ratcn::<(), ()>::new();
+    terminal
+        .draw(|frame| {
+            runtime.render_into(
+                frame.buffer_mut(),
+                Rect::new(3, 2, 8, 1),
+                &(),
+                &Theme::default_dark(),
+                |ctx| ctx.paint_widget(Line::from("tree"), ctx.area()),
+            );
+            frame.render_widget(Line::from("host"), Rect::new(3, 3, 8, 1));
+        })
+        .expect("draw");
+
+    let buffer = terminal.backend().buffer();
+    assert_eq!(buffer[(3, 2)].symbol(), "t");
+    assert_eq!(buffer[(3, 3)].symbol(), "h");
 }

--- a/crates/ratcn/tests/render_api.rs
+++ b/crates/ratcn/tests/render_api.rs
@@ -63,7 +63,7 @@ fn unified_render_apis_are_usable_from_an_external_crate() {
     terminal
         .draw(|frame| {
             let area = frame.area();
-            ratcn.render(frame, &state, &theme, |ctx| {
+            ratcn.render(frame, area, &state, &theme, |ctx| {
                 ctx.scope(
                     ChildId::Static("view"),
                     area,

--- a/demos/button-large/src/main.rs
+++ b/demos/button-large/src/main.rs
@@ -81,7 +81,7 @@ impl demo_shared::Demo for App {
             .set_style(area, Style::default().bg(theme.background));
 
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, area, state, theme, |ctx| {
             let buttons = BUTTONS.map(|(id, label)| {
                 let button = Button::new(label)
                     .size(ButtonSize::Large)

--- a/demos/button-small/src/main.rs
+++ b/demos/button-small/src/main.rs
@@ -79,7 +79,7 @@ impl demo_shared::Demo for App {
             .set_style(area, Style::default().bg(theme.background));
 
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, area, state, theme, |ctx| {
             let buttons = BUTTONS.map(|(id, label)| {
                 let button = Button::new(label)
                     .size(ButtonSize::Small)

--- a/demos/checkbox/src/main.rs
+++ b/demos/checkbox/src/main.rs
@@ -85,7 +85,7 @@ impl demo_shared::Demo for App {
             .set_style(area, Style::default().bg(theme.background));
 
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, area, state, theme, |ctx| {
             let demo = area.centered(
                 Constraint::Length(DEMO_WIDTH),
                 Constraint::Length(DEMO_HEIGHT),

--- a/demos/cycle/src/main.rs
+++ b/demos/cycle/src/main.rs
@@ -89,7 +89,7 @@ impl demo_shared::Demo for App {
             .set_style(area, Style::default().bg(theme.background));
 
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, area, state, theme, |ctx| {
             let demo = area.centered(
                 Constraint::Length(DEMO_WIDTH),
                 Constraint::Length(DEMO_HEIGHT),

--- a/demos/dialog/src/main.rs
+++ b/demos/dialog/src/main.rs
@@ -153,7 +153,7 @@ impl demo_shared::Demo for App {
         frame
             .buffer_mut()
             .set_style(area, Style::default().bg(theme.background));
-        self.ratcn.render(frame, &self.state, theme, |ctx| {
+        self.ratcn.render(frame, area, &self.state, theme, |ctx| {
             let open_button = Button::new("Open Dialog").on_press(|| Msg::OpenDialog);
             let button_area = area.centered(
                 Constraint::Length(open_button.width()),

--- a/demos/drag/src/main.rs
+++ b/demos/drag/src/main.rs
@@ -89,7 +89,7 @@ impl demo_shared::Demo for App {
             ),
             self.state.block_offset,
         );
-        self.ratcn.render(frame, &self.state, theme, |ctx| {
+        self.ratcn.render(frame, area, &self.state, theme, |ctx| {
             ctx.component(
                 ids::BLOCK,
                 DraggableBlock {

--- a/demos/effects/src/main.rs
+++ b/demos/effects/src/main.rs
@@ -143,7 +143,7 @@ impl demo_shared::Demo for App {
             .set_style(area, Style::default().bg(theme.background));
 
         let joke = joke_text(&self.state.joke);
-        self.ratcn.render(frame, &self.state, theme, |ctx| {
+        self.ratcn.render(frame, area, &self.state, theme, |ctx| {
             let content_width = area.width.min(CONTENT_WIDTH);
             let joke_height = wrapped_height(&joke, content_width).max(1);
             let content_height = joke_height + 1 + ButtonSize::Large.height();

--- a/demos/kanban/src/main.rs
+++ b/demos/kanban/src/main.rs
@@ -116,7 +116,8 @@ impl demo_shared::Demo for App {
             )),
         };
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        let area = board_layout.area;
+        self.ratcn.render(frame, area, state, theme, |ctx| {
             let column_areas = board_layout.column_areas();
             ctx.paint(move |ctx| {
                 for (column_index, column_area) in column_areas.iter().enumerate() {

--- a/demos/landing/src/main.rs
+++ b/demos/landing/src/main.rs
@@ -221,7 +221,7 @@ impl demo_shared::Demo for App {
             .buffer_mut()
             .set_style(frame_area, Style::default().bg(theme.background));
         let state = &self.state;
-        self.ratcn.render(frame, state, &theme, |ctx| {
+        self.ratcn.render(frame, frame_area, state, &theme, |ctx| {
             ctx.paint_widget(header_bar(ctx.theme), header_area(frame_area));
             for (index, tile_area) in tile_areas(frame_area).into_iter().enumerate() {
                 tiles::declare(index, ctx, tile_area);

--- a/demos/landing/src/screensaver.rs
+++ b/demos/landing/src/screensaver.rs
@@ -147,7 +147,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let area = frame.area();
-                ratcn.render(frame, &state, &theme, |ctx| {
+                ratcn.render(frame, area, &state, &theme, |ctx| {
                     ctx.paint_widget(Line::from("A"), area);
                     declare(ctx, area, Duration::ZERO);
                 });

--- a/demos/ledger93/src/app.rs
+++ b/demos/ledger93/src/app.rs
@@ -118,7 +118,7 @@ impl demo_shared::Demo for App {
             )
             .inner(Margin::new(PADDING_X, PADDING_Y));
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, area, state, theme, |ctx| {
             let [title, _gap, tabs, content, status] = area.layout(&shell_layout());
 
             ctx.paint_widget(

--- a/demos/list-multi/src/main.rs
+++ b/demos/list-multi/src/main.rs
@@ -113,7 +113,7 @@ impl demo_shared::Demo for App {
             .set_style(area, Style::default().bg(theme.background));
 
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, area, state, theme, |ctx| {
             let muted = ctx.theme.muted_foreground;
             let list = List::new(TOPICS.map(|label| ListItem::new(label, label)))
                 .item_focus(|s: &AppState| s.focused_topic, Msg::TopicFocusChanged)

--- a/demos/list-people/src/main.rs
+++ b/demos/list-people/src/main.rs
@@ -115,7 +115,7 @@ impl demo_shared::Demo for App {
             .set_style(area, Style::default().bg(theme.background));
 
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, area, state, theme, |ctx| {
             let muted = ctx.theme.muted_foreground;
             let list = List::new(PEOPLE.map(|(name, _)| ListItem::new(name, name)))
                 .item_focus(|s: &AppState| s.focused_person, Msg::PersonFocusChanged)

--- a/demos/list/src/main.rs
+++ b/demos/list/src/main.rs
@@ -118,7 +118,7 @@ impl demo_shared::Demo for App {
             .buffer_mut()
             .set_style(area, Style::default().bg(theme.background));
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, area, state, theme, |ctx| {
             let muted = ctx.theme.muted_foreground;
             let list = List::new(FOLDERS.map(|label| ListItem::new(label, label)))
                 .item_focus(

--- a/demos/panels/src/main.rs
+++ b/demos/panels/src/main.rs
@@ -128,7 +128,7 @@ impl demo_shared::Demo for App {
         let area = area.inner(Margin::new(PADDING_X, PADDING_Y));
         let state = &self.state;
         let panels_layout = Layout::vertical([Constraint::Fill(1); 2]).spacing(1);
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, area, state, theme, |ctx| {
             let [panel_a_area, panel_b_area] = area.layout(&panels_layout);
             ctx.scope(ids::PANEL_A, panel_a_area, Self::panel_options(), |ctx| {
                 Self::panel(ctx, PanelId::A, &[ids::A1, ids::A2]);

--- a/demos/scroll-area/src/main.rs
+++ b/demos/scroll-area/src/main.rs
@@ -96,7 +96,7 @@ impl demo_shared::Demo for App {
             .set_style(area, Style::default().bg(theme.background));
 
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, area, state, theme, |ctx| {
             let [column] = Layout::horizontal([Constraint::Length(VIEWPORT_WIDTH)])
                 .flex(Flex::Center)
                 .areas(area);

--- a/demos/select/src/main.rs
+++ b/demos/select/src/main.rs
@@ -88,7 +88,7 @@ impl demo_shared::Demo for App {
         let [select_area] = Layout::vertical([Constraint::Length(1)])
             .flex(Flex::Center)
             .areas(column);
-        self.ratcn.render(frame, &self.state, theme, |ctx| {
+        self.ratcn.render(frame, area, &self.state, theme, |ctx| {
             ctx.component(
                 "fruit",
                 Select::new(FRUITS.map(|fruit| ListItem::new(fruit, fruit)))

--- a/demos/tabs-automatic/src/main.rs
+++ b/demos/tabs-automatic/src/main.rs
@@ -109,7 +109,7 @@ impl demo_shared::Demo for App {
             .buffer_mut()
             .set_style(area, Style::default().bg(theme.background));
         let state = &self.state;
-        self.ratcn.render(frame, state, &theme, |ctx| {
+        self.ratcn.render(frame, area, state, &theme, |ctx| {
             let tabs = Tabs::new([
                 Tab::new(Screen::Overview, "Overview"),
                 Tab::new(Screen::Analytics, "Analytics"),

--- a/demos/tabs-basic/src/main.rs
+++ b/demos/tabs-basic/src/main.rs
@@ -115,7 +115,7 @@ impl demo_shared::Demo for App {
             .buffer_mut()
             .set_style(area, Style::default().bg(theme.background));
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, area, state, theme, |ctx| {
             let tabs = Tabs::new([
                 Tab::new(Screen::Overview, "Overview"),
                 Tab::new(Screen::Analytics, "Analytics"),

--- a/demos/tabs-disabled/src/main.rs
+++ b/demos/tabs-disabled/src/main.rs
@@ -116,7 +116,7 @@ impl demo_shared::Demo for App {
             .buffer_mut()
             .set_style(area, Style::default().bg(theme.background));
         let state = &self.state;
-        self.ratcn.render(frame, state, &theme, |ctx| {
+        self.ratcn.render(frame, area, state, &theme, |ctx| {
             let tabs = Tabs::new([
                 Tab::new(Screen::Overview, "Overview"),
                 Tab::new(Screen::Analytics, "Analytics").disabled(true),

--- a/demos/tabs-large/src/main.rs
+++ b/demos/tabs-large/src/main.rs
@@ -116,7 +116,7 @@ impl demo_shared::Demo for App {
             .buffer_mut()
             .set_style(area, Style::default().bg(theme.background));
         let state = &self.state;
-        self.ratcn.render(frame, state, &theme, |ctx| {
+        self.ratcn.render(frame, area, state, &theme, |ctx| {
             let tabs = Tabs::new([
                 Tab::new(Screen::Overview, "Overview"),
                 Tab::new(Screen::Analytics, "Analytics"),

--- a/demos/toast/src/main.rs
+++ b/demos/toast/src/main.rs
@@ -137,7 +137,7 @@ impl demo_shared::Demo for App {
             .buffer_mut()
             .set_style(area, Style::default().bg(theme.background));
 
-        self.ratcn.render(frame, &self.state, theme, |ctx| {
+        self.ratcn.render(frame, area, &self.state, theme, |ctx| {
             let random_button = Button::new("Make me a toast!")
                 .size(ButtonSize::Large)
                 .on_press(|| Msg::MakeToast);

--- a/demos/tooltip/src/main.rs
+++ b/demos/tooltip/src/main.rs
@@ -161,7 +161,7 @@ impl demo_shared::Demo for App {
             .areas(rest_area);
 
         let state = &self.state;
-        self.ratcn.render(frame, state, theme, |ctx| {
+        self.ratcn.render(frame, area, state, theme, |ctx| {
             let [edge_button_area] =
                 Layout::horizontal([Constraint::Length(button(EDGE.1).width())])
                     .flex(Flex::Center)

--- a/demos/wizard/src/app.rs
+++ b/demos/wizard/src/app.rs
@@ -118,7 +118,7 @@ impl demo_shared::Demo for App {
             )
             .inner(Margin::new(PADDING_X, PADDING_Y));
         let state = &self.state;
-        self.ratcn.render(frame, state, &theme, |ctx| {
+        self.ratcn.render(frame, area, state, &theme, |ctx| {
             let [stepper, panel, buttons] = area.layout(&shell_layout());
             let step = state.nav.step;
 

--- a/docs/docs/components/button.md
+++ b/docs/docs/components/button.md
@@ -26,7 +26,7 @@ Use `ButtonWidget` instead when only paint is needed.
 ```rust
 use ratcn::Button;
 
-ratcn.render(frame, state, &state.theme, |ctx| {
+ratcn.render(frame, save_area, state, &state.theme, |ctx| {
     let save = Button::new("Save")
         .disabled(state.saving)
         .on_press(|| Msg::Save);

--- a/docs/docs/components/dialog.md
+++ b/docs/docs/components/dialog.md
@@ -73,7 +73,8 @@ state.modals.open("confirm", &mut state.focus)?;
 state.modals.close(&mut state.focus);
 
 // In render(), after the base layer:
-ratcn.render(frame, &state, &theme, |ctx| {
+let area = frame.area();
+ratcn.render(frame, area, &state, &theme, |ctx| {
     // ... base content first ...
     if state.modals.is_open("confirm") {
         ctx.modal("confirm", dialog, ctx.area());

--- a/docs/docs/concepts/composition.md
+++ b/docs/docs/concepts/composition.md
@@ -36,7 +36,7 @@ Two panels, each a scope. `a` and `b` jump between them, Tab cycles inside the
 focused one, and Enter or Space presses a button.
 
 ```rust
-ratcn.render(frame, state, &state.theme, |ctx| {
+ratcn.render(frame, panel_a_area, state, &state.theme, |ctx| {
     ctx.scope(
         "panel_a",
         panel_a_area,

--- a/docs/docs/concepts/focus-hover-identity.md
+++ b/docs/docs/concepts/focus-hover-identity.md
@@ -40,10 +40,23 @@ Focus is a path stored in your app state — a `FocusState` bound with
 `Ratcn::focus(read, on_change)`. Focus changes come back as messages for your
 `update` to store, like every other state change.
 
-You never have to compute a starting focus: an empty path means "default
-startup focus", and the runtime resolves it to the first focusable component it
-finds. The first time the user moves focus, your app receives a concrete path
-to store.
+You never have to compute a starting focus: `FocusState::default()` or an empty
+`FocusState::intent(path)` means "default startup focus", and the runtime
+resolves it to the first focusable component it finds. The first time the user
+moves focus, your app receives a concrete path to store.
+
+**No focus.** Store `FocusState::none()` when no component should paint as
+focused, such as in an inactive hosted pane. It is distinct from default focus
+even though both have empty paths: `is_none()` distinguishes them, and
+`contains_path` is false for every query on `none()`, including an empty query.
+Unlike a parked path waiting for its target to appear, `none()` has no pending
+target to reveal.
+
+This does not disable input. Tab enters the first eligible control, Shift+Tab
+the last, root `focus_key` bindings still work, and pointer input can focus a
+control. The host decides which events reach an inactive pane. Explicit no-focus
+also survives modal resolution, but `ModalState::open` saves it and resets focus
+to `default()` so the new modal takes focus; `close` restores the saved `none()`.
 
 **Tab order follows declaration order.** `TabWrap::Wrap` cycles within a scope;
 `TabWrap::Escape` lets Tab leave it and continue in the parent. Shift+Tab walks

--- a/docs/docs/concepts/layers-and-modals.md
+++ b/docs/docs/concepts/layers-and-modals.md
@@ -53,8 +53,8 @@ message, in the same update that opens the popup. Keys bubble *through* the
 popup root to the component that declared it. See [Select](../components/select).
 
 A **modal** is the strongest: it becomes the **active layer**. While it is open
-the area behind is dimmed, keyboard and mouse routing are confined to it, focus
-resolves into it, and input that nothing inside handles is absorbed rather than
+the area behind is dimmed, keyboard and mouse routing are confined to it,
+and input that nothing inside handles is absorbed rather than
 reaching the UI underneath. Declare stacked modals bottom to top.
 
 ## Modal state in your app
@@ -104,8 +104,12 @@ state says are open — a mismatch is a declaration bug and fails the render.
 The binding also covers the brief gap between opening or closing a modal in
 `update` and the redraw that reflects it: events arriving in that gap are
 consumed instead of landing on a layer your state considers closed. Focus
-needs no help from it — any open modal resolves focus into itself, bound or
-not.
+takeover does not require this binding: the topmost eligible modal takes over
+default focus and declared paths it covers, when it has a focusable target.
+Explicit `FocusState::none()` stays unfocused; an intent naming an absent path
+stays parked. Merely declaring a modal does not reset app-held focus.
+Opening a new modal through `ModalState::open` saves that focus and resets it
+to `default()`, allowing the modal to take focus; closing restores the snapshot.
 
 Only modals have semantic state to validate this way. Popups and hints are
 opened by whatever app state your own component reads, and the runtime holds

--- a/docs/docs/concepts/layers-and-modals.md
+++ b/docs/docs/concepts/layers-and-modals.md
@@ -67,7 +67,8 @@ state says it is open:
 ```rust
 state.modals.open("confirm", &mut state.focus)?;
 
-ratcn.render(frame, &state, &state.theme, |ctx| {
+let area = frame.area();
+ratcn.render(frame, area, &state, &state.theme, |ctx| {
     // Base paint and declarations first.
     if state.modals.is_open("confirm") {
         let area = ctx.area();

--- a/docs/docs/concepts/rendering-and-events.md
+++ b/docs/docs/concepts/rendering-and-events.md
@@ -69,6 +69,40 @@ focused, or contains focus, is offered to `PaintCtx`, once the tree is complete
 and focus has resolved. Hover is the exception: `DeclareCtx::pointer_within()`
 answers it while declaring.
 
+## Offscreen rendering
+
+Use `Ratcn::render_into(buffer, area, state, theme, declare)` when the destination
+is your own `ratatui::buffer::Buffer`, for example a page taller than its visible
+window. Ordinary terminal apps should keep using `render`, which delegates to
+the same lifecycle through the frame's buffer.
+
+```rust
+use ratatui::{buffer::Buffer, layout::Rect};
+
+let area = Rect::new(0, 0, 80, 200);
+let mut page = Buffer::empty(area);
+ratcn.render_into(&mut page, area, &state, &state.theme, |ctx| {
+    // Declare the full page, including content below the visible window.
+});
+```
+
+Allocate and resize the buffer yourself. Rendering does not clear it; clear a
+reused buffer first when old content should disappear. Choose an `area` within
+`buffer.area`: layout receives it unchanged, without validation or silent
+clamping. Coordinates are absolute within the buffer, including its origin;
+they do not restart at `(0, 0)` for a sub-area. Viewports still apply their
+logical-coordinate transforms.
+
+Copying a visible window to the terminal and translating pointer positions back
+into buffer coordinates before `handle_event` are the host's responsibilities.
+The bounds contract is unchanged: floating placement, layer copies, and modal
+dimming respect `area`, but arbitrary base paint is not sandboxed and raw base
+buffer access still reaches the whole destination.
+
+A buffer carries no cursor metadata, and `render_into` reports no caret
+position. Future caret-bearing components may require a caret result from this
+API. There is no cursor output machinery today.
+
 ## What an event sees
 
 A successful render does two things: it paints, and it retains what was declared — the component instances, their identities, their areas, and

--- a/docs/docs/concepts/rendering-and-events.md
+++ b/docs/docs/concepts/rendering-and-events.md
@@ -6,7 +6,7 @@ description: "How a frame is declared, how ratcn keeps it as the retained surfac
 
 Ratcn enters an app at two calls:
 
-- `Ratcn::render(frame, state, theme, declare)` declares and paints one frame.
+- `Ratcn::render(frame, area, state, theme, declare)` declares and paints one frame.
 - `Ratcn::handle_event(event, state)` routes one event through the last
   successful declaration.
 
@@ -16,7 +16,8 @@ split areas with Ratatui, queue decorative widgets with
 `DeclareCtx::component`:
 
 ```rust
-ratcn.render(frame, &state, &state.theme, |ctx| {
+let area = frame.area();
+ratcn.render(frame, area, &state, &state.theme, |ctx| {
     ctx.paint_widget(Paragraph::new("Account"), title_area);
     ctx.component(
         "save",
@@ -38,6 +39,14 @@ type used by nested scopes, dialog sections, and a component's own `declare`.
 `ctx.state()` is the app state for this declaration pass. Components you declare
 with `component` get an identity and can receive events; widgets you paint are
 decoration and cannot.
+
+Pass a pane's rectangle as `area` to host a tree, or `frame.area()` to use the
+whole frame. `ctx.frame_area()` reports those root bounds, translated into
+logical coordinates inside a viewport. Floating components place themselves
+within them; layer copies and modal dimming are clipped to them. This is not
+a paint sandbox: base widgets can paint outside their rects, and unprojected
+base `PaintCtx::with_buffer` exposes the whole destination buffer. Events still
+arrive in screen coordinates; routing input between hosted trees stays yours.
 
 Declaring does not paint. `ctx.paint` queues a `'static` closure at the point it
 was reached, and the runtime replays the whole queue in that order once the

--- a/docs/docs/concepts/themes.md
+++ b/docs/docs/concepts/themes.md
@@ -31,7 +31,8 @@ Choose one built-in preset directly:
 use ratcn::Theme;
 
 let theme = Theme::catppuccin();
-ratcn.render(frame, &state, &theme, |ctx| {
+let area = frame.area();
+ratcn.render(frame, area, &state, &theme, |ctx| {
     // Declare components.
 });
 ```

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -68,7 +68,7 @@ and updates; the library reads state while rendering and returns messages when
 something happens. It enters your app at exactly two call sites — remove them
 and the rest of the loop is untouched:
 
-- `Ratcn::render(frame, state, theme, declare)` — declare which components are
+- `Ratcn::render(frame, area, state, theme, declare)` — declare which components are
   on screen this frame, and paint them.
 - `Ratcn::handle_event(event, state)` — route one input event and maybe get a
   message back.


### PR DESCRIPTION
## What And Why

Let applications host a Ratcn tree in a pane without treating it as the whole terminal. This provides reusable rendering and focus primitives, not a nested-app framework.

- **Breaking:** `Ratcn::render(frame, area, state, theme, declare)` takes the root area explicitly. Floating placement, layer copying, and modal dimming respect it; whole-frame callers pass `frame.area()`.
- Add `render_into` for caller-owned buffers, sharing the entire rendering lifecycle with `render`. Allocation, clearing, windowing, and pointer translation remain the host's responsibility.
- Add `FocusState::none()` / `is_none()`, distinct from default startup focus. Tab, root focus keys, and pointer input can re-enter; modal close restores the saved no-focus state.
- Migrate workspace callers, scaffolding, benchmarks, and documentation. Add regressions for hosted overlays, viewport coordinates, wide-character terminal output, offscreen rendering, and focus behavior.
- Fix clean-runner CI preparation with `cargo fetch --locked` before the existing offline CLI tests. The first CI run exposed missing non-native dependencies; this was reproduced in a private empty Cargo cache and fixed without changing tests or the lockfile.

The area is not a sandbox for arbitrary base paint or a root input boundary. Buffer rendering currently returns no cursor metadata. No dependencies were added.

This branch is based on `main` and does not include or modify the showcase in #19. Showcase adoption, including updating its extracted demo callers, is a separate integration step. The scrolling landing preview still needs windowing; the demo host trait is unchanged here.

## Verification

Each of the three library commits passed the full local Rust gate and independent correctness, API-contract, and regression-test reviews before acceptance. Review findings were reproduced, fixed, and re-reviewed. The separate CI-only follow-up also passed the full gate and independent review.

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p ratcn --locked`
- [x] `cargo test -p ratcn --all-features --locked`
- [x] `cargo test --workspace --exclude ratcn --locked`
- [x] `cargo check -p copy-fixture --examples --locked`
- [x] `cargo clippy -p ratcn --all-features --all-targets --locked -- -D warnings`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo clippy --workspace --exclude cargo-ratcn --all-targets --target wasm32-unknown-unknown --locked -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p ratcn --all-features --no-deps --locked`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`
- [x] `cargo package -p ratcn --locked` after each clean commit
- [x] `npx --yes pnpm@10.11.0 run docs:build`: all 26 WASM demos and VitePress site
- [x] External proof app through the real terminal session in private tmux servers at 80x24 and 100x32: bounded Select/Tooltip/modal rendering, every outside cell preserved, Tab/BackTab/hotkey/mouse focus entry, modal restoration, and below-fold `render_into` content plus event routing.

Final full Rust test runs had no failures or ignored tests. WASM verification is compilation/linting plus the docs build, not browser interaction. The terminal proof used encoded mouse input and two fixed sizes; it did not exercise live resizing or offscreen pointer translation.
